### PR TITLE
more error reporter fixes for github action

### DIFF
--- a/.github/workflows/daily-error-report.yml
+++ b/.github/workflows/daily-error-report.yml
@@ -51,7 +51,7 @@ jobs:
           POSTHOG_CLI_TOKEN: ${{ secrets.POSTHOG_CLI_API_KEY }}
           POSTHOG_CLI_ENV_ID: ${{ vars.POSTHOG_PROJECT_ID }}
         run: |
-          posthog-cli exp query run "SELECT properties.\$exception_fingerprint as fingerprint, count() as occurrences, any(properties.\$exception_types) as exception_type, any(properties.\$exception_values) as exception_message, substring(toString(any(properties.\$exception_list)), 1, 3000) as exception_list, any(properties.\$exception_level) as level, any(properties.error_code) as error_code, any(properties.is_user_error) as is_user_error, any(properties.command_name) as command_name, any(properties.cli_version) as cli_version, any(properties.node_version) as node_version, any(properties.platform) as platform, any(properties.arch) as arch, any(properties.os_type) as os_type, any(properties.is_agent) as is_agent, any(properties.agent_name) as agent_name, any(properties.api_status_code) as api_status_code, any(properties.api_request_url) as api_request_url, any(properties.api_request_method) as api_request_method, max(timestamp) as last_seen, min(timestamp) as first_seen FROM events WHERE event = '\$exception' AND timestamp >= now() - INTERVAL ${{ steps.time-range.outputs.hours }} HOUR GROUP BY fingerprint ORDER BY occurrences DESC LIMIT 25" > /tmp/details.jsonl || true
+          posthog-cli exp query run "SELECT properties.\$exception_fingerprint as fingerprint, count() as occurrences, any(properties.\$exception_types) as exception_type, any(properties.\$exception_values) as exception_message, substring(toString(any(properties.\$exception_list)), 1, 1500) as exception_list, any(properties.\$exception_level) as level, any(properties.error_code) as error_code, any(properties.is_user_error) as is_user_error, any(properties.command_name) as command_name, any(properties.cli_version) as cli_version, any(properties.node_version) as node_version, any(properties.platform) as platform, any(properties.arch) as arch, any(properties.os_type) as os_type, any(properties.is_agent) as is_agent, any(properties.agent_name) as agent_name, any(properties.api_status_code) as api_status_code, any(properties.api_request_url) as api_request_url, any(properties.api_request_method) as api_request_method, max(timestamp) as last_seen, min(timestamp) as first_seen FROM events WHERE event = '\$exception' AND timestamp >= now() - INTERVAL ${{ steps.time-range.outputs.hours }} HOUR GROUP BY fingerprint ORDER BY occurrences DESC LIMIT 25" > /tmp/details.jsonl || true
 
       - name: Trim output files
         run: |
@@ -86,7 +86,9 @@ jobs:
 
             ## Step 1: Read the error data
 
-            Read two JSONL files (one JSON array per line):
+            IMPORTANT: Use `cat /tmp/summary.jsonl` and `cat /tmp/details.jsonl` (Bash tool) to read the data files — do NOT use the Read tool, as it may hit token limits on large files.
+
+            Both files are JSONL (one JSON array per line):
 
             **`/tmp/summary.jsonl`** — aggregated error counts. Columns (by position):
             `[is_user_error, error_code, occurrences, users_affected, internal_occurrences, sample_message, sample_command]`
@@ -95,6 +97,8 @@ jobs:
 
             **`/tmp/details.jsonl`** — one representative event per unique error group (grouped by fingerprint, ordered by occurrences DESC). Columns (by position):
             `[fingerprint, occurrences, exception_type, exception_message, exception_list, level, error_code, is_user_error, command_name, cli_version, node_version, platform, arch, os_type, is_agent, agent_name, api_status_code, api_request_url, api_request_method, last_seen, first_seen]`
+
+            You MUST read ALL rows from both files. Every error group in the data must be analyzed.
 
             ## PRIVACY — this repo is public, the issue will be public
 
@@ -119,7 +123,7 @@ jobs:
 
             The details file is already grouped by fingerprint (one row per unique error group, ordered by occurrences). For each error group:
             1. Read the stack trace from `exception_list` (it's a JSON array of `{type, value, stacktrace: {frames: [{filename, lineno, colno, function}]}}`)
-               Note: `exception_list` is truncated to ~3000 chars — this should include the most relevant top frames.
+               Note: `exception_list` is truncated to ~1500 chars — this should include the most relevant top frames.
             2. **Include the error message and stack trace from PostHog** in the report. Show `exception_message` and the top 3-5 frames from `exception_list`. These are the actual errors users hit.
             3. **Build a PostHog link** for each error using the `fingerprint` field: `https://us.posthog.com/project/${{ vars.POSTHOG_PROJECT_ID }}/error_tracking/<fingerprint>`. Include this link in the report so readers can drill into PostHog for full details.
             4. Use the stack trace frames to find the relevant source files in this repository (under `src/`). Map the frame `filename` and `lineno` to actual source files using Grep/Glob.
@@ -139,11 +143,15 @@ jobs:
 
             ## Step 5: Create the GitHub issue
 
-            If there are errors worth reporting, create ONE GitHub issue using `gh issue create`. The issue should follow this structure:
+            If there are errors worth reporting:
+            1. First, write the full issue body to a file: use the Write tool to save the markdown body to `error-report-body.md` in the workspace root.
+            2. Then create the issue using: `gh issue create --title "<title>" --label error-report --body-file error-report-body.md`
+
+            This two-step approach is required because the issue body is too large for inline `--body` arguments.
 
             **Title**: `Error Report: <date> (<N> errors in last <hours>h)`
 
-            **Body** (use this template):
+            **Body** (write this to `error-report-body.md`):
 
             ```
             ## Summary
@@ -235,7 +243,7 @@ jobs:
             - Don't speculate — if you can't find the root cause in the code, say so.
             - When an existing issue already tracks the error, reference it with `#<number>` instead of re-explaining everything. Just note if occurrences have increased or new users are affected.
             - Recurring untracked errors should be flagged prominently — these are being ignored.
-          claude_args: '--model claude-sonnet-4-20250514 --allowed-tools Read Glob Grep "Bash(cat /tmp/*)" "Bash(gh issue create:*)" "Bash(gh issue list:*)" "Bash(gh issue view:*)" "Bash(gh label create:*)"'
+          claude_args: '--model claude-sonnet-4-20250514 --allowed-tools Read Write Glob Grep "Bash(cat /tmp/*)" "Bash(gh issue create:*)" "Bash(gh issue list:*)" "Bash(gh issue view:*)" "Bash(gh label create:*)"'
 
       - name: No errors summary
         if: steps.check-errors.outputs.has_errors != 'true'


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR improves the reliability and output quality of the daily error report GitHub Actions workflow. It fixes issues with large issue bodies being rejected by `gh issue create`, reduces the `exception_list` substring limit to avoid token bloat, and adds clearer instructions for the Claude agent reading the data files.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [x] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Reduced `exception_list` substring truncation from 3000 to 1500 characters to reduce token usage in the AI analysis step
> - Changed issue creation to a two-step process: first write the body to `error-report-body.md`, then use `--body-file` flag with `gh issue create` to avoid inline body size limits
> - Added `Write` to the list of allowed tools in `claude_args` so the agent can write the body file
> - Added explicit instruction to use `cat` via Bash tool (not the Read tool) to read data files, preventing token limit issues
> - Added instruction requiring the agent to read ALL rows from both JSONL files for complete coverage
> - Updated the stack trace truncation note in the prompt to reflect the new 1500-char limit
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> All changes are confined to the `.github/workflows/daily-error-report.yml` workflow file. The two-step issue creation approach (write body to file, then `--body-file`) is necessary because large markdown bodies exceed the shell argument size limit when passed inline to `gh issue create`.
>
> ---
> <sub>🤖 Generated by Claude | 2026-02-18 23:55 UTC</sub>