### PR TITLE
feat: add terminal links support for clickable URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "lodash.kebabcase": "^4.1.1",
     "p-wait-for": "^6.0.0",
     "tar": "^7.4.3",
+    "terminal-link": "^3.0.0",
     "tsdown": "^0.12.4",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",

--- a/src/cli/commands/auth/login.ts
+++ b/src/cli/commands/auth/login.ts
@@ -13,7 +13,7 @@ import type {
   TokenResponse,
   UserInfoResponse,
 } from "@core/auth/index.js";
-import { runCommand, runTask } from "../../utils/index.js";
+import { runCommand, runTask, createLink } from "../../utils/index.js";
 
 async function generateAndDisplayDeviceCode(): Promise<DeviceCodeResponse> {
   const deviceCodeResponse = await runTask(
@@ -29,7 +29,7 @@ async function generateAndDisplayDeviceCode(): Promise<DeviceCodeResponse> {
 
   log.info(
     `Verification code: ${chalk.bold(deviceCodeResponse.userCode)}` +
-      `\nPlease confirm this code at: ${deviceCodeResponse.verificationUri}`
+      `\nPlease confirm this code at: ${createLink(deviceCodeResponse.verificationUri, deviceCodeResponse.verificationUri)}`
   );
 
   return deviceCodeResponse;

--- a/src/cli/commands/project/create.ts
+++ b/src/cli/commands/project/create.ts
@@ -7,7 +7,7 @@ import kebabCase from "lodash.kebabcase";
 import { createProjectFiles, listTemplates } from "@core/project/index.js";
 import type { Template } from "@core/project/index.js";
 import { getBase44ApiUrl } from "@core/config.js";
-import { runCommand, runTask, onPromptCancel } from "../../utils/index.js";
+import { runCommand, runTask, onPromptCancel, createLink } from "../../utils/index.js";
 
 async function create(): Promise<void> {
   const templates = await listTemplates();
@@ -73,7 +73,8 @@ async function create(): Promise<void> {
   );
 
   log.success(`Project ${chalk.bold(name)} has been initialized!`);
-  log.success(`Dashboard link:\n${chalk.bold(`${getBase44ApiUrl()}/apps/${projectId}/editor/preview`)}`);
+  const dashboardUrl = `${getBase44ApiUrl()}/apps/${projectId}/editor/preview`;
+  log.success(`Dashboard link:\n${createLink(dashboardUrl, dashboardUrl)}`);
 }
 
 export const createCommand = new Command("create")

--- a/src/cli/commands/site/deploy.ts
+++ b/src/cli/commands/site/deploy.ts
@@ -3,7 +3,7 @@ import { Command } from "commander";
 import { log, confirm, isCancel } from "@clack/prompts";
 import { readProjectConfig } from "@core/project/index.js";
 import { deploySite } from "@core/site/index.js";
-import { runCommand, runTask } from "../../utils/index.js";
+import { runCommand, runTask, createLink } from "../../utils/index.js";
 
 async function deployAction(): Promise<void> {
   const { project } = await readProjectConfig();
@@ -36,7 +36,7 @@ async function deployAction(): Promise<void> {
     }
   );
 
-  log.success(`Site deployed to: ${result.app_url}`);
+  log.success(`Site deployed to: ${createLink(result.app_url, result.app_url)}`);
 }
 
 export const siteDeployCommand = new Command("site")

--- a/src/cli/utils/index.ts
+++ b/src/cli/utils/index.ts
@@ -2,3 +2,4 @@ export * from "./runCommand.js";
 export * from "./runTask.js";
 export * from "./prompts.js";
 export * from "./banner.js";
+export * from "./terminalLink.js";

--- a/src/cli/utils/terminalLink.ts
+++ b/src/cli/utils/terminalLink.ts
@@ -1,0 +1,40 @@
+import terminalLink from "terminal-link";
+import chalk from "chalk";
+
+/**
+ * Creates a clickable terminal link if supported, otherwise falls back to
+ * a formatted link with chalk underline.
+ *
+ * @param text - The text to display
+ * @param url - The URL to link to
+ * @returns A terminal link if supported, otherwise chalk-formatted text
+ */
+export function createLink(text: string, url: string): string {
+  // terminal-link automatically detects support and returns fallback if needed
+  // We customize the fallback to use chalk with underline
+  return terminalLink(text, url, {
+    fallback: (text, url) => {
+      return `${chalk.underline.blue(url)}`;
+    },
+  });
+}
+
+/**
+ * Checks if the current terminal supports clickable links.
+ * This uses terminal-link's internal detection mechanism.
+ *
+ * @returns true if terminal supports links, false otherwise
+ */
+export function supportsLinks(): boolean {
+  // terminal-link has a isSupported property but it's not exported
+  // We can detect support by checking if the terminal supports hyperlinks
+  // Common detection: iTerm2, VSCode terminal, GNOME terminal, etc.
+  return (
+    process.env.TERM_PROGRAM === "iTerm.app" ||
+    process.env.TERM_PROGRAM === "vscode" ||
+    process.env.TERM === "xterm-256color" ||
+    process.env.WT_SESSION !== undefined || // Windows Terminal
+    Boolean(process.env.KONSOLE_VERSION) ||
+    Boolean(process.env.VTE_VERSION)
+  );
+}


### PR DESCRIPTION
## Summary

Adds support for clickable terminal links using the `terminal-link` package. URLs displayed in the CLI are now clickable in supported terminals, with graceful fallback to chalk underline styling for unsupported terminals.

## Changes

- Added `terminal-link` package dependency
- Created `terminalLink` utility with support detection
- Updated login command to show clickable verification URI
- Updated site deploy to show clickable app URL
- Updated project create to show clickable dashboard link

Closes #54

Generated with [Claude Code](https://claude.ai/code)