### PR TITLE
feat(templates): load templates from remote base44/apps-examples repo

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -9,6 +9,11 @@ import { findProjectRoot } from "./project/index.js";
 // Templates are copied to dist/cli/templates/
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+// Remote templates repository configuration
+export const TEMPLATES_REPO_OWNER = "base44";
+export const TEMPLATES_REPO_NAME = "apps-examples";
+export const TEMPLATES_BRANCH = "main";
+
 export function getBase44GlobalDir(): string {
   return join(homedir(), ".base44");
 }
@@ -23,6 +28,20 @@ export function getTemplatesDir(): string {
 
 export function getTemplatesIndexPath(): string {
   return join(getTemplatesDir(), "templates.json");
+}
+
+/**
+ * Get the directory for cached remote templates.
+ */
+export function getRemoteTemplatesCacheDir(): string {
+  return join(getBase44GlobalDir(), "templates");
+}
+
+/**
+ * Get the path to the cached templates index file.
+ */
+export function getRemoteTemplatesIndexPath(): string {
+  return join(getRemoteTemplatesCacheDir(), "templates.json");
 }
 
 /**

--- a/src/core/project/index.ts
+++ b/src/core/project/index.ts
@@ -3,3 +3,4 @@ export * from "./schema.js";
 export * from "./api.js";
 export * from "./create.js";
 export * from "./template.js";
+export * from "./remote.js";

--- a/src/core/project/remote.ts
+++ b/src/core/project/remote.ts
@@ -1,0 +1,216 @@
+import { join } from "node:path";
+import { mkdir } from "node:fs/promises";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { createWriteStream } from "node:fs";
+import { createGunzip } from "node:zlib";
+import { extract } from "tar";
+import {
+  TEMPLATES_REPO_OWNER,
+  TEMPLATES_REPO_NAME,
+  TEMPLATES_BRANCH,
+  getRemoteTemplatesCacheDir,
+  getRemoteTemplatesIndexPath,
+} from "../config.js";
+import { pathExists, writeJsonFile, readJsonFile } from "../utils/fs.js";
+import { TemplatesConfigSchema } from "./schema.js";
+import type { Template } from "./schema.js";
+
+const GITHUB_API_BASE = "https://api.github.com";
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+interface CacheMetadata {
+  lastUpdated: number;
+  templates: Template[];
+}
+
+/**
+ * Fetch the list of templates from the remote repository.
+ * Uses a local cache with a 24-hour TTL.
+ */
+export async function listRemoteTemplates(): Promise<Template[]> {
+  const cacheDir = getRemoteTemplatesCacheDir();
+  const cacheIndexPath = getRemoteTemplatesIndexPath();
+
+  // Check if cache exists and is fresh
+  if (await pathExists(cacheIndexPath)) {
+    try {
+      const cached = (await readJsonFile(cacheIndexPath)) as CacheMetadata;
+      if (Date.now() - cached.lastUpdated < CACHE_TTL_MS) {
+        return cached.templates;
+      }
+    } catch {
+      // Cache is corrupted, will refresh
+    }
+  }
+
+  // Fetch fresh templates from GitHub
+  const templates = await fetchTemplatesFromGitHub();
+
+  // Create cache directory if it doesn't exist
+  if (!(await pathExists(cacheDir))) {
+    await mkdir(cacheDir, { recursive: true });
+  }
+
+  // Save to cache
+  const cacheData: CacheMetadata = {
+    lastUpdated: Date.now(),
+    templates,
+  };
+  await writeJsonFile(cacheIndexPath, cacheData);
+
+  return templates;
+}
+
+/**
+ * Fetch templates list from GitHub repository.
+ * First tries to fetch templates.json from the repo root.
+ * Falls back to listing directories as templates.
+ */
+async function fetchTemplatesFromGitHub(): Promise<Template[]> {
+  // Try to fetch templates.json from the repo
+  const templatesJsonUrl = `https://raw.githubusercontent.com/${TEMPLATES_REPO_OWNER}/${TEMPLATES_REPO_NAME}/${TEMPLATES_BRANCH}/templates.json`;
+
+  try {
+    const response = await fetch(templatesJsonUrl);
+    if (response.ok) {
+      const data = await response.json();
+      const result = TemplatesConfigSchema.parse(data);
+      return result.templates;
+    }
+  } catch {
+    // templates.json doesn't exist, fall back to listing directories
+  }
+
+  // Fall back: list directories in the repo as templates
+  const apiUrl = `${GITHUB_API_BASE}/repos/${TEMPLATES_REPO_OWNER}/${TEMPLATES_REPO_NAME}/contents?ref=${TEMPLATES_BRANCH}`;
+  const response = await fetch(apiUrl, {
+    headers: {
+      Accept: "application/vnd.github.v3+json",
+      "User-Agent": "base44-cli",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch templates from GitHub: ${response.statusText}`);
+  }
+
+  const contents = (await response.json()) as Array<{
+    name: string;
+    type: string;
+  }>;
+
+  // Filter to directories only (excluding common non-template files)
+  const excludeNames = ["node_modules", ".git", ".github", "templates.json", "README.md"];
+  const directories = contents.filter(
+    (item) => item.type === "dir" && !excludeNames.includes(item.name)
+  );
+
+  return directories.map((dir) => ({
+    id: dir.name,
+    name: dir.name,
+    description: `Example project: ${dir.name}`,
+    path: dir.name,
+  }));
+}
+
+/**
+ * Download and extract a template from the remote repository to the cache.
+ */
+export async function downloadRemoteTemplate(template: Template): Promise<string> {
+  const cacheDir = getRemoteTemplatesCacheDir();
+  const templateDir = join(cacheDir, template.path);
+
+  // Check if template is already cached
+  if (await pathExists(templateDir)) {
+    return templateDir;
+  }
+
+  // Download the specific folder from the repo using GitHub's tarball API
+  const tarballUrl = `https://api.github.com/repos/${TEMPLATES_REPO_OWNER}/${TEMPLATES_REPO_NAME}/tarball/${TEMPLATES_BRANCH}`;
+
+  const response = await fetch(tarballUrl, {
+    headers: {
+      Accept: "application/vnd.github.v3.tarball",
+      "User-Agent": "base44-cli",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to download template: ${response.statusText}`);
+  }
+
+  // Create cache directory if it doesn't exist
+  if (!(await pathExists(cacheDir))) {
+    await mkdir(cacheDir, { recursive: true });
+  }
+
+  // Extract the tarball
+  const tempTarPath = join(cacheDir, `temp-${Date.now()}.tar.gz`);
+
+  try {
+    // Download tarball to temp file
+    const fileStream = createWriteStream(tempTarPath);
+    await pipeline(Readable.fromWeb(response.body as never), fileStream);
+
+    // Extract the specific template folder
+    await extractTemplateFolder(tempTarPath, cacheDir, template.path);
+
+    return templateDir;
+  } finally {
+    // Clean up temp file
+    try {
+      const { unlink } = await import("node:fs/promises");
+      await unlink(tempTarPath);
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+}
+
+/**
+ * Extract a specific folder from a GitHub tarball.
+ * GitHub tarballs have a prefix like "owner-repo-sha/" that we need to handle.
+ */
+async function extractTemplateFolder(
+  tarballPath: string,
+  destDir: string,
+  templatePath: string
+): Promise<void> {
+  // First, we need to find the prefix in the tarball
+  // GitHub uses format: owner-repo-sha/
+  let prefix = "";
+
+  // Extract to get the prefix
+  await extract({
+    file: tarballPath,
+    cwd: destDir,
+    filter: (path) => {
+      if (!prefix) {
+        // First entry will give us the prefix
+        const firstSlash = path.indexOf("/");
+        if (firstSlash > 0) {
+          prefix = path.substring(0, firstSlash + 1);
+        }
+      }
+      // Only extract files from our template folder
+      const relativePath = path.replace(prefix, "");
+      return relativePath.startsWith(templatePath + "/") || relativePath === templatePath;
+    },
+    strip: 1, // Remove the prefix directory
+  });
+}
+
+/**
+ * Get the path to a cached remote template, downloading it if necessary.
+ */
+export async function getRemoteTemplateDir(template: Template): Promise<string> {
+  const cacheDir = getRemoteTemplatesCacheDir();
+  const templateDir = join(cacheDir, template.path);
+
+  if (!(await pathExists(templateDir))) {
+    await downloadRemoteTemplate(template);
+  }
+
+  return templateDir;
+}

--- a/src/core/project/schema.ts
+++ b/src/core/project/schema.ts
@@ -5,6 +5,8 @@ export const TemplateSchema = z.object({
   name: z.string(),
   description: z.string(),
   path: z.string(),
+  /** Source of the template: 'bundled' (in CLI package) or 'remote' (from GitHub) */
+  source: z.enum(["bundled", "remote"]).optional(),
 });
 
 export const TemplatesConfigSchema = z.object({

--- a/src/core/project/template.ts
+++ b/src/core/project/template.ts
@@ -2,9 +2,10 @@ import { join } from "node:path";
 import { globby } from "globby";
 import ejs from "ejs";
 import { getTemplatesDir, getTemplatesIndexPath } from "../config.js";
-import { readJsonFile, writeFile, copyFile } from "../utils/fs.js";
+import { readJsonFile, writeFile, copyFile, pathExists } from "../utils/fs.js";
 import { TemplatesConfigSchema } from "./schema.js";
 import type { Template } from "./schema.js";
+import { listRemoteTemplates, getRemoteTemplateDir } from "./remote.js";
 
 export interface TemplateData {
   name: string;
@@ -12,10 +13,65 @@ export interface TemplateData {
   projectId: string;
 }
 
+/**
+ * List all available templates.
+ * Combines bundled templates with remote templates from base44/apps-examples.
+ */
 export async function listTemplates(): Promise<Template[]> {
-  const parsed = await readJsonFile(getTemplatesIndexPath());
-  const result = TemplatesConfigSchema.parse(parsed);
-  return result.templates;
+  const templates: Template[] = [];
+
+  // First, try to load bundled templates (fallback for offline use)
+  try {
+    const bundledIndexPath = getTemplatesIndexPath();
+    if (await pathExists(bundledIndexPath)) {
+      const parsed = await readJsonFile(bundledIndexPath);
+      const result = TemplatesConfigSchema.parse(parsed);
+      templates.push(...result.templates.map((t) => ({ ...t, source: "bundled" as const })));
+    }
+  } catch {
+    // Bundled templates not available
+  }
+
+  // Then, try to fetch remote templates
+  try {
+    const remoteTemplates = await listRemoteTemplates();
+    // Mark remote templates and add them (avoiding duplicates by id)
+    const bundledIds = new Set(templates.map((t) => t.id));
+    for (const t of remoteTemplates) {
+      if (!bundledIds.has(t.id)) {
+        templates.push({ ...t, source: "remote" as const });
+      }
+    }
+  } catch {
+    // Remote templates not available (offline mode)
+  }
+
+  if (templates.length === 0) {
+    throw new Error(
+      "No templates available. Please check your internet connection or try again later."
+    );
+  }
+
+  return templates;
+}
+
+/**
+ * Get the directory path for a template, handling both bundled and remote templates.
+ */
+async function getTemplateDirectory(template: Template): Promise<string> {
+  // Check if it's a remote template
+  if ((template as Template & { source?: string }).source === "remote") {
+    return await getRemoteTemplateDir(template);
+  }
+
+  // Default to bundled templates
+  const bundledPath = join(getTemplatesDir(), template.path);
+  if (await pathExists(bundledPath)) {
+    return bundledPath;
+  }
+
+  // If bundled path doesn't exist, try remote
+  return await getRemoteTemplateDir(template);
 }
 
 /**
@@ -28,7 +84,7 @@ export async function renderTemplate(
   destPath: string,
   data: TemplateData
 ): Promise<void> {
-  const templateDir = join(getTemplatesDir(), template.path);
+  const templateDir = await getTemplateDirectory(template);
 
   // Get all files in the template directory
   const files = await globby("**/*", {


### PR DESCRIPTION
## Description

Load templates dynamically from the `base44/apps-examples` GitHub repository at runtime instead of bundling them in the CLI, allowing templates to be updated without releasing a new CLI version.

## Related Issue

Fixes #38

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Changes Made

- Create `remote.ts` module for fetching templates from GitHub
- Fetch template list from `base44/apps-examples` repository
- Cache templates locally in `~/.base44/templates/` with 24-hour TTL
- Combine bundled and remote templates in `listTemplates()`
- Support both bundled and remote templates in `renderTemplate()`
- Add `source` field to Template schema for tracking origin
- Fallback to bundled templates when offline

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All tests pass (`npm test`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have updated AGENTS.md if I made architectural changes

## Additional Notes

### Architecture

The CLI now:
1. Tries to fetch templates from `https://github.com/base44/apps-examples`
2. Caches them locally with 24-hour TTL
3. Falls back to bundled templates if offline or fetch fails

### Remote Repository Requirements

The `base44/apps-examples` repo should have either:
- A `templates.json` file at the root listing templates
- Or directories at the root that will be auto-discovered as templates

### Cache Location

Templates are cached in `~/.base44/templates/` to avoid repeated downloads.