### PR TITLE
small api change to link command - remove the --existing flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,15 @@ base44 link
 base44 link --create --name "my-app" --description "My app description"
 
 # Link to an existing project by ID (non-interactive)
-base44 link --existing <app-id>
+base44 link --projectId <app-id>
 ```
 
 | Option | Description |
 |--------|-------------|
 | `-c, --create` | Create a new project (skip selection prompt) |
-| `-e, --existing <id>` | Link to an existing project by ID |
 | `-n, --name <name>` | Project name (required with --create) |
 | `-d, --description <desc>` | Project description (optional) |
+| `-p, --projectId <id>` | Link to an existing project by ID (skips selection prompt) |
 
 ### Deployment
 

--- a/src/core/project/api.ts
+++ b/src/core/project/api.ts
@@ -20,8 +20,13 @@ export async function createProject(projectName: string, description?: string) {
 }
 
 export async function listProjects(): Promise<ProjectsResponse> {
-  const query = 'sort=-updated_date&fields=id,name,user_description,is_managed_source_code';
-  const response = await base44Client.get(`api/apps?${query}`);
+  const response = await base44Client.get(`api/apps`, {
+    searchParams: {
+      "sort": "-updated_date",
+      "fields": "id,name,user_description,is_managed_source_code"
+    }
+  });
+
   const projects = ProjectsResponseSchema.parse(await response.json());
 
   return projects;


### PR DESCRIPTION
## Description

No need to have a --existing flag if --projectId exists, its redundant

## Related Issue

<!-- Link to the issue this PR addresses, e.g., Fixes #123 or Closes #456 -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested these changes -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All tests pass (`npm test`)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have updated AGENTS.md if I made architectural changes

## Additional Notes

<!-- Add any additional notes, screenshots, or context about the PR here -->
