### PR TITLE
fix(ci): update model to claude-haiku-4-5

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -179,7 +179,7 @@ jobs:
             🔧 Bug fixes and internal improvements
             ```
           claude_args: |
-            --model claude-3-5-haiku-latest
+            --model claude-haiku-4-5
             --allowedTools "Bash(git log:*),Bash(gh pr:*),Read,Edit(CHANGELOG.md),Write(release-summary.md)"
 
       - name: Build package


### PR DESCRIPTION
## Summary
- `claude-3-5-haiku-latest` is not a valid model ID — it was the root cause of the Claude Code crash (exit code 1, 0 cost, ~400ms) in the changelog generation step
- Updated to `claude-haiku-4-5` per [Anthropic docs](https://docs.anthropic.com/en/docs/about-claude/models/overview)

## Test plan
- [ ] Trigger manual publish with `update_changelog: true` and `dry_run: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)