### PR TITLE
fix: make skills installation non-critical in create command

### DIFF
--- a/src/cli/commands/project/create.ts
+++ b/src/cli/commands/project/create.ts
@@ -242,19 +242,24 @@ async function executeCreate({
   }
 
   if (shouldAddSkills) {
-    await runTask(
-      "Installing AI agent skills...",
-      async () => {
-        await execa("npx", ["-y", "add-skill", "base44/skills", "-y"], {
-          cwd: resolvedPath,
-          shell: true
-        });
-      },
-      {
-        successMessage: theme.colors.base44Orange("AI agent skills added successfully"),
-        errorMessage: "Failed to add AI agent skills - you can add them later with: npx add-skill base44/skills",
-      }
-    );
+    try {
+      await runTask(
+        "Installing AI agent skills...",
+        async () => {
+          await execa("npx", ["-y", "add-skill", "base44/skills", "-y"], {
+            cwd: resolvedPath,
+            shell: true
+          });
+        },
+        {
+          successMessage: theme.colors.base44Orange("AI agent skills added successfully"),
+          errorMessage: "Failed to add AI agent skills - you can add them later with: npx add-skill base44/skills",
+        }
+      );
+    } catch {
+      // Skills installation is non-critical (e.g., user may not have git installed)
+      // The error message is already shown by runTask, so we just continue
+    }
   }
 
   log.message(`${theme.styles.header("Project")}: ${theme.colors.base44Orange(name)}`);


### PR DESCRIPTION
## Summary

- Fixes CLI crash on Windows when user doesn't have Git installed
- The `add-skill` package uses `git` internally to clone the skills repo
- If git is not found (`spawn git ENOENT`), the CLI now continues instead of crashing
- The error message is still shown, but the project creation completes successfully

## Test plan

- [x] Manual verification of the code change
- [ ] Test on Windows without Git installed - should show error message but complete successfully
- [ ] Test on macOS/Linux with Git - should work as before

## Related issue

User reported stack trace:
```
Error: spawn git ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:285:19)
```

When running `base44 create` on Windows without Git installed.