### PR TITLE
fix(ci): fix allowedTools parsing in changelog generation

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -134,7 +134,7 @@ jobs:
                - **Fixed** - bug fixes
                - **Removed** - removed features
 
-            4. If "Update changelog" above is "true" AND "Dry run" is "false", update CHANGELOG.md by inserting the new entry AFTER `## [Unreleased]`. Skip file writes during dry runs.
+            4. If "Update changelog" above is "true" AND "Dry run" is "false", update CHANGELOG.md by inserting the new entry AFTER `## [Unreleased]`. Do NOT edit CHANGELOG.md during dry runs.
 
             5. **Always** write a file called `release-summary.md` with a concise, media-sharable summary of user-facing changes. This is what gets shared in Slack/social — keep it tight.
 


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR fixes and enhances the changelog generation step in the manual publish workflow. The `--allowedTools` argument was not being parsed correctly, so the step is fixed with properly quoted patterns. Additionally, the step is extended to always generate a `release-summary.md` file containing a concise, media-shareable summary of user-facing changes (for Slack/social sharing), while preserving the existing behavior of only writing to `CHANGELOG.md` during non-dry-run releases when explicitly enabled.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Fixed `--allowedTools` argument quoting in `claude_args` so tool patterns are parsed correctly by the Claude Code action
> - Renamed the step from "Generate Changelog" to "Generate Changelog & Release Summary" to reflect expanded scope
> - Changed the step condition to always run when a previous tag exists (removed the `update_changelog == 'true' && dry_run == 'false'` gate from the step itself)
> - Passed `update_changelog` and `dry_run` flags into the Claude prompt so the model can conditionally skip editing `CHANGELOG.md` on dry runs
> - Added instruction for Claude to always produce a `release-summary.md` file in a structured, emoji-rich format suitable for Slack/social media sharing
> - Added a new "Release summary" step that cats `release-summary.md` to the GitHub Actions job summary when the file exists
> - Added `Write(release-summary.md)` and updated `Read` (without path restriction) to the allowed tools list
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The `release-summary.md` format includes two variants: a detailed format for releases with notable features (grouped under New and Fixes sections), and a compact format for internal-only or bug-fix-only releases. The file is written to the workspace and appended to the GitHub Actions step summary for easy visibility after a publish run.
>
> ---
> <sub>Generated by Claude | 2026-02-25 00:00 UTC</sub>