### PR TITLE
Simplify AI agent skills selection to yes/no prompt

### DIFF
--- a/src/cli/commands/project/create.ts
+++ b/src/cli/commands/project/create.ts
@@ -245,11 +245,7 @@ async function executeCreate({
     await runTask(
       "Installing AI agent skills...",
       async () => {
-        await execa("npx", [
-          "-y", "add-skill", "base44/skills",
-          "-y",  // Skip add-skill prompts (use defaults)
-          "-s", "base44-cli", "-s", "base44-sdk",
-        ], {
+        await execa("npx", ["-y", "add-skill", "base44/skills", "-y"], {
           cwd: resolvedPath,
           stdio: "inherit",
         });


### PR DESCRIPTION
Simplifies the AI agent skills prompt in the base44 create flow:

Changed from multiselect to yes/no confirmation: Instead of showing a multiselect where users pick individual agents (Cursor, Claude Code), the prompt is now a simple "Add AI agent skills?" confirmation
All agents installed automatically: When the user confirms, all supported agents are installed without requiring individual selection
Generic wording: Removed specific agent names from the prompt and CLI help text to keep it future-proof as more agents are added
Before
```
Add AI agent skills? (Select agents to configure)
◉ Cursor
◉ Claude Code
```

After
```
Add AI agent skills?
◉ Yes  ○ No
```
