### PR TITLE
Add repository field to package.json for npm provenance

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,7 +10,7 @@ const program = new Command();
 
 program
   .name('base44')
-  .description('Base44 CLI 2 - Unified interface for managing Base44 applications')
+  .description('Base44 CLI - Unified interface for managing Base44 applications')
   .version(getPackageVersion());
 
 // Register authentication commands


### PR DESCRIPTION
Adds the `repository` field to `package.json` to fix npm publish with provenance verification.

## Changes
- Added `repository.type` and `repository.url` fields pointing to `https://github.com/base44/cli`

## Why
npm's sigstore provenance verification requires the `repository.url` in `package.json` to match the GitHub repository from which the package is being published.