### PR TITLE
feat(connectors): allow skipping OAuth with Esc key

### DIFF
--- a/src/cli/commands/connectors/push.ts
+++ b/src/cli/commands/connectors/push.ts
@@ -45,6 +45,8 @@ async function runOAuthFlowWithSkip(
 
   const s = spinner();
 
+  // Clack's spinner calls block() which puts stdin in raw mode — Esc/Ctrl+C
+  // calls process.exit(0) directly, bypassing SIGINT. Override to skip instead.
   const originalExit = process.exit;
   process.exit = (() => {
     skipped = true;
@@ -68,13 +70,13 @@ async function runOAuthFlowWithSkip(
         interval: POLL_INTERVAL_MS,
         timeout: POLL_TIMEOUT_MS,
       },
-    ).catch((err) => {
-      if (err instanceof TimeoutError) {
-        finalStatus = "PENDING";
-      } else {
-        throw err;
-      }
-    });
+    );
+  } catch (err) {
+    if (err instanceof TimeoutError) {
+      finalStatus = "PENDING";
+    } else {
+      throw err;
+    }
   } finally {
     process.exit = originalExit;
 


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR adds the ability to skip individual OAuth connector authorizations during the `connectors push` flow by pressing the Esc key. Previously, users had to wait for authorization to complete or timeout, or kill the entire process. Now when authorizing multiple connectors, users can skip specific connectors without interrupting the entire push operation. Skipped connectors are tracked and reported separately in the summary output.
>
> ## Related Issue
>
> Part of #184 (connectors feature implementation)
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added `runOAuthFlowWithSkip()` function to handle OAuth flows with Esc key skip capability
> - Introduced `OAuthFlowStatus` type extending `ConnectorOAuthStatus` with "SKIPPED" state
> - Implemented temporary `process.exit` override to intercept Esc/Ctrl+C key presses during OAuth flow
> - Updated `printSummary()` to track and display skipped connectors as warnings
> - Replaced `runTask()` with direct `spinner()` usage for more control over exit handling
> - Added polling constants (`POLL_INTERVAL_MS`, `POLL_TIMEOUT_MS`) for OAuth status checks
> - Enhanced spinner messages to indicate "Esc to skip" functionality
> - Added comprehensive JSDoc comment explaining the `process.exit` override mechanism
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [x] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated AGENTS.md if I made architectural changes
>
> ## Additional Notes
>
> **Technical implementation:** Clack's `block()` function (used by `spinner()`) puts stdin in raw mode where Esc/Ctrl+C triggers `process.exit(0)` directly instead of emitting SIGINT. To implement skip functionality, we temporarily override `process.exit` during the OAuth flow to set a `skipped` flag instead of killing the process. The override is restored in a `finally` block to ensure normal exit behavior is preserved after each connector's authorization attempt.
>
> **Review fixes:** Added inline comment documenting the `process.exit` override, wrapped OAuth flow in try/catch/finally for better error handling.
>
> ---
> <sub>🤖 Generated by Claude | 2026-02-12 22:15 UTC</sub>