### PR TITLE
feature: introduce global --json flag

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "base44",

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,6 +1,6 @@
 # Adding & Modifying CLI Commands
 
-**Keywords:** command, factory pattern, CLIContext, isNonInteractive, runCommand, runTask, spinner, theming, chalk, program.ts, register, banner, intro, outro
+**Keywords:** command, factory pattern, CLIContext, isNonInteractive, isJsonMode, runCommand, runTask, spinner, theming, chalk, program.ts, register, banner, intro, outro, json, --json, data, piping
 
 Commands live in `src/cli/commands/<domain>/`. They use a **factory pattern** with dependency injection via `CLIContext`.
 
@@ -72,6 +72,7 @@ await runCommand(myAction, { fullBanner: true, requireAuth: true }, context);
 - `fullBanner` - Show ASCII art banner instead of simple tag (for special commands like `create`)
 - `requireAuth` - Check authentication before running, auto-triggers login if needed
 - `requireAppConfig` - Load `.app.jsonc` and cache for sync access (default: `true`)
+- `interactive` - Mark command as requiring interactive prompts; throws if `--json` is used
 
 ## CLIContext (Dependency Injection)
 
@@ -79,11 +80,13 @@ await runCommand(myAction, { fullBanner: true, requireAuth: true }, context);
 export interface CLIContext {
   errorReporter: ErrorReporter;
   isNonInteractive: boolean;
+  isJsonMode: boolean;
 }
 ```
 
 - Created once in `runCLI()` at startup
 - `isNonInteractive` is `true` when stdin/stdout are not a TTY (e.g., CI, piped output, AI agents). Use it to skip interactive prompts, browser opens, and animations.
+- `isJsonMode` is set by the global `--json` flag via a `preAction` hook. Commands don't need to check it directly -- `runCommand` handles all mode-switching.
 - Passed to `createProgram(context)`, which passes it to each command factory
 - Commands pass it to `runCommand()` for error reporting integration
 
@@ -194,6 +197,59 @@ export function getMyCommand(context: CLIContext): Command {
 ```
 
 Access `command.args` for positional arguments and `command.opts()` for options inside the hook. See `secrets/set.ts` and `project/create.ts` for real examples.
+
+## JSON Mode (`--json`)
+
+The CLI supports a global `--json` flag that outputs structured JSON instead of human-readable text. This enables piping output to tools like `jq`:
+
+```bash
+base44 logs --function my-fn --json | jq '.logs[] | .message'
+```
+
+### How it works
+
+When `--json` is set, `runCommand` mutes `process.stdout.write` before calling `commandFn()`. This silences all clack output (intro, outro, `log.*`, spinners) automatically. Only the serialized `result.data` is written to stdout. Errors are written to stderr as JSON.
+
+### Adding JSON support to a command
+
+Return a `data` field from your action. Always use a top-level object (wrap arrays):
+
+```typescript
+async function listAction(): Promise<RunCommandResult> {
+  const items = await fetchItems();
+
+  return {
+    outroMessage: `Found ${items.length} items`,
+    stdout: formatItems(items),       // human mode
+    data: { items },                  // json mode: { "items": [...] }
+  };
+}
+```
+
+- `data` is `Record<string, unknown>` -- always an object, never a raw array
+- If `data` is not set, `runCommand` falls back to `{ "message": outroMessage }`
+- Commands need zero changes to be silenced -- the stdout muting handles `log.*` and spinners
+
+### Error format
+
+On error in JSON mode, a JSON object is written to stderr:
+
+```json
+{
+  "error": true,
+  "code": "API_ERROR",
+  "message": "Request failed with status 500",
+  "hints": [{ "message": "Check your network connection" }]
+}
+```
+
+### Interactive commands
+
+Commands that use interactive prompts (`select`, `confirm`, `text`) must set `interactive: true` in their `runCommand` options. This causes an immediate error if `--json` is used:
+
+```typescript
+await runCommand(myAction, { requireAuth: true, interactive: true }, context);
+```
 
 ## Rules (Command-Specific)
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -72,7 +72,6 @@ await runCommand(myAction, { fullBanner: true, requireAuth: true }, context);
 - `fullBanner` - Show ASCII art banner instead of simple tag (for special commands like `create`)
 - `requireAuth` - Check authentication before running, auto-triggers login if needed
 - `requireAppConfig` - Load `.app.jsonc` and cache for sync access (default: `true`)
-- `interactive` - Mark command as requiring interactive prompts; throws if `--json` is used
 
 ## CLIContext (Dependency Injection)
 
@@ -245,11 +244,25 @@ On error in JSON mode, a JSON object is written to stderr:
 
 ### Interactive commands
 
-Commands that use interactive prompts (`select`, `confirm`, `text`) must set `interactive: true` in their `runCommand` options. This causes an immediate error if `--json` is used:
+Commands with interactive prompts (`select`, `confirm`, `text`) should validate required flags in a `preAction` hook. This fires before `runCommand` (no wasted auth/API calls) and works for both `--json` and piped/CI sessions:
 
 ```typescript
-await runCommand(myAction, { requireAuth: true, interactive: true }, context);
+export function getMyCommand(context: CLIContext): Command {
+  return new Command("my-cmd")
+    .option("-y, --yes", "Skip confirmation prompt")
+    .hook("preAction", (command) => {
+      if (!context.isJsonMode && !context.isNonInteractive) return;
+      if (!command.opts().yes) {
+        command.error("Non-interactive mode requires: --yes");
+      }
+    })
+    .action(async (options) => {
+      await runCommand(() => myAction(options), { requireAuth: true }, context);
+    });
+}
 ```
+
+List specific missing flags so users know exactly what to add (e.g., `Missing: --project-id <id>, --path <path>`).
 
 ## Rules (Command-Specific)
 

--- a/src/cli/commands/project/create.ts
+++ b/src/cli/commands/project/create.ts
@@ -304,7 +304,12 @@ export function getCreateCommand(context: CLIContext): Command {
       } else {
         await runCommand(
           () => createInteractive({ name, ...options }),
-          { fullBanner: true, requireAuth: true, requireAppConfig: false },
+          {
+            fullBanner: true,
+            requireAuth: true,
+            requireAppConfig: false,
+            interactive: true,
+          },
           context,
         );
       }

--- a/src/cli/commands/project/create.ts
+++ b/src/cli/commands/project/create.ts
@@ -45,12 +45,23 @@ async function getTemplateById(templateId: string): Promise<Template> {
   return template;
 }
 
-function validateNonInteractiveFlags(command: Command): void {
-  const { path } = command.opts<CreateOptions>();
+function validateFlags(context: CLIContext) {
+  return (command: Command): void => {
+    const opts = command.opts<CreateOptions>();
+    const name = command.args[0];
 
-  if (path && !command.args.length) {
-    command.error("Non-interactive mode requires all flags: --name, --path");
-  }
+    if (opts.path && !(opts.name ?? name)) {
+      command.error("Non-interactive mode requires all flags: --name, --path");
+    }
+
+    if (context.isJsonMode || context.isNonInteractive) {
+      if (!(opts.name ?? name) || !opts.path) {
+        command.error(
+          "Non-interactive mode requires: <name> and --path <path>",
+        );
+      }
+    }
+  };
 }
 
 async function createInteractive(
@@ -290,7 +301,7 @@ export function getCreateCommand(context: CLIContext): Command {
     )
     .option("--deploy", "Build and deploy the site")
     .option("--no-skills", "Skip AI agent skills installation")
-    .hook("preAction", validateNonInteractiveFlags)
+    .hook("preAction", validateFlags(context))
     .action(async (name: string | undefined, options: CreateOptions) => {
       const isNonInteractive = !!(options.name ?? name) && !!options.path;
 
@@ -308,7 +319,6 @@ export function getCreateCommand(context: CLIContext): Command {
             fullBanner: true,
             requireAuth: true,
             requireAppConfig: false,
-            interactive: true,
           },
           context,
         );

--- a/src/cli/commands/project/deploy.ts
+++ b/src/cli/commands/project/deploy.ts
@@ -120,12 +120,22 @@ export async function deployAction(
   return { outroMessage: "App deployed successfully" };
 }
 
+function validateNonInteractiveMode(context: CLIContext) {
+  return (command: Command): void => {
+    if (!context.isJsonMode && !context.isNonInteractive) return;
+    if (!command.opts<DeployOptions>().yes) {
+      command.error("Non-interactive mode requires: --yes");
+    }
+  };
+}
+
 export function getDeployCommand(context: CLIContext): Command {
   return new Command("deploy")
     .description(
       "Deploy all project resources (entities, functions, agents, connectors, and site)",
     )
     .option("-y, --yes", "Skip confirmation prompt")
+    .hook("preAction", validateNonInteractiveMode(context))
     .action(async (options: DeployOptions) => {
       await runCommand(
         () =>

--- a/src/cli/commands/project/eject.ts
+++ b/src/cli/commands/project/eject.ts
@@ -169,6 +169,19 @@ async function eject(options: EjectOptions): Promise<RunCommandResult> {
   return { outroMessage: "Your new project is set and ready to use" };
 }
 
+function validateNonInteractiveMode(context: CLIContext) {
+  return (command: Command): void => {
+    if (!context.isJsonMode && !context.isNonInteractive) return;
+    const opts = command.opts<EjectOptions>();
+    const missing: string[] = [];
+    if (!opts.projectId) missing.push("--project-id <id>");
+    if (!opts.path) missing.push("--path <path>");
+    if (missing.length > 0) {
+      command.error(`Non-interactive mode requires: ${missing.join(", ")}`);
+    }
+  };
+}
+
 export function getEjectCommand(context: CLIContext): Command {
   return new Command("eject")
     .description("Download the code for an existing Base44 project")
@@ -178,10 +191,11 @@ export function getEjectCommand(context: CLIContext): Command {
       "Project ID to eject (skips interactive selection)",
     )
     .option("-y, --yes", "Skip confirmation prompts")
+    .hook("preAction", validateNonInteractiveMode(context))
     .action(async (options: EjectOptions) => {
       await runCommand(
         () => eject({ ...options, isNonInteractive: context.isNonInteractive }),
-        { requireAuth: true, requireAppConfig: false, interactive: true },
+        { requireAuth: true, requireAppConfig: false },
         context,
       );
     });

--- a/src/cli/commands/project/eject.ts
+++ b/src/cli/commands/project/eject.ts
@@ -181,7 +181,7 @@ export function getEjectCommand(context: CLIContext): Command {
     .action(async (options: EjectOptions) => {
       await runCommand(
         () => eject({ ...options, isNonInteractive: context.isNonInteractive }),
-        { requireAuth: true, requireAppConfig: false },
+        { requireAuth: true, requireAppConfig: false, interactive: true },
         context,
       );
     });

--- a/src/cli/commands/project/link.ts
+++ b/src/cli/commands/project/link.ts
@@ -35,16 +35,26 @@ interface LinkOptions {
 
 type LinkAction = "create" | "choose";
 
-function validateNonInteractiveFlags(command: Command): void {
-  const { create, name, projectId } = command.opts<LinkOptions>();
+function validateFlags(context: CLIContext) {
+  return (command: Command): void => {
+    const { create, name, projectId } = command.opts<LinkOptions>();
 
-  if (create && projectId) {
-    command.error("--create and --projectId cannot be used together");
-  }
+    if (create && projectId) {
+      command.error("--create and --projectId cannot be used together");
+    }
 
-  if (create && !name) {
-    command.error("--name is required when using --create");
-  }
+    if (create && !name) {
+      command.error("--name is required when using --create");
+    }
+
+    if (context.isJsonMode || context.isNonInteractive) {
+      if (!projectId && !create) {
+        command.error(
+          "Non-interactive mode requires --projectId <id> or --create --name <name>",
+        );
+      }
+    }
+  };
 }
 
 async function promptForLinkAction(): Promise<LinkAction> {
@@ -260,11 +270,11 @@ export function getLinkCommand(context: CLIContext): Command {
       "-p, --projectId <id>",
       "Project ID to link to an existing project (skips selection prompt)",
     )
-    .hook("preAction", validateNonInteractiveFlags)
+    .hook("preAction", validateFlags(context))
     .action(async (options: LinkOptions) => {
       await runCommand(
         () => link(options),
-        { requireAuth: true, requireAppConfig: false, interactive: true },
+        { requireAuth: true, requireAppConfig: false },
         context,
       );
     });

--- a/src/cli/commands/project/link.ts
+++ b/src/cli/commands/project/link.ts
@@ -264,7 +264,7 @@ export function getLinkCommand(context: CLIContext): Command {
     .action(async (options: LinkOptions) => {
       await runCommand(
         () => link(options),
-        { requireAuth: true, requireAppConfig: false },
+        { requireAuth: true, requireAppConfig: false, interactive: true },
         context,
       );
     });

--- a/src/cli/commands/project/logs.ts
+++ b/src/cli/commands/project/logs.ts
@@ -21,7 +21,6 @@ interface LogsOptions {
   level?: string;
   limit?: string;
   order?: string;
-  json?: boolean;
 }
 
 /**
@@ -187,11 +186,11 @@ async function logsAction(options: LogsOptions): Promise<RunCommandResult> {
     entries = entries.slice(0, limit);
   }
 
-  const logsOutput = options.json
-    ? `${JSON.stringify(entries, null, 2)}\n`
-    : formatLogs(entries);
-
-  return { outroMessage: "Fetched logs", stdout: logsOutput };
+  return {
+    outroMessage: "Fetched logs",
+    stdout: formatLogs(entries),
+    data: { logs: entries },
+  };
 }
 
 export function getLogsCommand(context: CLIContext): Command {

--- a/src/cli/commands/site/deploy.ts
+++ b/src/cli/commands/site/deploy.ts
@@ -53,10 +53,20 @@ async function deployAction(options: DeployOptions): Promise<RunCommandResult> {
   return { outroMessage: `Visit your site at: ${result.appUrl}` };
 }
 
+function validateNonInteractiveMode(context: CLIContext) {
+  return (command: Command): void => {
+    if (!context.isJsonMode && !context.isNonInteractive) return;
+    if (!command.opts<DeployOptions>().yes) {
+      command.error("Non-interactive mode requires: --yes");
+    }
+  };
+}
+
 export function getSiteDeployCommand(context: CLIContext): Command {
   return new Command("deploy")
     .description("Deploy built site files to Base44 hosting")
     .option("-y, --yes", "Skip confirmation prompt")
+    .hook("preAction", validateNonInteractiveMode(context))
     .action(async (options: DeployOptions) => {
       await runCommand(
         () =>
@@ -64,7 +74,7 @@ export function getSiteDeployCommand(context: CLIContext): Command {
             ...options,
             isNonInteractive: context.isNonInteractive,
           }),
-        { requireAuth: true, interactive: !options.yes },
+        { requireAuth: true },
         context,
       );
     });

--- a/src/cli/commands/site/deploy.ts
+++ b/src/cli/commands/site/deploy.ts
@@ -64,7 +64,7 @@ export function getSiteDeployCommand(context: CLIContext): Command {
             ...options,
             isNonInteractive: context.isNonInteractive,
           }),
-        { requireAuth: true },
+        { requireAuth: true, interactive: !options.yes },
         context,
       );
     });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,7 +14,11 @@ async function runCLI(): Promise<void> {
 
   // Create context for dependency injection
   const isNonInteractive = !process.stdin.isTTY || !process.stdout.isTTY;
-  const context: CLIContext = { errorReporter, isNonInteractive };
+  const context: CLIContext = {
+    errorReporter,
+    isNonInteractive,
+    isJsonMode: false,
+  };
 
   // Create program with injected context
   const program = createProgram(context);

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -29,6 +29,17 @@ export function createProgram(context: CLIContext): Command {
     )
     .version(packageJson.version);
 
+  program.option(
+    "--json",
+    "Output results as JSON instead of human-readable text",
+  );
+
+  program.hook("preAction", (thisCommand) => {
+    if (thisCommand.opts().json) {
+      context.isJsonMode = true;
+    }
+  });
+
   program.configureHelp({
     sortSubcommands: true,
   });

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -3,4 +3,5 @@ import type { ErrorReporter } from "./telemetry/error-reporter.js";
 export interface CLIContext {
   errorReporter: ErrorReporter;
   isNonInteractive: boolean;
+  isJsonMode: boolean;
 }

--- a/src/cli/utils/runCommand.ts
+++ b/src/cli/utils/runCommand.ts
@@ -5,7 +5,11 @@ import { printBanner } from "@/cli/utils/banner.js";
 import { theme } from "@/cli/utils/theme.js";
 import { printUpgradeNotificationIfAvailable } from "@/cli/utils/upgradeNotification.js";
 import { isLoggedIn, readAuth } from "@/core/auth/index.js";
-import { isCLIError } from "@/core/errors.js";
+import {
+  AuthRequiredError,
+  InvalidInputError,
+  isCLIError,
+} from "@/core/errors.js";
 import { initAppConfig } from "@/core/project/index.js";
 
 interface RunCommandOptions {
@@ -27,6 +31,12 @@ interface RunCommandOptions {
    * @default true
    */
   requireAppConfig?: boolean;
+  /**
+   * Mark this command as requiring interactive prompts (select, confirm, text).
+   * When set, the command will throw if --json is used.
+   * @default false
+   */
+  interactive?: boolean;
 }
 
 export interface RunCommandResult {
@@ -36,11 +46,24 @@ export interface RunCommandResult {
    * Useful for commands that produce machine-readable or pipeable output.
    */
   stdout?: string;
+  /**
+   * Structured data for --json output. Serialized by runCommand when
+   * isJsonMode is true. Always a top-level object (wrap arrays:
+   * `{ logs: [...] }` not `[...]`).
+   *
+   * When --json is set but data is not provided, runCommand falls back to
+   * `{ "message": outroMessage }`.
+   */
+  data?: Record<string, unknown>;
 }
 
 /**
  * Wraps a command function with the Base44 intro/outro and error handling.
  * All CLI commands should use this utility to ensure consistent branding.
+ *
+ * In JSON mode (--json flag), stdout is muted so all clack output (intro,
+ * outro, log.*, spinners) is silenced automatically. Only the serialized
+ * `result.data` is written to stdout. Errors are written to stderr as JSON.
  *
  * **Important**: Commands should NOT call `intro()` or `outro()` directly.
  * This function handles both. Commands can return an optional `outroMessage`
@@ -49,41 +72,43 @@ export interface RunCommandResult {
  * @param commandFn - The async function to execute. Returns `RunCommandResult` with optional `outroMessage`.
  * @param options - Optional configuration for the command wrapper
  * @param context - CLI context with dependencies (errorReporter, etc.)
- *
- * @example
- * export function getMyCommand(context: CLIContext): Command {
- *   return new Command("my-command")
- *     .action(async () => {
- *       await runCommand(
- *         async () => {
- *           // ... do work ...
- *           return { outroMessage: "Done!" };
- *         },
- *         { requireAuth: true },
- *         context
- *       );
- *     });
- * }
  */
 export async function runCommand(
   commandFn: () => Promise<RunCommandResult>,
   options: RunCommandOptions | undefined,
   context: CLIContext,
 ): Promise<void> {
-  if (options?.fullBanner) {
-    await printBanner(context.isNonInteractive);
-    intro("");
-  } else {
-    intro(theme.colors.base44OrangeBackground(" Base 44 "));
-  }
-  await printUpgradeNotificationIfAvailable();
+  const json = context.isJsonMode;
+  let savedStdoutWrite: typeof process.stdout.write | undefined;
 
   try {
-    // Check authentication if required
+    if (json) {
+      if (options?.interactive) {
+        throw new InvalidInputError(
+          "This command requires interactive input and cannot be used with --json",
+        );
+      }
+      savedStdoutWrite = process.stdout.write.bind(process.stdout);
+      process.stdout.write = (() => true) as typeof process.stdout.write;
+    }
+
+    if (options?.fullBanner) {
+      await printBanner(context.isNonInteractive);
+      intro("");
+    } else {
+      intro(theme.colors.base44OrangeBackground(" Base 44 "));
+    }
+    await printUpgradeNotificationIfAvailable();
+
     if (options?.requireAuth) {
       const loggedIn = await isLoggedIn();
 
       if (!loggedIn) {
+        if (json) {
+          throw new AuthRequiredError(
+            "Authentication required. Run: base44 login",
+          );
+        }
         log.info("You need to login first to continue.");
         await login();
       }
@@ -98,41 +123,63 @@ export async function runCommand(
       }
     }
 
-    // Initialize app config unless explicitly disabled
     if (options?.requireAppConfig !== false) {
       const appConfig = await initAppConfig();
       context.errorReporter.setContext({ appId: appConfig.id });
     }
 
     const result = await commandFn();
-    outro(result.outroMessage || "");
 
-    if (result.stdout) {
-      process.stdout.write(result.stdout);
-    }
-  } catch (error) {
-    // Display error message
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    log.error(errorMessage);
-
-    // Show stack trace if DEBUG mode
-    if (process.env.DEBUG === "1" && error instanceof Error && error.stack) {
-      log.error(theme.styles.dim(error.stack));
-    }
-
-    // Display hints if this is a CLIError with hints
-    if (isCLIError(error)) {
-      const hints = theme.format.agentHints(error.hints);
-      if (hints) {
-        log.error(hints);
+    if (json) {
+      const output = result.data ?? {
+        message: result.outroMessage ?? "Done",
+      };
+      savedStdoutWrite!(`${JSON.stringify(output, null, 2)}\n`);
+    } else {
+      outro(result.outroMessage || "");
+      if (result.stdout) {
+        process.stdout.write(result.stdout);
       }
     }
+  } catch (error) {
+    if (json) {
+      const errorContext = context.errorReporter.getErrorContext();
+      const jsonError: Record<string, unknown> = {
+        error: true,
+        message: error instanceof Error ? error.message : String(error),
+        context: errorContext,
+      };
+      if (isCLIError(error)) {
+        jsonError.code = error.code;
+        if (error.hints.length > 0) {
+          jsonError.hints = error.hints;
+        }
+      }
+      process.stderr.write(`${JSON.stringify(jsonError, null, 2)}\n`);
+    } else {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      log.error(errorMessage);
 
-    // Get error context and display in outro
-    const errorContext = context.errorReporter.getErrorContext();
-    outro(theme.format.errorContext(errorContext));
+      if (process.env.DEBUG === "1" && error instanceof Error && error.stack) {
+        log.error(theme.styles.dim(error.stack));
+      }
 
-    // Re-throw for runCLI to handle (error reporting, exit code)
+      if (isCLIError(error)) {
+        const hints = theme.format.agentHints(error.hints);
+        if (hints) {
+          log.error(hints);
+        }
+      }
+
+      const errorContext = context.errorReporter.getErrorContext();
+      outro(theme.format.errorContext(errorContext));
+    }
+
     throw error;
+  } finally {
+    if (savedStdoutWrite) {
+      process.stdout.write = savedStdoutWrite;
+    }
   }
 }

--- a/src/cli/utils/runCommand.ts
+++ b/src/cli/utils/runCommand.ts
@@ -5,11 +5,7 @@ import { printBanner } from "@/cli/utils/banner.js";
 import { theme } from "@/cli/utils/theme.js";
 import { printUpgradeNotificationIfAvailable } from "@/cli/utils/upgradeNotification.js";
 import { isLoggedIn, readAuth } from "@/core/auth/index.js";
-import {
-  AuthRequiredError,
-  InvalidInputError,
-  isCLIError,
-} from "@/core/errors.js";
+import { AuthRequiredError, isCLIError } from "@/core/errors.js";
 import { initAppConfig } from "@/core/project/index.js";
 
 interface RunCommandOptions {
@@ -31,12 +27,6 @@ interface RunCommandOptions {
    * @default true
    */
   requireAppConfig?: boolean;
-  /**
-   * Mark this command as requiring interactive prompts (select, confirm, text).
-   * When set, the command will throw if --json is used.
-   * @default false
-   */
-  interactive?: boolean;
 }
 
 export interface RunCommandResult {
@@ -83,11 +73,6 @@ export async function runCommand(
 
   try {
     if (json) {
-      if (options?.interactive) {
-        throw new InvalidInputError(
-          "This command requires interactive input and cannot be used with --json",
-        );
-      }
       savedStdoutWrite = process.stdout.write.bind(process.stdout);
       process.stdout.write = (() => true) as typeof process.stdout.write;
     }

--- a/tests/cli/logs.spec.ts
+++ b/tests/cli/logs.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { fixture, setupCLITests } from "./testkit/index.js";
 
 describe("logs command", () => {
@@ -182,5 +182,70 @@ describe("logs command", () => {
     );
 
     t.expectResult(result).toSucceed();
+  });
+
+  describe("--json mode", () => {
+    it("outputs structured JSON with logs wrapped in an object", async () => {
+      await t.givenLoggedInWithProject(fixture("basic"));
+      t.api.mockFunctionLogs("my-function", [
+        {
+          time: "2024-01-15T10:30:00.000Z",
+          level: "info",
+          message: "Test log",
+        },
+      ]);
+
+      const result = await t.run("logs", "--function", "my-function", "--json");
+
+      t.expectResult(result).toSucceed();
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed).toHaveProperty("logs");
+      expect(parsed.logs).toHaveLength(1);
+      expect(parsed.logs[0]).toMatchObject({
+        time: "2024-01-15T10:30:00.000Z",
+        level: "info",
+        source: "my-function",
+      });
+    });
+
+    it("outputs empty logs array when no logs found", async () => {
+      await t.givenLoggedInWithProject(fixture("basic"));
+      t.api.mockFunctionLogs("my-function", []);
+
+      const result = await t.run("logs", "--function", "my-function", "--json");
+
+      t.expectResult(result).toSucceed();
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.logs).toEqual([]);
+    });
+
+    it("suppresses clack UI output in JSON mode", async () => {
+      await t.givenLoggedInWithProject(fixture("basic"));
+      t.api.mockFunctionLogs("my-function", [
+        {
+          time: "2024-01-15T10:30:00.000Z",
+          level: "info",
+          message: "Test",
+        },
+      ]);
+
+      const result = await t.run("logs", "--function", "my-function", "--json");
+
+      t.expectResult(result).toSucceed();
+      expect(result.stdout).not.toContain("Base 44");
+      expect(result.stdout).not.toContain("Fetched logs");
+    });
+
+    it("falls back to message object when command has no data", async () => {
+      await t.givenLoggedInWithProject(fixture("basic"));
+
+      const result = await t.run("logs", "--json");
+
+      t.expectResult(result).toSucceed();
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed).toEqual({
+        message: "No functions found in this project.",
+      });
+    });
   });
 });

--- a/tests/cli/testkit/CLITestkit.ts
+++ b/tests/cli/testkit/CLITestkit.ts
@@ -18,6 +18,7 @@ interface CLIContext {
     getErrorContext: () => { sessionId?: string; appId?: string };
   };
   isNonInteractive: boolean;
+  isJsonMode: boolean;
 }
 
 /** Type for the bundled program module */
@@ -140,6 +141,7 @@ export class CLITestkit {
         getErrorContext: () => ({ sessionId: "test-session" }),
       },
       isNonInteractive: true,
+      isJsonMode: false,
     };
     const program = createProgram(mockContext);
 


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR introduces a global `--json` flag that switches the CLI from human-readable output to structured JSON, enabling commands to be piped into tools like `jq`. When active, `runCommand` mutes all clack UI output (intro, outro, spinners, `log.*`) by patching `process.stdout.write`, and writes only the serialized `result.data` object to stdout. Errors are emitted to stderr as structured JSON objects.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added `isJsonMode` field to `CLIContext` and initialize it to `false` in `runCLI()`
> - Registered a global `--json` option and `preAction` hook in `program.ts` that sets `context.isJsonMode = true`
> - Refactored `runCommand` to mute `process.stdout.write` in JSON mode, output `result.data` (or `{ message: outroMessage }` fallback) to stdout, and emit structured error objects to stderr
> - Added `data?: Record<string, unknown>` field to `RunCommandResult` for commands to return structured output
> - Migrated `logs` command from its own `--json` option to the global flag, returning `{ logs: entries }` as `data`
> - Added `preAction` validation hooks to `create`, `link`, `deploy`, `eject`, and `site/deploy` commands so they fail fast with clear error messages in JSON/non-interactive mode when required flags are missing
> - Added JSON mode test cases for the `logs` command covering structured output, empty results, UI suppression, and the fallback message format
> - Updated `docs/commands.md` with a comprehensive JSON mode guide including usage examples, error format, and patterns for interactive commands
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [x] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The stdout-muting approach means existing commands get JSON-mode silence for free — no per-command changes needed. Only commands that return machine-readable output need to add a `data` field. The `preAction` validation pattern ensures auth and API calls are never wasted when required flags are absent in non-interactive or JSON sessions.
>
> ---
> <sub>🤖 Generated by Claude | 2026-02-25 15:30 UTC</sub>