### PR TITLE
feat: add template option to project creation command

### DIFF
--- a/src/cli/commands/project/create.ts
+++ b/src/cli/commands/project/create.ts
@@ -21,15 +21,6 @@ interface CreateOptions {
   deploy?: boolean;
 }
 
-async function getDefaultTemplate(): Promise<Template> {
-  const templates = await listTemplates();
-  const template = templates.find((t) => t.id === DEFAULT_TEMPLATE_ID);
-  if (!template) {
-    throw new Error(`Default template "${DEFAULT_TEMPLATE_ID}" not found`);
-  }
-  return template;
-}
-
 async function getTemplateById(templateId: string): Promise<Template> {
   const templates = await listTemplates();
   const template = templates.find((t) => t.id === templateId);
@@ -114,9 +105,7 @@ async function createInteractive(options: CreateOptions): Promise<RunCommandResu
 }
 
 async function createNonInteractive(options: CreateOptions): Promise<RunCommandResult> {
-  const template = options.template
-    ? await getTemplateById(options.template)
-    : await getDefaultTemplate();
+  const template = await getTemplateById(options.template ?? DEFAULT_TEMPLATE_ID);
 
   return await executeCreate({
     template,


### PR DESCRIPTION
* Introduced a new `template` option to the `create` command for specifying a template ID.
* Implemented `getTemplateById` function to retrieve templates by ID and handle errors for invalid IDs.
* Updated `createNonInteractive` function to use the specified template or fallback to the default template.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Related Issue

<!-- Link to the issue this PR addresses, e.g., Fixes #123 or Closes #456 -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested these changes -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All tests pass (`npm test`)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have updated AGENTS.md if I made architectural changes

## Additional Notes

<!-- Add any additional notes, screenshots, or context about the PR here -->
