### PR TITLE
fix(ci): run README check on push to main instead of PR events

### DIFF
--- a/.github/workflows/readme-check.yml
+++ b/.github/workflows/readme-check.yml
@@ -1,28 +1,24 @@
 name: README Check
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+  push:
+    branches: [main]
     paths:
       - "src/cli/commands/**"
       - "README.md"
   workflow_dispatch:
-    # Run from Actions tab to test: use a branch that has an open PR, or run on default to see check result in the job log only.
 
 jobs:
   readme-check:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
-      issues: read
       id-token: write
 
     steps:
-      - name: Checkout PR branch
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
           fetch-depth: 1
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -32,7 +28,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            You are checking whether README.md is still accurate after the changes in this PR.
+            You are checking whether README.md is still accurate after changes on main.
 
             GROUND TRUTH (read from the repo):
             1. Read src/cli/program.ts to get all registered commands. Note which are registered with { hidden: true } — those should NOT appear in the README command table.
@@ -46,13 +42,8 @@ jobs:
             - Installation section: Package name and Node version mentioned must match package.json.
             - Quick start: The example commands (e.g. base44 login, base44 create) must still exist as commands in the codebase.
 
-            PR number for this run (use this exact number in gh pr comment; if blank/empty, do not comment—print conclusion to the terminal only): ${{ github.event.pull_request.number }}
-
             RULES:
-            1. If everything matches do nothing further and exit.
-            2. If you find discrepancies: Update README.md with the correct content (use the Write tool). If the PR number line above has a number (i.e. this is a PR-triggered run), commit and push the fix: git config user.name "github-actions[bot]"; git config user.email "github-actions[bot]@users.noreply.github.com"; git add README.md; git commit -m "docs: update README to match CLI (command table, install, or quick start)"; git push. Then post one short comment with gh pr comment <that number> --body "..." summarizing what was fixed (e.g. "README check ran. N issue(s) found and applied: [brief list]. README.md has been updated in this branch."; escape the body for the shell). If the PR number is empty (manual/workflow_dispatch run), do NOT run git push. Instead, print the summary of discrepancies to the terminal so the user can review them.
-            3. The PR comment or terminal output must only state that the check ran and the conclusion. Do not paste full diffs or long suggestion lists.
-          claude_args: '--allowed-tools Read Glob Grep Write Edit "Bash(gh pr comment:*)" "Bash(git config *)" "Bash(git add *)" "Bash(git commit *)" "Bash(git push *)"'
-          allowed_bots: 'claude[bot]'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+            1. If everything matches, do nothing further and exit.
+            2. If you find discrepancies: Update README.md with the correct content, then commit and push the fix: git config user.name "github-actions[bot]"; git config user.email "github-actions[bot]@users.noreply.github.com"; git add README.md; git commit -m "docs: sync README with CLI commands"; git push.
+            3. Only modify README.md. Do not touch any other file.
+          claude_args: '--allowed-tools Read Glob Grep "Write(README.md)" "Edit(README.md)" "Bash(git config *)" "Bash(git add README.md)" "Bash(git commit *)" "Bash(git push *)"'


### PR DESCRIPTION
## Summary
The current README check workflow works well, but running it on PR events (`synchronize`, `opened`, etc.) causes a few friction points:

- It comments on the PR thread repeatedly — every push triggers another run, which spams the conversation with duplicate messages
- It runs multiple times while the PR is still in progress, before it's actually ready for review
- It pushes fix commits to the remote branch while I'm still working locally, so I have to rebase or re-pull to stay in sync

This PR switches the workflow to run **on push to main** instead, so the check only happens once — after the PR merges. If the README is out of date, Claude fixes it directly on main with a single commit.

### Changes
- Trigger on `push` to `main` (filtered to `src/cli/commands/**` and `README.md`) instead of `pull_request` events
- Add `github.actor != 'github-actions[bot]'` guard to prevent loops from bot-authored commits
- Scope allowed tools to `README.md` only (`Write(README.md)`, `Edit(README.md)`, `git add README.md`)
- Remove PR-related permissions and tools (`pull-requests: write`, `gh pr comment`, `allowed_bots`)

## Test plan
- [ ] Verify workflow runs on push to main when `src/cli/commands/**` or `README.md` changes
- [ ] Verify workflow skips when the pusher is `github-actions[bot]`
- [ ] Test via `workflow_dispatch` from the Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)