### PR TITLE
feat: add GitHub Actions workflow to notify skills repository on release

### DIFF
--- a/.github/workflows/notify-skills-repo.yml
+++ b/.github/workflows/notify-skills-repo.yml
@@ -1,0 +1,31 @@
+name: Notify Skills Repo on Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.BASE44_GITHUB_ACTIONS_APP_ID }}
+          private-key: ${{ secrets.BASE44_GITHUB_ACTIONS_APP_PRIVATE_KEY }}
+          owner: base44
+          repositories: skills
+
+      - name: Trigger skills repo sync
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: base44/skills
+          event-type: cli-release
+          client-payload: |
+            {
+              "version": "${{ github.event.release.tag_name }}",
+              "release_url": "${{ github.event.release.html_url }}",
+              "release_name": "${{ github.event.release.name }}"
+            }


### PR DESCRIPTION
## Description

This workflow triggers a repository dispatch event to synchronize the skills repository whenever a new release is published. It generates a GitHub App token and sends relevant release information as a payload.


## Related Issue

https://github.com/base44/skills/issues/20

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Other (please describe): New Github Worklow

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested these changes -->

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All tests pass (`npm test`)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have updated AGENTS.md if I made architectural changes

## Additional Notes

<!-- Add any additional notes, screenshots, or context about the PR here -->
