### PR TITLE
fix: update skill installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ When creating a project, [base44/skills](https://github.com/base44/skills) are a
 If you need to install skills manually, use the following command:
 
 ```bash
-npx add-skill base44/skills
+npx skills add base44/skills
 ```
 
 ## Help

--- a/src/cli/commands/project/create.ts
+++ b/src/cli/commands/project/create.ts
@@ -229,14 +229,14 @@ async function executeCreate({
       await runTask(
         "Installing AI agent skills...",
         async () => {
-          await execa("npx", ["-y", "add-skill", "base44/skills", "-y"], {
+          await execa("npx", ["-y", "skills", "add", "base44/skills", "-y"], {
             cwd: resolvedPath,
             shell: true
           });
         },
         {
           successMessage: theme.colors.base44Orange("AI agent skills added successfully"),
-          errorMessage: "Failed to add AI agent skills - you can add them later with: npx add-skill base44/skills",
+          errorMessage: "Failed to add AI agent skills - you can add them later with: npx skills add base44/skills",
         }
       );
     } catch {


### PR DESCRIPTION
## Description

This PR updates the skill installation command throughout the codebase to use the new `npx skills add` syntax instead of the deprecated `npx add-skill` command. The change affects both the README documentation and the CLI's project creation command to ensure users receive correct instructions for installing AI agent skills.

## Related Issue

None

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Changes Made

- Updated README.md to use `npx skills add base44/skills` instead of `npx add-skill base44/skills`
- Modified src/cli/commands/project/create.ts to use the new command syntax in the skill installation flow
- Updated error message in create command to reflect the correct command for manual installation

## Testing

- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed
- [ ] All tests pass (`npm test`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have updated AGENTS.md if I made architectural changes

## Additional Notes

This change ensures consistency with the updated skills package API. The old `add-skill` command is being replaced by the new `skills add` command pattern. This is a straightforward command update that maintains backward compatibility since it only changes the invocation syntax, not the underlying functionality.

---
<sub>🤖 Generated by Claude | 2026-02-01 00:00 UTC</sub>