### PR TITLE
feat(create): suggest deploying site after project creation

### DIFF
--- a/src/cli/commands/project/create.ts
+++ b/src/cli/commands/project/create.ts
@@ -1,12 +1,14 @@
 import { resolve } from "node:path";
+import { execSync } from "node:child_process";
 import { Command } from "commander";
-import { log, group, text, select } from "@clack/prompts";
+import { log, group, text, select, confirm, isCancel } from "@clack/prompts";
 import type { Option } from "@clack/prompts";
 import chalk from "chalk";
 import kebabCase from "lodash.kebabcase";
-import { createProjectFiles, listTemplates } from "@core/project/index.js";
+import { createProjectFiles, listTemplates, readProjectConfig } from "@core/project/index.js";
 import type { Template } from "@core/project/index.js";
 import { getBase44ApiUrl } from "@core/config.js";
+import { deploySite } from "@core/site/index.js";
 import { runCommand, runTask, onPromptCancel } from "../../utils/index.js";
 
 async function create(): Promise<void> {
@@ -74,6 +76,50 @@ async function create(): Promise<void> {
 
   log.success(`Project ${chalk.bold(name)} has been initialized!`);
   log.success(`Dashboard link:\n${chalk.bold(`${getBase44ApiUrl()}/apps/${projectId}/editor/preview`)}`);
+
+  // Check if project has site configuration and offer to deploy
+  try {
+    const { project } = await readProjectConfig(resolvedPath);
+    if (project.site?.buildCommand && project.site?.outputDirectory) {
+      const shouldDeploy = await confirm({
+        message: "Would you like to deploy your site now?",
+      });
+
+      if (!isCancel(shouldDeploy) && shouldDeploy) {
+        // Build the project
+        await runTask(
+          "Building project...",
+          async () => {
+            execSync(project.site!.buildCommand!, {
+              cwd: resolvedPath,
+              stdio: "pipe",
+            });
+          },
+          {
+            successMessage: "Build completed",
+            errorMessage: "Build failed",
+          }
+        );
+
+        // Deploy the site
+        const outputDir = resolve(resolvedPath, project.site.outputDirectory);
+        const result = await runTask(
+          "Deploying site...",
+          async () => {
+            return await deploySite(outputDir);
+          },
+          {
+            successMessage: "Site deployed successfully",
+            errorMessage: "Deployment failed",
+          }
+        );
+
+        log.success(`Site deployed to: ${chalk.bold(result.app_url)}`);
+      }
+    }
+  } catch {
+    // No site config or deployment not available - skip silently
+  }
 }
 
 export const createCommand = new Command("create")


### PR DESCRIPTION
## Description

After creating a project with site configuration, prompt the user to deploy their site immediately, providing a smoother path from project creation to live deployment.

## Related Issue

Fixes #36

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Changes Made

- Add confirmation prompt after project creation asking if user wants to deploy
- Automatically run build command if project has site configuration
- Deploy the built site to Base44 hosting if user confirms
- Only prompt for templates with `site.buildCommand` and `site.outputDirectory`

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All tests pass (`npm test`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have updated AGENTS.md if I made architectural changes

## Additional Notes

The deploy suggestion only appears for templates that have site configuration (currently `backend-and-client`). The flow is:
1. Create project files
2. Ask "Would you like to deploy your site now?"
3. If yes: run build command, then deploy to Base44 hosting