### PR TITLE
fix: use colon-based allowed-tools patterns for gh commands

### DIFF
--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -84,4 +84,4 @@ jobs:
             - For Testing checkboxes: check them ONLY if you can verify tests exist/pass from the PR
             - For Checklist items: check them based on your code analysis (e.g., check "style guidelines" if code follows existing patterns)
             - Be concise but informative in the Description and Changes Made sections
-          claude_args: '--allowed-tools "Bash(gh pr view *)" "Bash(gh pr edit *)" "Bash(git diff *)" "Bash(git log *)" Read Glob Grep'
+          claude_args: '--allowed-tools "Bash(gh pr:*)" "Bash(git diff:*)" "Bash(git log:*)" Read Glob Grep'


### PR DESCRIPTION
## Summary
- Uses `Bash(gh pr:*)` pattern syntax to allow all gh pr subcommands
- Fixes permission denials for `gh pr diff` and `gh pr edit` commands

The previous patterns like `Bash(gh pr edit *)` weren't matching properly. The colon-based syntax `Bash(gh pr:*)` correctly matches all `gh pr` subcommands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)