### PR TITLE
feat(workflows): add allowed_bots configuration for claude bot

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,6 +40,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          allowed_bots: 'claude[bot]'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -85,3 +85,4 @@ jobs:
             - For Checklist items: check them based on your code analysis (e.g., check "style guidelines" if code follows existing patterns)
             - Be concise but informative in the Description and Changes Made sections
           claude_args: '--allowed-tools "Bash(gh pr:*)" "Bash(git diff:*)" "Bash(git log:*)" Read Glob Grep'
+          allowed_bots: 'claude[bot]'


### PR DESCRIPTION
Add allowed_bots: 'claude[bot]' to both the code review and PR description
workflows to explicitly allow claude[bot] to interact with and trigger these
GitHub Actions workflows.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
