### PR TITLE
fix: use 'npm install -g base44@latest' instead of 'npm update -g base44'

### DIFF
--- a/src/cli/utils/upgradeNotification.ts
+++ b/src/cli/utils/upgradeNotification.ts
@@ -7,7 +7,7 @@ function formatUpgradeMessage(info: UpgradeInfo): string {
   const { shinyOrange } = theme.colors;
   const { bold } = theme.styles;
 
-  return `${shinyOrange("Update available!")} ${shinyOrange(`${info.currentVersion} → ${info.latestVersion}`)}  ${shinyOrange("Run:")} ${bold(shinyOrange("npm update -g base44"))}`;
+  return `${shinyOrange("Update available!")} ${shinyOrange(`${info.currentVersion} → ${info.latestVersion}`)}  ${shinyOrange("Run:")} ${bold(shinyOrange("npm install -g base44@latest"))}`;
 }
 
 export async function printUpgradeNotificationIfAvailable(): Promise<void> {

--- a/tests/cli/version-check.spec.ts
+++ b/tests/cli/version-check.spec.ts
@@ -13,7 +13,7 @@ describe("upgrade notification", () => {
     t.expectResult(result).toSucceed();
     t.expectResult(result).toContain("Update available!");
     t.expectResult(result).toContain("1.0.0");
-    t.expectResult(result).toContain("npm update -g base44");
+    t.expectResult(result).toContain("npm install -g base44@latest");
   });
 
   it("does not display notification when version is current", async () => {


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR fixes the upgrade notification message to use the correct npm command for updating the CLI globally. The previous command `npm update -g base44` doesn't guarantee the latest version, whereas `npm install -g base44@latest` explicitly installs the newest release. This ensures users who see the upgrade notification can reliably update to the latest version.
>
> ## Related Issue
>
> Fixes #221
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Updated upgrade notification message in `src/cli/utils/upgradeNotification.ts` to display `npm install -g base44@latest` instead of `npm update -g base44`
> - Updated test in `tests/cli/version-check.spec.ts` to verify the new command appears in the notification
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [x] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated AGENTS.md if I made architectural changes
>
> ## Additional Notes
>
> The change is minimal and only affects the user-facing message. No architectural or logic changes were made. The existing test was updated to match the new command, ensuring the notification displays correctly.
>
> ---
> <sub>🤖 Generated by Claude | 2026-02-10 18:42 UTC</sub>