### PR TITLE
fix(ci): update model to claude-haiku-4-5

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -179,7 +179,7 @@ jobs:
             🔧 Bug fixes and internal improvements
             ```
           claude_args: |
-            --model claude-3-5-haiku-latest
+            --model claude-haiku-4-5
             --allowedTools "Bash(git log:*),Bash(gh pr:*),Read,Edit(CHANGELOG.md),Write(release-summary.md)"
 
       - name: Build package


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR fixes a CI failure in the manual publish workflow by updating the Claude model ID used for changelog generation. The model identifier `claude-3-5-haiku-latest` was invalid, causing the Claude Code step to crash (exit code 1, ~0 cost, ~400ms runtime). It is replaced with the correct model ID `claude-haiku-4-5` per current Anthropic documentation.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [x] Other (please describe): CI configuration fix — corrects an invalid model ID in a GitHub Actions workflow
>
> ## Changes Made
>
> - Updated `--model` argument in `.github/workflows/manual-publish.yml` from `claude-3-5-haiku-latest` to `claude-haiku-4-5` in the changelog generation step
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The fix aligns the workflow with the current Anthropic model naming convention. The previous identifier (`claude-3-5-haiku-latest`) is no longer valid; `claude-haiku-4-5` is the correct model ID as of the current Anthropic model catalog. To verify the fix, trigger a manual publish run with `update_changelog: true` and `dry_run: true`.
>
> ---
> <sub>Generated by Claude | 2026-02-25 00:00 UTC</sub>