### PR TITLE
small fixes to logs command

### DIFF
--- a/src/cli/commands/project/logs.ts
+++ b/src/cli/commands/project/logs.ts
@@ -9,8 +9,10 @@ import type {
   FunctionLogsResponse,
   LogLevel,
 } from "@/core/resources/function/index.js";
-import { LogLevelSchema } from "@/core/resources/function/index.js";
-import { fetchFunctionLogs } from "@/core/resources/function/index.js";
+import {
+  fetchFunctionLogs,
+  LogLevelSchema,
+} from "@/core/resources/function/index.js";
 
 interface LogsOptions {
   function?: string;

--- a/src/core/resources/function/schema.ts
+++ b/src/core/resources/function/schema.ts
@@ -113,7 +113,7 @@ export type LogLevel = z.infer<typeof LogLevelSchema>;
 
 const FunctionLogEntrySchema = z.object({
   time: z.string(),
-  level: z.string(),
+  level: LogLevelSchema,
   message: z.string(),
 });
 

--- a/tests/cli/logs.spec.ts
+++ b/tests/cli/logs.spec.ts
@@ -46,7 +46,7 @@ describe("logs command", () => {
   it("fetches logs for all project functions when no --function specified", async () => {
     await t.givenLoggedInWithProject(fixture("full-project"));
     t.api.mockFunctionLogs("hello", [
-      { time: "2024-01-15T10:29:00Z", level: "log", message: "Hello world" },
+      { time: "2024-01-15T10:29:00Z", level: "info", message: "Hello world" },
     ]);
 
     const result = await t.run("logs");

--- a/tests/cli/testkit/Base44APIMock.ts
+++ b/tests/cli/testkit/Base44APIMock.ts
@@ -59,7 +59,7 @@ interface AgentsFetchResponse {
 
 interface FunctionLogEntry {
   time: string;
-  level: "log" | "info" | "warn" | "error" | "debug";
+  level: "info" | "warning" | "error" | "debug";
   message: string;
 }
 


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR fixes the `logs` command to align with the Deno Deploy runtime's log level values and adds a `--level` filter option. It removes the previously added `--json` flag and corrects the log level schema from `["log", "info", "warn", "error", "debug"]` to `["info", "warning", "error", "debug"]` to match what Deno actually emits.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Updated `LogLevelSchema` in `src/core/resources/function/schema.ts` to use Deno Deploy–compatible log levels (`info`, `warning`, `error`, `debug`), replacing the old `log`/`warn` values
> - Exported `LogLevelSchema` so it can be consumed by the CLI layer
> - Added `--level <level>` option to the `logs` command, with choices auto-derived from `LogLevelSchema` and passed through to `FunctionLogFilters`
> - Removed the `--json` flag from the `logs` command
> - Updated `FunctionLogEntry` type in `Base44APIMock` to use the corrected log level union
> - Updated and expanded tests: fixed existing test data (`"log"` → `"info"`), added tests for `--level` filtering, invalid level rejection, and `"warning"` level handling
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [x] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The `--level` option is hidden from help output (`.hideHelp()`) to keep the command surface minimal while still supporting level-based filtering for power users.
>
> ---
> <sub>🤖 Generated by Claude | 2026-02-23 14:51 UTC</sub>