### PR TITLE
added error reporter action

### DIFF
--- a/.github/workflows/daily-error-report.yml
+++ b/.github/workflows/daily-error-report.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set time range
         id: time-range
         run: |
-          HOURS="${{ github.event.inputs.hours || '24' }}"
+          HOURS="${{ inputs.hours || '24' }}"
           echo "hours=$HOURS" >> $GITHUB_OUTPUT
 
       - name: Query error summary
@@ -199,9 +199,7 @@ jobs:
             - Don't speculate — if you can't find the root cause in the code, say so.
             - When an existing issue already tracks the error, reference it with `#<number>` instead of re-explaining everything. Just note if occurrences have increased or new users are affected.
             - Recurring untracked errors should be flagged prominently — these are being ignored.
-          claude_args: |
-            --model claude-sonnet-4-20250514
-            --allowedTools Read,Glob,Grep,"Bash(cat /tmp/*)",Bash(gh issue create:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh label create:*)
+          claude_args: '--model claude-sonnet-4-20250514 --allowed-tools Read Glob Grep "Bash(cat /tmp/*)" "Bash(gh issue create:*)" "Bash(gh issue list:*)" "Bash(gh issue view:*)" "Bash(gh label create:*)"'
 
       - name: No errors summary
         if: steps.check-errors.outputs.has_errors != 'true'


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR introduces a GitHub Actions workflow that runs daily at 08:00 UTC to automatically triage CLI errors captured in PostHog. It runs two HogQL queries to fetch aggregated error summaries and detailed event logs, then hands the data to Claude Code, which reads source files to perform root cause analysis, checks for recurring errors across previous daily reports and existing open issues, and creates a structured, labeled GitHub issue. If no significant errors are found, the workflow skips issue creation and writes a brief note to the Actions step summary instead.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added `.github/workflows/daily-error-report.yml` — a scheduled workflow (daily at 08:00 UTC) that also supports manual dispatch with a configurable `hours` look-back parameter (default: 24h)
> - Installs the PostHog CLI and executes two HogQL queries: an aggregated error summary (grouped by `error_code` / `is_user_error`) and a detailed per-event log (last 50 events), saved as JSONL to `/tmp/`
> - Passes both result files to `anthropics/claude-code-action@v1`, which is prompted to: check existing `error-report` issues for recurrence, search for matching open issues, read relevant source files for root cause analysis, classify system vs. user errors, and create a labeled GitHub issue following a structured template
> - Filters out low-signal user errors; only includes them when ≥5 unique users are affected or a CLI bug is suspected
> - Marks internal users (`@wix.com` / `@base44.com`) in reports without excluding them
> - Restricts Claude to a safe tool allowlist: `Read`, `Glob`, `Grep`, `cat /tmp/*`, and scoped `gh issue` commands
> - Skips issue creation and emits a step summary message when no errors are present
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> Three secrets/variables must be configured in the repository before this workflow can run:
> - `POSTHOG_CLI_API_KEY` — PostHog personal API token (secret)
> - `POSTHOG_PROJECT_ID` — PostHog project/environment ID (repository variable)
> - `CLAUDE_CODE_OAUTH_TOKEN` — OAuth token for the Claude Code GitHub Action (secret)
>
> The workflow requires `issues: write` and `id-token: write` permissions. The `id-token: write` permission is needed by the Claude Code action for OIDC-based authentication.
>
> ---
> <sub>🤖 Generated by Claude | 2026-02-18 23:30 UTC</sub>