### PR TITLE
feat(connectors): add API client for connector management

### DIFF
--- a/src/core/resources/connector/api.ts
+++ b/src/core/resources/connector/api.ts
@@ -1,0 +1,128 @@
+import type { KyResponse } from "ky";
+import { getAppClient } from "@/core/clients/index.js";
+import { ApiError, SchemaValidationError } from "@/core/errors.js";
+import type {
+  IntegrationType,
+  ListConnectorsResponse,
+  OAuthStatusResponse,
+  RemoveConnectorResponse,
+  SyncConnectorResponse,
+} from "./schema.js";
+import {
+  ListConnectorsResponseSchema,
+  OAuthStatusResponseSchema,
+  RemoveConnectorResponseSchema,
+  SyncConnectorResponseSchema,
+} from "./schema.js";
+
+/**
+ * List all connectors for the current app.
+ * GET /api/apps/{app_id}/external-auth/list
+ */
+export async function listConnectors(): Promise<ListConnectorsResponse> {
+  const appClient = getAppClient();
+
+  let response: KyResponse;
+  try {
+    response = await appClient.get("external-auth/list");
+  } catch (error) {
+    throw await ApiError.fromHttpError(error, "listing connectors");
+  }
+
+  const result = ListConnectorsResponseSchema.safeParse(await response.json());
+
+  if (!result.success) {
+    throw new SchemaValidationError(
+      "Invalid response from server",
+      result.error
+    );
+  }
+
+  return result.data;
+}
+
+export async function syncConnector(
+  integrationType: IntegrationType,
+  scopes: string[]
+): Promise<SyncConnectorResponse> {
+  const appClient = getAppClient();
+
+  let response: KyResponse;
+  try {
+    response = await appClient.post("external-auth/sync", {
+      json: {
+        integration_type: integrationType,
+        scopes,
+      },
+    });
+  } catch (error) {
+    throw await ApiError.fromHttpError(error, "syncing connector");
+  }
+
+  const result = SyncConnectorResponseSchema.safeParse(await response.json());
+
+  if (!result.success) {
+    throw new SchemaValidationError(
+      "Invalid response from server",
+      result.error
+    );
+  }
+
+  return result.data;
+}
+
+export async function getOAuthStatus(
+  integrationType: IntegrationType,
+  connectionId: string
+): Promise<OAuthStatusResponse> {
+  const appClient = getAppClient();
+
+  let response: KyResponse;
+  try {
+    response = await appClient.get("external-auth/status", {
+      searchParams: {
+        integration_type: integrationType,
+        connection_id: connectionId,
+      },
+    });
+  } catch (error) {
+    throw await ApiError.fromHttpError(error, "checking OAuth status");
+  }
+
+  const result = OAuthStatusResponseSchema.safeParse(await response.json());
+
+  if (!result.success) {
+    throw new SchemaValidationError(
+      "Invalid response from server",
+      result.error
+    );
+  }
+
+  return result.data;
+}
+
+export async function removeConnector(
+  integrationType: IntegrationType
+): Promise<RemoveConnectorResponse> {
+  const appClient = getAppClient();
+
+  let response: KyResponse;
+  try {
+    response = await appClient.delete(
+      `external-auth/integrations/${integrationType}/remove`
+    );
+  } catch (error) {
+    throw await ApiError.fromHttpError(error, "removing connector");
+  }
+
+  const result = RemoveConnectorResponseSchema.safeParse(await response.json());
+
+  if (!result.success) {
+    throw new SchemaValidationError(
+      "Invalid response from server",
+      result.error
+    );
+  }
+
+  return result.data;
+}

--- a/src/core/resources/connector/index.ts
+++ b/src/core/resources/connector/index.ts
@@ -1,3 +1,4 @@
+export * from "./api.js";
 export * from "./config.js";
 export * from "./resource.js";
 export * from "./schema.js";

--- a/src/core/resources/connector/resource.ts
+++ b/src/core/resources/connector/resource.ts
@@ -2,15 +2,9 @@ import type { Resource } from "../types.js";
 import { readAllConnectors } from "./config.js";
 import type { ConnectorResource } from "./schema.js";
 
-/**
- * Connector resource implementation.
- * Note: Connectors are push-only (no pull support).
- * The push function will be implemented when the OAuth flow is ready.
- */
 export const connectorResource: Resource<ConnectorResource> = {
   readAll: readAllConnectors,
   push: async () => {
-    // Push will be implemented in the OAuth flow task
     throw new Error("Connector push not yet implemented");
   },
 };

--- a/src/core/resources/connector/schema.ts
+++ b/src/core/resources/connector/schema.ts
@@ -1,9 +1,5 @@
 import { z } from "zod";
 
-// ─── CONNECTOR SCHEMAS PER INTEGRATION ────────────────────────────────────────
-// Each integration has a literal type discriminator.
-// Scopes are provider-specific - see official docs for available scopes.
-
 /** Google Calendar - Scopes: https://developers.google.com/identity/protocols/oauth2/scopes#calendar */
 export const GoogleCalendarConnectorSchema = z.object({
   type: z.literal("googlecalendar"),
@@ -76,12 +72,6 @@ export const TikTokConnectorSchema = z.object({
   scopes: z.array(z.string()).default([]),
 });
 
-// ─── DISCRIMINATED UNION ──────────────────────────────────────────────────────
-
-/**
- * Local connector resource schema using discriminated union.
- * Each integration type has its own schema with a literal type discriminator.
- */
 export const ConnectorResourceSchema = z.discriminatedUnion("type", [
   GoogleCalendarConnectorSchema,
   GoogleDriveConnectorSchema,
@@ -99,9 +89,6 @@ export const ConnectorResourceSchema = z.discriminatedUnion("type", [
 
 export type ConnectorResource = z.infer<typeof ConnectorResourceSchema>;
 
-/**
- * Supported OAuth integration types.
- */
 export const IntegrationTypeSchema = z.enum([
   "googlecalendar",
   "googledrive",
@@ -119,11 +106,6 @@ export const IntegrationTypeSchema = z.enum([
 
 export type IntegrationType = z.infer<typeof IntegrationTypeSchema>;
 
-// ─── API RESPONSE SCHEMAS ─────────────────────────────────────────────────────
-
-/**
- * Connector status from upstream API.
- */
 export const ConnectorStatusSchema = z.enum([
   "ACTIVE",
   "DISCONNECTED",
@@ -132,9 +114,6 @@ export const ConnectorStatusSchema = z.enum([
 
 export type ConnectorStatus = z.infer<typeof ConnectorStatusSchema>;
 
-/**
- * Upstream connector from the list API.
- */
 export const UpstreamConnectorSchema = z.object({
   integration_type: IntegrationTypeSchema,
   status: ConnectorStatusSchema,
@@ -144,9 +123,6 @@ export const UpstreamConnectorSchema = z.object({
 
 export type UpstreamConnector = z.infer<typeof UpstreamConnectorSchema>;
 
-/**
- * Response from GET /api/apps/{app_id}/external-auth/list
- */
 export const ListConnectorsResponseSchema = z.object({
   integrations: z.array(UpstreamConnectorSchema),
 });
@@ -155,14 +131,32 @@ export type ListConnectorsResponse = z.infer<
   typeof ListConnectorsResponseSchema
 >;
 
-/**
- * Response from GET /api/external-auth/auto-added-scopes
- */
-export const AutoAddedScopesResponseSchema = z.record(
-  IntegrationTypeSchema,
-  z.array(z.string())
-);
+export const SyncConnectorResponseSchema = z.object({
+  redirect_url: z.string().nullable(),
+  connection_id: z.string().nullable(),
+  already_authorized: z.boolean(),
+  error: z.literal("different_user").optional(),
+  error_message: z.string().optional(),
+  other_user_email: z.string().optional(),
+});
 
-export type AutoAddedScopesResponse = z.infer<
-  typeof AutoAddedScopesResponseSchema
+export type SyncConnectorResponse = z.infer<typeof SyncConnectorResponseSchema>;
+
+export const OAuthPollingStatusSchema = z.enum(["ACTIVE", "FAILED", "PENDING"]);
+
+export type OAuthPollingStatus = z.infer<typeof OAuthPollingStatusSchema>;
+
+export const OAuthStatusResponseSchema = z.object({
+  status: OAuthPollingStatusSchema,
+});
+
+export type OAuthStatusResponse = z.infer<typeof OAuthStatusResponseSchema>;
+
+export const RemoveConnectorResponseSchema = z.object({
+  status: z.literal("removed"),
+  integration_type: IntegrationTypeSchema,
+});
+
+export type RemoveConnectorResponse = z.infer<
+  typeof RemoveConnectorResponseSchema
 >;


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR adds API client methods for managing OAuth connectors in the Base44 CLI. It introduces four new API functions (listConnectors, syncConnector, getOAuthStatus, removeConnector) along with updated Zod response schemas for validation. The implementation follows the project's established patterns for API error handling and schema validation.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Created `src/core/resources/connector/api.ts` with four new API client methods:
>   - `listConnectors()`: Fetches all connectors for the current app
>   - `syncConnector()`: Syncs a connector with specified scopes
>   - `getOAuthStatus()`: Polls OAuth authorization status for a connection
>   - `removeConnector()`: Removes a connector integration
> - Added corresponding Zod schemas for API responses: `SyncConnectorResponseSchema`, `OAuthStatusResponseSchema`, `RemoveConnectorResponseSchema`
> - Added new types: `OAuthPollingStatus`, `SyncConnectorResponse`, `OAuthStatusResponse`, `RemoveConnectorResponse`
> - Removed verbose comments from schema definitions for cleaner code
> - Exported API functions from `connector/index.ts`
> - Updated `connectorResource` push method (still throws error pending OAuth flow implementation)
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated AGENTS.md if I made architectural changes
>
> ## Additional Notes
>
> This PR lays the groundwork for OAuth connector management commands. The actual `push` implementation for connectors will be added in a follow-up task once the full OAuth flow is ready. All API methods follow the project's standard error handling patterns using `ApiError.fromHttpError()` and Zod schema validation.
>
> ---
> <sub>🤖 Generated by Claude | 2026-02-04 11:30 UTC</sub>