### PR TITLE
small fix to eject command when there are no options

### DIFF
--- a/src/cli/commands/project/eject.ts
+++ b/src/cli/commands/project/eject.ts
@@ -59,7 +59,10 @@ async function eject(options: EjectOptions): Promise<RunCommandResult> {
     selectedProject = foundProject;
     log.info(`Selected project: ${theme.styles.bold(selectedProject.name)}`);
   } else {
-    // Interactive: show project selection prompt
+    if (ejectableProjects.length === 0) {
+      return { outroMessage: "No projects available to eject." };
+    }
+
     const projectOptions: Option<Project>[] = ejectableProjects.map((p) => ({
       value: p,
       label: p.name,


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR fixes a bug in the `eject` command where, in interactive mode, the project selection prompt would be displayed even when there are no ejectable projects available. Now, if the list of ejectable projects is empty and no `--project-id` flag was provided, the command exits gracefully with a clear message instead of showing an empty prompt.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added an early-return guard in `eject.ts` for the interactive path: if `ejectableProjects` is empty, the command returns with `"No projects available to eject."` instead of proceeding to the selection prompt.
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The fix only applies to the interactive (non-`--project-id`) code path. The `--project-id` path already handles a missing project by throwing an `InvalidInputError` with a helpful hint, so no change is needed there.
>
> ---
> <sub>🤖 Generated by Claude | 2026-02-25 00:00 UTC</sub>