### PR TITLE
Change 'Pick a template' to 'Pick an option' in create command

### DIFF
--- a/src/cli/commands/project/create.ts
+++ b/src/cli/commands/project/create.ts
@@ -66,7 +66,7 @@ async function createInteractive(options: CreateOptions): Promise<RunCommandResu
     {
       template: () =>
         select({
-          message: "Pick a template",
+          message: "Pick an option",
           options: templateOptions,
         }),
       name: () => {


### PR DESCRIPTION
## Summary
- Updated the prompt message in the `create` command from "Pick a template" to "Pick an option"

## Test plan
- [ ] Run `base44 create` and verify the prompt now says "Pick an option"

🤖 Generated with [Claude Code](https://claude.com/claude-code)