### PR TITLE
docs: add missing commands to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,16 @@ The CLI will guide you through project setup. For step-by-step tutorials, see th
 | [`create`](https://docs.base44.com/developers/references/cli/commands/create) | Create a new Base44 project from a template |
 | [`deploy`](https://docs.base44.com/developers/references/cli/commands/deploy) | Deploy resources and site to Base44 |
 | [`link`](https://docs.base44.com/developers/references/cli/commands/link) | Link a local project to a project on Base44 |
-| [`dashboard`](https://docs.base44.com/developers/references/cli/commands/dashboard) | Open the app dashboard in your browser |
+| [`dashboard open`](https://docs.base44.com/developers/references/cli/commands/dashboard) | Open the app dashboard in your browser |
 | [`login`](https://docs.base44.com/developers/references/cli/commands/login) | Authenticate with Base44 |
 | [`logout`](https://docs.base44.com/developers/references/cli/commands/logout) | Sign out and clear stored credentials |
 | [`whoami`](https://docs.base44.com/developers/references/cli/commands/whoami) | Display the current authenticated user |
+| [`agents pull`](https://docs.base44.com/developers/references/cli/commands/agents-pull) | Pull agents from Base44 to local files |
+| [`agents push`](https://docs.base44.com/developers/references/cli/commands/agents-push) | Push local agents to Base44 |
 | [`entities push`](https://docs.base44.com/developers/references/cli/commands/entities-push) | Push local entity schemas to Base44 |
 | [`functions deploy`](https://docs.base44.com/developers/references/cli/commands/functions-deploy) | Deploy local functions to Base44 |
 | [`site deploy`](https://docs.base44.com/developers/references/cli/commands/site-deploy) | Deploy built site files to Base44 hosting |
+| [`site open`](https://docs.base44.com/developers/references/cli/commands/site-open) | Open the published site in your browser |
 
 
 <!--| [`eject`](https://docs.base44.com/developers/references/cli/commands/eject) | Create a Base44 backend project from an existing Base44 app | -->


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Updates the README commands table to include missing CLI commands that were not previously documented. Adds `agents pull`, `agents push`, and `site open` commands, and corrects the `dashboard` command entry to show the proper `dashboard open` invocation for consistency.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [x] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added `agents pull` command entry with documentation link
> - Added `agents push` command entry with documentation link
> - Added `site open` command entry with documentation link
> - Fixed `dashboard` command to display as `dashboard open` for accuracy
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [x] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated AGENTS.md if I made architectural changes
>
> ## Additional Notes
>
> This is a documentation-only change to the README. No code changes were made. The commands themselves already exist in the CLI; they were simply missing from the README documentation table.
>
> ---
> <sub>🤖 Generated by Claude | 2026-02-08 10:30 UTC</sub>