### PR TITLE
first step migration to sdk

### DIFF
--- a/src/cli/commands/agents/pull.ts
+++ b/src/cli/commands/agents/pull.ts
@@ -2,13 +2,12 @@ import { dirname, join } from "node:path";
 import { log } from "@clack/prompts";
 import { Command } from "commander";
 import type { CLIContext } from "@/cli/types.js";
-import { readProjectConfig } from "@/core/index.js";
-import { fetchAgents, writeAgents } from "@/core/resources/agent/index.js";
+import type { ProjectSDK } from "@/core/sdk.js";
 import { runCommand, runTask } from "../../utils/index.js";
 import type { RunCommandResult } from "../../utils/runCommand.js";
 
-async function pullAgentsAction(): Promise<RunCommandResult> {
-  const { project } = await readProjectConfig();
+async function pullAgentsAction(sdk: ProjectSDK): Promise<RunCommandResult> {
+  const { project } = await sdk.project.readConfig();
 
   const configDir = dirname(project.configPath);
   const agentsDir = join(configDir, project.agentsDir);
@@ -16,7 +15,7 @@ async function pullAgentsAction(): Promise<RunCommandResult> {
   const remoteAgents = await runTask(
     "Fetching agents from Base44",
     async () => {
-      return await fetchAgents();
+      return await sdk.agents.fetch();
     },
     {
       successMessage: "Agents fetched successfully",
@@ -31,7 +30,7 @@ async function pullAgentsAction(): Promise<RunCommandResult> {
   const { written, deleted } = await runTask(
     "Writing agent files",
     async () => {
-      return await writeAgents(agentsDir, remoteAgents.items);
+      return await sdk.agents.writeLocal(agentsDir, remoteAgents.items);
     },
     {
       successMessage: "Agent files written successfully",

--- a/src/cli/commands/agents/push.ts
+++ b/src/cli/commands/agents/push.ts
@@ -1,13 +1,12 @@
 import { log } from "@clack/prompts";
 import { Command } from "commander";
 import type { CLIContext } from "@/cli/types.js";
-import { readProjectConfig } from "@/core/index.js";
-import { pushAgents } from "@/core/resources/agent/index.js";
+import type { ProjectSDK } from "@/core/sdk.js";
 import { runCommand, runTask } from "../../utils/index.js";
 import type { RunCommandResult } from "../../utils/runCommand.js";
 
-async function pushAgentsAction(): Promise<RunCommandResult> {
-  const { agents } = await readProjectConfig();
+async function pushAgentsAction(sdk: ProjectSDK): Promise<RunCommandResult> {
+  const { agents } = await sdk.project.readConfig();
 
   log.info(
     agents.length === 0
@@ -18,7 +17,7 @@ async function pushAgentsAction(): Promise<RunCommandResult> {
   const result = await runTask(
     "Pushing agents to Base44",
     async () => {
-      return await pushAgents(agents);
+      return await sdk.agents.push(agents);
     },
     {
       successMessage: "Agents pushed successfully",

--- a/src/cli/commands/auth/login-flow.ts
+++ b/src/cli/commands/auth/login-flow.ts
@@ -5,21 +5,18 @@ import type { RunCommandResult } from "@/cli/utils/runCommand.js";
 import { theme } from "@/cli/utils/theme.js";
 import type {
   DeviceCodeResponse,
+  ProjectSDK,
   TokenResponse,
   UserInfoResponse,
-} from "@/core/auth/index.js";
-import {
-  generateDeviceCode,
-  getTokenFromDeviceCode,
-  getUserInfo,
-  writeAuth,
-} from "@/core/auth/index.js";
+} from "@/core/sdk.js";
 
-async function generateAndDisplayDeviceCode(): Promise<DeviceCodeResponse> {
+async function generateAndDisplayDeviceCode(
+  sdk: ProjectSDK
+): Promise<DeviceCodeResponse> {
   const deviceCodeResponse = await runTask(
     "Generating device code...",
     async () => {
-      return await generateDeviceCode();
+      return await sdk.auth.generateDeviceCode();
     },
     {
       successMessage: "Device code generated",
@@ -36,6 +33,7 @@ async function generateAndDisplayDeviceCode(): Promise<DeviceCodeResponse> {
 }
 
 async function waitForAuthentication(
+  sdk: ProjectSDK,
   deviceCode: string,
   expiresIn: number,
   interval: number
@@ -48,7 +46,7 @@ async function waitForAuthentication(
       async () => {
         await pWaitFor(
           async () => {
-            const result = await getTokenFromDeviceCode(deviceCode);
+            const result = await sdk.auth.getTokenFromDeviceCode(deviceCode);
             if (result !== null) {
               tokenResponse = result;
               return true;
@@ -81,12 +79,13 @@ async function waitForAuthentication(
 }
 
 async function saveAuthData(
+  sdk: ProjectSDK,
   response: TokenResponse,
   userInfo: UserInfoResponse
 ): Promise<void> {
   const expiresAt = Date.now() + response.expiresIn * 1000;
 
-  await writeAuth({
+  await sdk.auth.write({
     accessToken: response.accessToken,
     refreshToken: response.refreshToken,
     expiresAt,
@@ -99,18 +98,19 @@ async function saveAuthData(
  * Execute the login flow (device code authentication).
  * This function is separate from the command to avoid circular dependencies.
  */
-export async function login(): Promise<RunCommandResult> {
-  const deviceCodeResponse = await generateAndDisplayDeviceCode();
+export async function login(sdk: ProjectSDK): Promise<RunCommandResult> {
+  const deviceCodeResponse = await generateAndDisplayDeviceCode(sdk);
 
   const token = await waitForAuthentication(
+    sdk,
     deviceCodeResponse.deviceCode,
     deviceCodeResponse.expiresIn,
     deviceCodeResponse.interval
   );
 
-  const userInfo = await getUserInfo(token.accessToken);
+  const userInfo = await sdk.auth.getUserInfo(token.accessToken);
 
-  await saveAuthData(token, userInfo);
+  await saveAuthData(sdk, token, userInfo);
 
   return {
     outroMessage: `Successfully logged in as ${theme.styles.bold(userInfo.email)}`,

--- a/src/cli/commands/auth/logout.ts
+++ b/src/cli/commands/auth/logout.ts
@@ -2,10 +2,10 @@ import { Command } from "commander";
 import type { CLIContext } from "@/cli/types.js";
 import { runCommand } from "@/cli/utils/index.js";
 import type { RunCommandResult } from "@/cli/utils/runCommand.js";
-import { deleteAuth } from "@/core/auth/index.js";
+import type { ProjectSDK } from "@/core/sdk.js";
 
-async function logout(): Promise<RunCommandResult> {
-  await deleteAuth();
+async function logout(sdk: ProjectSDK): Promise<RunCommandResult> {
+  await sdk.auth.delete();
   return { outroMessage: "Logged out successfully" };
 }
 

--- a/src/cli/commands/auth/whoami.ts
+++ b/src/cli/commands/auth/whoami.ts
@@ -2,10 +2,10 @@ import { Command } from "commander";
 import type { CLIContext } from "@/cli/types.js";
 import { runCommand, theme } from "@/cli/utils/index.js";
 import type { RunCommandResult } from "@/cli/utils/runCommand.js";
-import { readAuth } from "@/core/auth/index.js";
+import type { ProjectSDK } from "@/core/sdk.js";
 
-async function whoami(): Promise<RunCommandResult> {
-  const auth = await readAuth();
+async function whoami(sdk: ProjectSDK): Promise<RunCommandResult> {
+  const auth = await sdk.auth.read();
   return { outroMessage: `Logged in as: ${theme.styles.bold(auth.email)}` };
 }
 

--- a/src/cli/commands/dashboard/open.ts
+++ b/src/cli/commands/dashboard/open.ts
@@ -3,9 +3,11 @@ import open from "open";
 import type { CLIContext } from "@/cli/types.js";
 import { getDashboardUrl, runCommand } from "@/cli/utils/index.js";
 import type { RunCommandResult } from "@/cli/utils/runCommand.js";
+import type { ProjectSDK } from "@/core/sdk.js";
 
-async function openDashboard(): Promise<RunCommandResult> {
-  const dashboardUrl = getDashboardUrl();
+async function openDashboard(sdk: ProjectSDK): Promise<RunCommandResult> {
+  const appId = sdk.project.getAppConfig().id;
+  const dashboardUrl = getDashboardUrl(appId);
 
   if (!process.env.CI) {
     await open(dashboardUrl);

--- a/src/cli/commands/entities/push.ts
+++ b/src/cli/commands/entities/push.ts
@@ -3,11 +3,10 @@ import { Command } from "commander";
 import type { CLIContext } from "@/cli/types.js";
 import { runCommand, runTask } from "@/cli/utils/index.js";
 import type { RunCommandResult } from "@/cli/utils/runCommand.js";
-import { readProjectConfig } from "@/core/index.js";
-import { pushEntities } from "@/core/resources/entity/index.js";
+import type { ProjectSDK } from "@/core/sdk.js";
 
-async function pushEntitiesAction(): Promise<RunCommandResult> {
-  const { entities } = await readProjectConfig();
+async function pushEntitiesAction(sdk: ProjectSDK): Promise<RunCommandResult> {
+  const { entities } = await sdk.project.readConfig();
 
   if (entities.length === 0) {
     return { outroMessage: "No entities found in project" };
@@ -19,7 +18,7 @@ async function pushEntitiesAction(): Promise<RunCommandResult> {
   const result = await runTask(
     "Pushing entities to Base44",
     async () => {
-      return await pushEntities(entities);
+      return await sdk.entities.push(entities);
     },
     {
       successMessage: "Entities pushed successfully",

--- a/src/cli/commands/functions/deploy.ts
+++ b/src/cli/commands/functions/deploy.ts
@@ -4,11 +4,12 @@ import type { CLIContext } from "@/cli/types.js";
 import { runCommand, runTask } from "@/cli/utils/index.js";
 import type { RunCommandResult } from "@/cli/utils/runCommand.js";
 import { ApiError } from "@/core/errors.js";
-import { readProjectConfig } from "@/core/index.js";
-import { pushFunctions } from "@/core/resources/function/index.js";
+import type { ProjectSDK } from "@/core/sdk.js";
 
-async function deployFunctionsAction(): Promise<RunCommandResult> {
-  const { functions } = await readProjectConfig();
+async function deployFunctionsAction(
+  sdk: ProjectSDK
+): Promise<RunCommandResult> {
+  const { functions } = await sdk.project.readConfig();
 
   if (functions.length === 0) {
     return {
@@ -24,7 +25,7 @@ async function deployFunctionsAction(): Promise<RunCommandResult> {
   const result = await runTask(
     "Deploying functions to Base44",
     async () => {
-      return await pushFunctions(functions);
+      return await sdk.functions.push(functions);
     },
     {
       successMessage: "Functions deployed successfully",

--- a/src/cli/commands/project/create.ts
+++ b/src/cli/commands/project/create.ts
@@ -14,14 +14,7 @@ import {
 } from "@/cli/utils/index.js";
 import type { RunCommandResult } from "@/cli/utils/runCommand.js";
 import { InvalidInputError } from "@/core/errors.js";
-import { deploySite, isDirEmpty, pushEntities } from "@/core/index.js";
-import type { Template } from "@/core/project/index.js";
-import {
-  createProjectFiles,
-  listTemplates,
-  readProjectConfig,
-  setAppConfig,
-} from "@/core/project/index.js";
+import type { ProjectSDK, Template } from "@/core/sdk.js";
 
 const DEFAULT_TEMPLATE_ID = "backend-only";
 
@@ -33,8 +26,11 @@ interface CreateOptions {
   skills?: boolean;
 }
 
-async function getTemplateById(templateId: string): Promise<Template> {
-  const templates = await listTemplates();
+async function getTemplateById(
+  sdk: ProjectSDK,
+  templateId: string
+): Promise<Template> {
+  const templates = await sdk.project.listTemplates();
   const template = templates.find((t) => t.id === templateId);
   if (!template) {
     const validIds = templates.map((t) => t.id).join(", ");
@@ -54,9 +50,10 @@ function validateNonInteractiveFlags(command: Command): void {
 }
 
 async function createInteractive(
+  sdk: ProjectSDK,
   options: CreateOptions
 ): Promise<RunCommandResult> {
-  const templates = await listTemplates();
+  const templates = await sdk.project.listTemplates();
   const templateOptions: Option<Template>[] = templates.map((t) => ({
     value: t,
     label: t.name,
@@ -85,7 +82,7 @@ async function createInteractive(
             });
       },
       projectPath: async ({ results }) => {
-        const suggestedPath = (await isDirEmpty())
+        const suggestedPath = (await sdk.project.isDirEmpty())
           ? "./"
           : `./${kebabCase(results.name)}`;
         return text({
@@ -100,7 +97,7 @@ async function createInteractive(
     }
   );
 
-  return await executeCreate({
+  return await executeCreate(sdk, {
     template: result.template,
     name: result.name,
     projectPath: result.projectPath as string,
@@ -111,13 +108,15 @@ async function createInteractive(
 }
 
 async function createNonInteractive(
+  sdk: ProjectSDK,
   options: CreateOptions
 ): Promise<RunCommandResult> {
   const template = await getTemplateById(
+    sdk,
     options.template ?? DEFAULT_TEMPLATE_ID
   );
 
-  return await executeCreate({
+  return await executeCreate(sdk, {
     template,
     name: options.name!,
     projectPath: options.path!,
@@ -127,30 +126,33 @@ async function createNonInteractive(
   });
 }
 
-async function executeCreate({
-  template,
-  name: rawName,
-  description,
-  projectPath,
-  deploy,
-  skills,
-  isInteractive,
-}: {
-  template: Template;
-  name: string;
-  description?: string;
-  projectPath: string;
-  deploy?: boolean;
-  skills?: boolean;
-  isInteractive: boolean;
-}): Promise<RunCommandResult> {
+async function executeCreate(
+  sdk: ProjectSDK,
+  {
+    template,
+    name: rawName,
+    description,
+    projectPath,
+    deploy,
+    skills,
+    isInteractive,
+  }: {
+    template: Template;
+    name: string;
+    description?: string;
+    projectPath: string;
+    deploy?: boolean;
+    skills?: boolean;
+    isInteractive: boolean;
+  }
+): Promise<RunCommandResult> {
   const name = rawName.trim();
   const resolvedPath = resolve(projectPath);
 
   const { projectId } = await runTask(
     "Setting up your project...",
     async () => {
-      return await createProjectFiles({
+      return await sdk.project.createFiles({
         name,
         description: description?.trim(),
         path: resolvedPath,
@@ -163,10 +165,10 @@ async function executeCreate({
     }
   );
 
-  // Set app config in cache for sync access to getDashboardUrl and getAppClient
-  setAppConfig({ id: projectId, projectRoot: resolvedPath });
+  // Set app config in cache for sync access to getAppClient
+  sdk.project.setAppConfig({ id: projectId, projectRoot: resolvedPath });
 
-  const { project, entities } = await readProjectConfig(resolvedPath);
+  const { project, entities } = await sdk.project.readConfig(resolvedPath);
   let finalAppUrl: string | undefined;
 
   if (entities.length > 0) {
@@ -186,7 +188,7 @@ async function executeCreate({
       await runTask(
         `Pushing ${entities.length} data models to Base44...`,
         async () => {
-          await pushEntities(entities);
+          await sdk.entities.push(entities);
         },
         {
           successMessage: theme.colors.base44Orange(
@@ -222,7 +224,7 @@ async function executeCreate({
           await execa({ cwd: resolvedPath, shell: true })`${buildCommand}`;
 
           updateMessage("Deploying site...");
-          return await deploySite(join(resolvedPath, outputDirectory));
+          return await sdk.site.deploy(join(resolvedPath, outputDirectory));
         },
         {
           successMessage: theme.colors.base44Orange(
@@ -296,14 +298,17 @@ export function getCreateCommand(context: CLIContext): Command {
 
       if (isNonInteractive) {
         await runCommand(
-          () =>
-            createNonInteractive({ name: options.name ?? name, ...options }),
+          (sdk) =>
+            createNonInteractive(sdk, {
+              name: options.name ?? name,
+              ...options,
+            }),
           { requireAuth: true, requireAppConfig: false },
           context
         );
       } else {
         await runCommand(
-          () => createInteractive({ name, ...options }),
+          (sdk) => createInteractive(sdk, { name, ...options }),
           { fullBanner: true, requireAuth: true, requireAppConfig: false },
           context
         );

--- a/src/cli/commands/project/deploy.ts
+++ b/src/cli/commands/project/deploy.ts
@@ -8,20 +8,19 @@ import {
   theme,
 } from "@/cli/utils/index.js";
 import type { RunCommandResult } from "@/cli/utils/runCommand.js";
-import {
-  deployAll,
-  hasResourcesToDeploy,
-  readProjectConfig,
-} from "@/core/project/index.js";
+import type { ProjectSDK } from "@/core/sdk.js";
 
 interface DeployOptions {
   yes?: boolean;
 }
 
-async function deployAction(options: DeployOptions): Promise<RunCommandResult> {
-  const projectData = await readProjectConfig();
+async function deployAction(
+  sdk: ProjectSDK,
+  options: DeployOptions
+): Promise<RunCommandResult> {
+  const projectData = await sdk.project.readConfig();
 
-  if (!hasResourcesToDeploy(projectData)) {
+  if (!sdk.project.hasResourcesToDeploy(projectData)) {
     return {
       outroMessage: "No resources found to deploy",
     };
@@ -70,7 +69,7 @@ async function deployAction(options: DeployOptions): Promise<RunCommandResult> {
   const result = await runTask(
     "Deploying your app...",
     async () => {
-      return await deployAll(projectData);
+      return await sdk.project.deployAll(projectData);
     },
     {
       successMessage: theme.colors.base44Orange("Deployment completed"),
@@ -78,8 +77,9 @@ async function deployAction(options: DeployOptions): Promise<RunCommandResult> {
     }
   );
 
+  const appId = sdk.project.getAppConfig().id;
   log.message(
-    `${theme.styles.header("Dashboard")}: ${theme.colors.links(getDashboardUrl())}`
+    `${theme.styles.header("Dashboard")}: ${theme.colors.links(getDashboardUrl(appId))}`
   );
   if (result.appUrl) {
     log.message(
@@ -98,7 +98,7 @@ export function getDeployCommand(context: CLIContext): Command {
     .option("-y, --yes", "Skip confirmation prompt")
     .action(async (options: DeployOptions) => {
       await runCommand(
-        () => deployAction(options),
+        (sdk) => deployAction(sdk, options),
         { requireAuth: true },
         context
       );

--- a/src/cli/commands/project/link.ts
+++ b/src/cli/commands/project/link.ts
@@ -16,15 +16,7 @@ import {
   ConfigNotFoundError,
   InvalidInputError,
 } from "@/core/errors.js";
-import type { Project } from "@/core/project/index.js";
-import {
-  appConfigExists,
-  createProject,
-  findProjectRoot,
-  listProjects,
-  setAppConfig,
-  writeAppConfig,
-} from "@/core/project/index.js";
+import type { Project, ProjectSDK } from "@/core/sdk.js";
 
 interface LinkOptions {
   create?: boolean;
@@ -127,8 +119,11 @@ async function promptForExistingProject(
   return selectedProject;
 }
 
-async function link(options: LinkOptions): Promise<RunCommandResult> {
-  const projectRoot = await findProjectRoot();
+async function link(
+  sdk: ProjectSDK,
+  options: LinkOptions
+): Promise<RunCommandResult> {
+  const projectRoot = await sdk.project.findRoot();
 
   if (!projectRoot) {
     throw new ConfigNotFoundError(
@@ -136,7 +131,7 @@ async function link(options: LinkOptions): Promise<RunCommandResult> {
     );
   }
 
-  if (await appConfigExists(projectRoot.root)) {
+  if (await sdk.project.appConfigExists(projectRoot.root)) {
     throw new ConfigExistsError(
       "Project is already linked. An .app.jsonc file with the appId already exists.",
       {
@@ -160,7 +155,7 @@ async function link(options: LinkOptions): Promise<RunCommandResult> {
   if (action === "choose") {
     const projects = await runTask(
       "Fetching projects...",
-      async () => listProjects(),
+      async () => sdk.project.list(),
       {
         successMessage: "Projects fetched",
         errorMessage: "Failed to fetch projects",
@@ -203,8 +198,11 @@ async function link(options: LinkOptions): Promise<RunCommandResult> {
     await runTask(
       "Linking project...",
       async () => {
-        await writeAppConfig(projectRoot.root, projectId);
-        setAppConfig({ id: projectId, projectRoot: projectRoot.root });
+        await sdk.project.writeAppConfig(projectRoot.root, projectId);
+        sdk.project.setAppConfig({
+          id: projectId,
+          projectRoot: projectRoot.root,
+        });
       },
       {
         successMessage: "Project linked successfully",
@@ -223,7 +221,7 @@ async function link(options: LinkOptions): Promise<RunCommandResult> {
     const { projectId } = await runTask(
       "Creating project on Base44...",
       async () => {
-        return await createProject(name, description);
+        return await sdk.project.create(name, description);
       },
       {
         successMessage: "Project created successfully",
@@ -231,16 +229,16 @@ async function link(options: LinkOptions): Promise<RunCommandResult> {
       }
     );
 
-    await writeAppConfig(projectRoot.root, projectId);
+    await sdk.project.writeAppConfig(projectRoot.root, projectId);
 
     // Set app config in cache for sync access to getDashboardUrl
-    setAppConfig({ id: projectId, projectRoot: projectRoot.root });
+    sdk.project.setAppConfig({ id: projectId, projectRoot: projectRoot.root });
 
     finalProjectId = projectId;
   }
 
   log.message(
-    `${theme.styles.header("Dashboard")}: ${theme.colors.links(getDashboardUrl(finalProjectId))}`
+    `${theme.styles.header("Dashboard")}: ${theme.colors.links(getDashboardUrl(finalProjectId!))}`
   );
   return { outroMessage: "Project linked" };
 }
@@ -263,7 +261,7 @@ export function getLinkCommand(context: CLIContext): Command {
     .hook("preAction", validateNonInteractiveFlags)
     .action(async (options: LinkOptions) => {
       await runCommand(
-        () => link(options),
+        (sdk) => link(sdk, options),
         { requireAuth: true, requireAppConfig: false },
         context
       );

--- a/src/cli/commands/site/deploy.ts
+++ b/src/cli/commands/site/deploy.ts
@@ -5,15 +5,17 @@ import type { CLIContext } from "@/cli/types.js";
 import { runCommand, runTask } from "@/cli/utils/index.js";
 import type { RunCommandResult } from "@/cli/utils/runCommand.js";
 import { ConfigNotFoundError } from "@/core/errors.js";
-import { readProjectConfig } from "@/core/project/index.js";
-import { deploySite } from "@/core/site/index.js";
+import type { ProjectSDK } from "@/core/sdk.js";
 
 interface DeployOptions {
   yes?: boolean;
 }
 
-async function deployAction(options: DeployOptions): Promise<RunCommandResult> {
-  const { project } = await readProjectConfig();
+async function deployAction(
+  sdk: ProjectSDK,
+  options: DeployOptions
+): Promise<RunCommandResult> {
+  const { project } = await sdk.project.readConfig();
 
   if (!project.site?.outputDirectory) {
     throw new ConfigNotFoundError("No site configuration found.", {
@@ -41,7 +43,7 @@ async function deployAction(options: DeployOptions): Promise<RunCommandResult> {
   const result = await runTask(
     "Creating archive and deploying site...",
     async () => {
-      return await deploySite(outputDir);
+      return await sdk.site.deploy(outputDir);
     },
     {
       successMessage: "Site deployed successfully",
@@ -58,7 +60,7 @@ export function getSiteDeployCommand(context: CLIContext): Command {
     .option("-y, --yes", "Skip confirmation prompt")
     .action(async (options: DeployOptions) => {
       await runCommand(
-        () => deployAction(options),
+        (sdk) => deployAction(sdk, options),
         { requireAuth: true },
         context
       );

--- a/src/cli/commands/site/open.ts
+++ b/src/cli/commands/site/open.ts
@@ -3,10 +3,10 @@ import open from "open";
 import type { CLIContext } from "@/cli/types.js";
 import { runCommand } from "@/cli/utils/index.js";
 import type { RunCommandResult } from "@/cli/utils/runCommand.js";
-import { getSiteUrl } from "@/core/site/index.js";
+import type { ProjectSDK } from "@/core/sdk.js";
 
-async function openAction(): Promise<RunCommandResult> {
-  const siteUrl = await getSiteUrl();
+async function openAction(sdk: ProjectSDK): Promise<RunCommandResult> {
+  const siteUrl = await sdk.site.getUrl();
 
   if (!process.env.CI) {
     await open(siteUrl);

--- a/src/cli/commands/types/generate.ts
+++ b/src/cli/commands/types/generate.ts
@@ -2,19 +2,19 @@ import { Command } from "commander";
 import type { CLIContext } from "@/cli/types.js";
 import { runCommand, runTask } from "@/cli/utils/index.js";
 import type { RunCommandResult } from "@/cli/utils/runCommand.js";
-import { readProjectConfig } from "@/core/index.js";
-import { generateTypesFile, updateProjectConfig } from "@/core/types/index.js";
+import type { ProjectSDK } from "@/core/sdk.js";
 
 const TYPES_FILE_PATH = "base44/.types/types.d.ts";
 
-async function generateTypesAction(): Promise<RunCommandResult> {
-  const { entities, functions, agents, project } = await readProjectConfig();
+async function generateTypesAction(sdk: ProjectSDK): Promise<RunCommandResult> {
+  const { entities, functions, agents, project } =
+    await sdk.project.readConfig();
 
   await runTask("Generating types", async () => {
-    await generateTypesFile({ entities, functions, agents });
+    await sdk.types.generate({ entities, functions, agents });
   });
 
-  const tsconfigUpdated = await updateProjectConfig(project.root);
+  const tsconfigUpdated = await sdk.types.updateProjectConfig(project.root);
 
   return {
     outroMessage: tsconfigUpdated
@@ -29,10 +29,6 @@ export function getTypesGenerateCommand(context: CLIContext): Command {
       "Generate TypeScript declaration file (types.d.ts) from project resources"
     )
     .action(async () => {
-      await runCommand(
-        () => generateTypesAction(),
-        { requireAuth: false },
-        context
-      );
+      await runCommand(generateTypesAction, { requireAuth: false }, context);
     });
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,5 @@
 import { createProgram } from "@/cli/program.js";
-import { readAuth } from "@/core/auth/index.js";
+import { createProjectSDK } from "@/core/sdk.js";
 import { CLIExitError } from "./errors.js";
 import { ErrorReporter } from "./telemetry/error-reporter.js";
 import { addCommandInfoToErrorReporter } from "./telemetry/index.js";
@@ -12,14 +12,17 @@ async function runCLI(): Promise<void> {
   // Register process error handlers FIRST
   errorReporter.registerProcessErrorHandlers();
 
+  // Create SDK instance
+  const sdk = createProjectSDK();
+
   // Create context for dependency injection
-  const context: CLIContext = { errorReporter };
+  const context: CLIContext = { errorReporter, sdk };
 
   // Create program with injected context
   const program = createProgram(context);
 
   try {
-    const userInfo = await readAuth();
+    const userInfo = await sdk.auth.read();
     errorReporter.setContext({
       user: { email: userInfo.email, name: userInfo.name },
     });
@@ -44,4 +47,4 @@ async function runCLI(): Promise<void> {
   }
 }
 
-export { runCLI, createProgram, CLIExitError };
+export { runCLI, createProgram, createProjectSDK, CLIExitError };

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -1,5 +1,7 @@
+import type { ProjectSDK } from "@/core/sdk.js";
 import type { ErrorReporter } from "./telemetry/error-reporter.js";
 
 export interface CLIContext {
   errorReporter: ErrorReporter;
+  sdk: ProjectSDK;
 }

--- a/src/cli/utils/runCommand.ts
+++ b/src/cli/utils/runCommand.ts
@@ -4,9 +4,8 @@ import type { CLIContext } from "@/cli/types.js";
 import { printBanner } from "@/cli/utils/banner.js";
 import { theme } from "@/cli/utils/theme.js";
 import { printUpgradeNotificationIfAvailable } from "@/cli/utils/upgradeNotification.js";
-import { isLoggedIn } from "@/core/auth/index.js";
 import { isCLIError } from "@/core/errors.js";
-import { initAppConfig } from "@/core/project/index.js";
+import type { ProjectSDK } from "@/core/sdk.js";
 
 export interface RunCommandOptions {
   /**
@@ -41,17 +40,17 @@ export interface RunCommandResult {
  * This function handles both. Commands can return an optional `outroMessage`
  * which will be displayed at the end.
  *
- * @param commandFn - The async function to execute. Returns `RunCommandResult` with optional `outroMessage`.
+ * @param commandFn - The async function to execute. Receives the SDK instance and returns `RunCommandResult`.
  * @param options - Optional configuration for the command wrapper
- * @param context - CLI context with dependencies (errorReporter, etc.)
+ * @param context - CLI context with dependencies (errorReporter, sdk, etc.)
  *
  * @example
  * export function getMyCommand(context: CLIContext): Command {
  *   return new Command("my-command")
  *     .action(async () => {
  *       await runCommand(
- *         async () => {
- *           // ... do work ...
+ *         async (sdk) => {
+ *           // ... do work using sdk ...
  *           return { outroMessage: "Done!" };
  *         },
  *         { requireAuth: true },
@@ -61,10 +60,12 @@ export interface RunCommandResult {
  * }
  */
 export async function runCommand(
-  commandFn: () => Promise<RunCommandResult>,
+  commandFn: (sdk: ProjectSDK) => Promise<RunCommandResult>,
   options: RunCommandOptions | undefined,
   context: CLIContext
 ): Promise<void> {
+  const { sdk } = context;
+
   console.log();
 
   if (options?.fullBanner) {
@@ -79,21 +80,21 @@ export async function runCommand(
   try {
     // Check authentication if required
     if (options?.requireAuth) {
-      const loggedIn = await isLoggedIn();
+      const loggedIn = await sdk.auth.isLoggedIn();
 
       if (!loggedIn) {
         log.info("You need to login first to continue.");
-        await login();
+        await login(sdk);
       }
     }
 
     // Initialize app config unless explicitly disabled
     if (options?.requireAppConfig !== false) {
-      const appConfig = await initAppConfig();
+      const appConfig = await sdk.project.initAppConfig();
       context.errorReporter.setContext({ appId: appConfig.id });
     }
 
-    const { outroMessage } = await commandFn();
+    const { outroMessage } = await commandFn(sdk);
     outro(outroMessage || "");
   } catch (error) {
     // Display error message

--- a/src/cli/utils/urls.ts
+++ b/src/cli/utils/urls.ts
@@ -1,14 +1,11 @@
 import { getBase44ApiUrl } from "@/core/config.js";
-import { getAppConfig } from "@/core/project/index.js";
 
 /**
  * Gets the dashboard URL for a project.
  *
- * @param projectId - Optional project ID. If not provided, uses cached appId from getAppConfig().
+ * @param projectId - The project ID
  * @returns The dashboard URL
- * @throws Error if no projectId provided and app config is not initialized
  */
-export function getDashboardUrl(projectId?: string): string {
-  const id = projectId ?? getAppConfig().id;
-  return `${getBase44ApiUrl()}/apps/${id}/editor/workspace/overview`;
+export function getDashboardUrl(projectId: string): string {
+  return `${getBase44ApiUrl()}/apps/${projectId}/editor/workspace/overview`;
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -5,5 +5,6 @@ export * from "./consts.js";
 export * from "./errors.js";
 export * from "./project/index.js";
 export * from "./resources/index.js";
+export * from "./sdk.js";
 export * from "./site/index.js";
 export * from "./utils/index.js";

--- a/src/core/sdk.ts
+++ b/src/core/sdk.ts
@@ -1,0 +1,133 @@
+// SDK Facade - single API surface between CLI and core internals.
+// CLI commands receive the SDK via dependency injection, never importing core modules directly.
+//
+// Use `createProjectSDK()` to create an instance. Later, this factory can accept
+// configuration (e.g., app config, auth tokens) to enable true instance isolation.
+
+// --- Auth ---
+import {
+  generateDeviceCode,
+  getTokenFromDeviceCode,
+  getUserInfo,
+} from "@/core/auth/api.js";
+import {
+  deleteAuth,
+  isLoggedIn,
+  readAuth,
+  requireAuth,
+  writeAuth,
+} from "@/core/auth/config.js";
+// --- Project ---
+import { createProject, listProjects } from "@/core/project/api.js";
+import {
+  appConfigExists,
+  getAppConfig,
+  initAppConfig,
+  setAppConfig,
+  writeAppConfig,
+} from "@/core/project/app-config.js";
+import { findProjectRoot, readProjectConfig } from "@/core/project/config.js";
+import { createProjectFiles } from "@/core/project/create.js";
+import { deployAll, hasResourcesToDeploy } from "@/core/project/deploy.js";
+import { listTemplates } from "@/core/project/template.js";
+// --- Resources ---
+import { fetchAgents, pushAgents } from "@/core/resources/agent/api.js";
+import { writeAgents } from "@/core/resources/agent/config.js";
+import { pushEntities } from "@/core/resources/entity/deploy.js";
+import { pushFunctions } from "@/core/resources/function/deploy.js";
+// --- Site ---
+import { getSiteUrl } from "@/core/site/api.js";
+import { deploySite } from "@/core/site/deploy.js";
+// --- Types ---
+import { generateTypesFile } from "@/core/types/generator.js";
+import { updateProjectConfig } from "@/core/types/update-project.js";
+// --- Utils ---
+import { isDirEmpty } from "@/core/utils/fs.js";
+
+// --- Re-export types that CLI commands need ---
+export type {
+  AuthData,
+  DeviceCodeResponse,
+  TokenResponse,
+  UserInfoResponse,
+} from "@/core/auth/schema.js";
+export type { CachedAppConfig } from "@/core/project/app-config.js";
+export type {
+  CreateProjectOptions,
+  CreateProjectResult,
+} from "@/core/project/create.js";
+export type { DeployAllResult } from "@/core/project/deploy.js";
+export type {
+  Project,
+  ProjectConfig,
+  Template,
+} from "@/core/project/schema.js";
+export type { ProjectData, ProjectRoot } from "@/core/project/types.js";
+export type {
+  AgentConfig,
+  AgentConfigApiResponse,
+  ListAgentsResponse,
+  SyncAgentsResponse,
+} from "@/core/resources/agent/schema.js";
+export type {
+  Entity,
+  SyncEntitiesResponse,
+} from "@/core/resources/entity/schema.js";
+export type {
+  BackendFunction,
+  DeployFunctionsResponse,
+} from "@/core/resources/function/schema.js";
+export type { DeployResponse as SiteDeployResponse } from "@/core/site/schema.js";
+export type { GenerateTypesInput } from "@/core/types/generator.js";
+
+export type ProjectSDK = ReturnType<typeof createProjectSDK>;
+
+export function createProjectSDK() {
+  return {
+    auth: {
+      read: readAuth,
+      write: writeAuth,
+      delete: deleteAuth,
+      isLoggedIn,
+      requireAuth,
+      generateDeviceCode,
+      getTokenFromDeviceCode,
+      getUserInfo,
+    },
+    project: {
+      readConfig: readProjectConfig,
+      createFiles: createProjectFiles,
+      create: createProject,
+      list: listProjects,
+      listTemplates,
+      findRoot: findProjectRoot,
+      initAppConfig,
+      getAppConfig,
+      setAppConfig,
+      appConfigExists,
+      writeAppConfig,
+      deployAll,
+      hasResourcesToDeploy,
+      isDirEmpty,
+    },
+    entities: {
+      push: pushEntities,
+    },
+    functions: {
+      push: pushFunctions,
+    },
+    agents: {
+      push: pushAgents,
+      fetch: fetchAgents,
+      writeLocal: writeAgents,
+    },
+    site: {
+      deploy: deploySite,
+      getUrl: getSiteUrl,
+    },
+    types: {
+      generate: generateTypesFile,
+      updateProjectConfig,
+    },
+  };
+}

--- a/tests/cli/testkit/CLITestkit.ts
+++ b/tests/cli/testkit/CLITestkit.ts
@@ -17,11 +17,13 @@ interface CLIContext {
     setContext: (context: Record<string, unknown>) => void;
     getErrorContext: () => { sessionId?: string; appId?: string };
   };
+  sdk: unknown;
 }
 
 /** Type for the bundled program module */
 interface ProgramModule {
   createProgram: (context: CLIContext) => Command;
+  createProjectSDK: () => unknown;
   CLIExitError: new (code: number) => Error & { code: number };
 }
 
@@ -128,7 +130,7 @@ export class CLITestkit {
     vi.resetModules();
 
     // Import CLI module fresh after reset
-    const { createProgram, CLIExitError } = (await import(
+    const { createProgram, createProjectSDK, CLIExitError } = (await import(
       DIST_INDEX_PATH
     )) as ProgramModule;
 
@@ -138,6 +140,7 @@ export class CLITestkit {
         setContext: () => {},
         getErrorContext: () => ({ sessionId: "test-session" }),
       },
+      sdk: createProjectSDK(),
     };
     const program = createProgram(mockContext);
 


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Introduces an SDK facade pattern to establish a clean separation between CLI commands and core functionality. Commands now receive a `ProjectSDK` instance via dependency injection instead of importing core modules directly, setting the foundation for better testability and future instance isolation.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [x] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Created `src/core/sdk.ts` with `createProjectSDK()` factory that exports organized namespaces (auth, project, entities, functions, agents, site, types)
> - Updated `CLIContext` interface to include `sdk: ProjectSDK` alongside `errorReporter`
> - Modified `runCommand()` to pass SDK instance to command functions: `commandFn: (sdk: ProjectSDK) => Promise<RunCommandResult>`
> - Refactored all CLI commands (auth, project, entities, functions, agents, site, types, dashboard) to receive SDK via parameter instead of importing from `@/core`
> - Updated `getDashboardUrl()` to require explicit `projectId` parameter instead of implicitly reading from cached config
> - Initialized SDK in `runCLI()` and injected into command context
> - Updated test infrastructure (`CLITestkit`) to create and inject SDK instance for command tests
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [x] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated AGENTS.md if I made architectural changes
>
> ## Additional Notes
>
> This is the first step in migrating to an SDK-based architecture. The SDK currently wraps existing functions but maintains the same global state behavior. Future work can enhance the SDK factory to accept configuration (app config, auth tokens, custom API endpoints) for true instance isolation, enabling better testing and multi-project support.
>
> **Architecture Benefits:**
> - Clear API boundary between CLI and core modules
> - Better dependency injection for testing
> - Preparation for stateful SDK instances
> - Organized namespace structure (sdk.auth.*, sdk.project.*, etc.)
> 
> **Breaking Changes:** None - this is an internal refactoring that doesn't affect the CLI interface or behavior.
>
> ---
> <sub>🤖 Generated by Claude | 2026-02-08 23:00 UTC</sub>