### PR TITLE
fix: readme workflow

### DIFF
--- a/.github/workflows/readme-check.yml
+++ b/.github/workflows/readme-check.yml
@@ -19,9 +19,10 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout repository
+      - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.head_ref }}
           fetch-depth: 1
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Fixes the README Check workflow to properly checkout the PR branch by adding the `ref: ${{ github.head_ref }}` parameter to the checkout action. This ensures the workflow runs against the PR's branch code rather than the default branch, allowing it to correctly validate and update README.md based on the actual changes in the PR.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added `ref: ${{ github.head_ref }}` to the checkout step in `.github/workflows/readme-check.yml`
> - Updated step name from "Checkout repository" to "Checkout PR branch" for clarity
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> This change ensures the GitHub Actions workflow correctly checks out the PR's HEAD branch, which is critical for the Claude README Check action to validate and potentially update README.md based on the actual command changes in the PR.
>
> ---
> <sub>🤖 Generated by Claude | 2026-02-18 00:00 UTC</sub>