### PR TITLE
docs: add non-TTY environment handling and user cancellation guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,25 @@ import { myCommand } from "./commands/<domain>/<action>.js";
 program.addCommand(myCommand);
 ```
 
-### 3. Command wrapper options
+### 3. Handling user cancellation
+
+When using `@clack/prompts` interactive prompts, always handle user cancellation properly:
+
+```typescript
+import { select, isCancel, cancel } from "@clack/prompts";
+import { CLIExitError } from "@/cli/errors.js";
+
+const result = await select({ message: "Choose an option", options: [...] });
+
+if (isCancel(result)) {
+  cancel("Operation cancelled.");
+  throw new CLIExitError(0);  // NOT process.exit(0)
+}
+```
+
+**Important**: Always throw `CLIExitError(0)` instead of `process.exit(0)` for user cancellations. This allows proper cleanup and keeps the code testable.
+
+### 4. Command wrapper options
 
 ```typescript
 // Standard command - loads app config by default
@@ -434,9 +452,15 @@ The CLI uses a split architecture for better development experience:
 - `errors.ts` - CLI-specific errors (CLIExitError)
 - `index.ts` - Barrel export for entry points (exports program, CLIExitError)
 
+**Non-TTY Environment Handling**:
+- Entry points detect non-interactive environments (`!process.stdin.isTTY || !process.stdout.isTTY`)
+- When detected, sets `process.env.CI = 'true'` to disable `@clack/prompts` animations
+- This prevents broken output when running in piped output, automated scripts, or AI agent contexts
+
 **Error Handling Flow**:
 - Commands throw errors → `runCommand()` catches, logs, and throws `CLIExitError(1)`
 - Entry points (`bin/run.js`, `bin/dev.js`) catch `CLIExitError` and call `process.exit(code)`
+- `CLIExitError` is passed through `runCommand()` without logging (intentional exits like user cancellation)
 - This keeps `process.exit()` out of core code, making it testable
 
 ### Node.js Version


### PR DESCRIPTION
## Description

This PR adds documentation to AGENTS.md covering two critical patterns for CLI development: proper handling of non-TTY environments (CI/automated contexts) and user cancellation flows. These patterns ensure the CLI behaves correctly when run in piped output, automated scripts, or when users cancel interactive prompts.

## Related Issue

None

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Changes Made

- Added section on handling user cancellation with `@clack/prompts`, emphasizing the use of `CLIExitError(0)` over `process.exit(0)`
- Documented non-TTY environment detection pattern that sets `CI=true` to disable Clack animations
- Enhanced error handling flow documentation to clarify that `CLIExitError` is passed through `runCommand()` without logging
- Renumbered existing section 3 to section 4 to accommodate new content

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [x] All tests pass (`npm test`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have updated AGENTS.md if I made architectural changes

## Additional Notes

This documentation captures patterns implemented in commit 26b34d7, ensuring future contributors understand these important conventions for CLI reliability in different execution contexts.

---
<sub>🤖 Generated by Claude | 2026-01-28 20:35 UTC</sub>