### PR TITLE
chore: hide secrets command from help output

### DIFF
--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -58,7 +58,7 @@ export function createProgram(context: CLIContext): Command {
   program.addCommand(getFunctionsDeployCommand(context));
 
   // Register secrets commands
-  program.addCommand(getSecretsCommand(context));
+  program.addCommand(getSecretsCommand(context), { hidden: true });
 
   // Register site commands
   program.addCommand(getSiteCommand(context));


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR hides the `secrets` command from the CLI help output by passing `{ hidden: true }` when registering it with Commander.js. The command remains fully functional and accessible — it simply no longer appears in `base44 --help` or `base44 help`. This is useful for commands not yet ready for general use or intended for internal/advanced use only.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [x] Other (please describe): Hide CLI command from help output without removing it
>
> ## Changes Made
>
> - In `src/cli/program.ts`, added `{ hidden: true }` option when registering the secrets command via `program.addCommand()`, so it no longer appears in the help output
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The secrets command is still registered and usable — only its visibility in the help menu is affected. This pattern is supported natively by Commander.js via the `addCommand` options argument.
>
> ---
> <sub>🤖 Generated by Claude | 2026-02-25 00:00 UTC</sub>