### PR TITLE
Fix: issue where we don't collect user info into error reporter context

### DIFF
--- a/src/cli/utils/runCommand.ts
+++ b/src/cli/utils/runCommand.ts
@@ -4,7 +4,7 @@ import type { CLIContext } from "@/cli/types.js";
 import { printBanner } from "@/cli/utils/banner.js";
 import { theme } from "@/cli/utils/theme.js";
 import { printUpgradeNotificationIfAvailable } from "@/cli/utils/upgradeNotification.js";
-import { isLoggedIn } from "@/core/auth/index.js";
+import { isLoggedIn, readAuth } from "@/core/auth/index.js";
 import { isCLIError } from "@/core/errors.js";
 import { initAppConfig } from "@/core/project/index.js";
 
@@ -84,6 +84,15 @@ export async function runCommand(
       if (!loggedIn) {
         log.info("You need to login first to continue.");
         await login();
+      }
+
+      try {
+        const userInfo = await readAuth();
+        context.errorReporter.setContext({
+          user: { email: userInfo.email, name: userInfo.name },
+        });
+      } catch {
+        // User info is optional context for error reporting
       }
     }
 


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR fixes a bug where user information (email and name) was not being collected into the error reporter context after authentication. The error reporter now properly receives user context when commands require authentication, enabling better error tracking and debugging in telemetry.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added import of `readAuth` function from `@/core/auth/index.js`
> - Added user context population in `runCommand()` after authentication check
> - User info (email and name) is now passed to `errorReporter.setContext()` when `requireAuth` is true
> - Wrapped in try/catch to handle cases where user info might not be available (fails silently as this is optional telemetry context)
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [x] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated AGENTS.md if I made architectural changes
>
> ## Additional Notes
>
> The error is caught and suppressed intentionally since user info is optional context for error reporting and should not block command execution. This ensures that telemetry includes user identification for better debugging while maintaining system resilience.
>
> ---
> <sub>🤖 Generated by Claude | 2026-02-08 22:15 UTC</sub>