### PR TITLE
docs: Add subprocess logging guidelines for runTask

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,6 +441,19 @@ When adding async operations to CLI commands:
 - Follows existing patterns in `create.ts` (entity push, site deploy, skills install)
 - Avoid manual try/catch with `log.message` for async operations
 
+### Subprocess Logging in runTask
+
+When running subprocesses with `execa` inside `runTask()`, use `{ shell: true }` without `stdio: "inherit"` to suppress subprocess output. The spinner provides user feedback, and subprocess logs would interfere with the UI.
+
+```typescript
+await runTask("Installing...", async () => {
+  await execa("npx", ["-y", "some-package"], {
+    cwd: targetPath,
+    shell: true  // Suppresses subprocess output
+  });
+});
+```
+
 ## File Locations
 
 - `cli/plan.md` - Implementation plan


### PR DESCRIPTION
## Description

This PR adds documentation guidelines to AGENTS.md for handling subprocess output when using `execa` inside `runTask()` operations. The documentation clarifies best practices for managing subprocess logging to maintain a clean CLI user experience with spinner feedback.

## Related Issue

None

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Changes Made

- Added new "Subprocess Logging in runTask" section to AGENTS.md (line 444-455)
- Documented recommended approach: suppressing subprocess output using `{ shell: true }` without `stdio: "inherit"` to keep spinner UI clean
- Included clear code example demonstrating the pattern with `execa`
- Explains that the spinner provides user feedback and subprocess logs would interfere with the UI

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed (N/A for documentation)
- [x] All tests pass (`npm test`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A for documentation)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have updated AGENTS.md if I made architectural changes

## Additional Notes

This documentation helps maintain consistent CLI UX by preventing subprocess output from interfering with the spinner feedback mechanism. The guidance follows existing documentation patterns in AGENTS.md with clear recommendations and a practical code example. This is particularly useful when running npm/npx commands or other CLI tools within agent task operations.

---
<sub>🤖 Generated by Claude | 2026-01-27 09:15 UTC</sub>