### PR TITLE
fix(ci): use Claude CLI for README check + add broken link detection

### DIFF
--- a/.github/scripts/fix-broken-links.ts
+++ b/.github/scripts/fix-broken-links.ts
@@ -13,6 +13,7 @@ interface LycheeResults {
 /**
  * Reads lychee JSON results and strips broken link markup from a markdown file.
  * [text](broken-url) → text
+ * Skips image links ![alt](url).
  */
 export function fixBrokenLinks(
   lycheeResultsPath: string,
@@ -31,7 +32,7 @@ export function fixBrokenLinks(
   for (const url of brokenUrls) {
     const escaped = url.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     content = content.replace(
-      new RegExp(`\\[([^\\]]*)\\]\\(${escaped}\\)`, "g"),
+      new RegExp(`(?<!!)\\[([^\\]]*)\\]\\(${escaped}\\)`, "g"),
       "$1",
     );
   }
@@ -60,18 +61,16 @@ export function parseBrokenUrls(lycheeResultsPath: string): Set<string> {
     for (const links of Object.values(results.error_map || {})) {
       for (const link of links) brokenUrls.add(link.url);
     }
-  } catch {}
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") {
+      console.warn(`Warning: could not parse lychee results: ${err}`);
+    }
+  }
   return brokenUrls;
 }
 
-// Run as CLI script
-const isMainModule =
-  typeof process !== "undefined" &&
-  process.argv[1] &&
-  (process.argv[1].endsWith("fix-broken-links.js") ||
-    process.argv[1].endsWith("fix-broken-links.ts"));
-
-if (isMainModule) {
+if (import.meta.main) {
   const lycheeResults = process.argv[2] || ".lychee-results.json";
   const markdownFile = process.argv[3] || "README.md";
   fixBrokenLinks(lycheeResults, markdownFile);

--- a/.github/workflows/readme-check.yml
+++ b/.github/workflows/readme-check.yml
@@ -8,6 +8,10 @@ on:
       - "README.md"
   workflow_dispatch:
 
+concurrency:
+  group: readme-check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   readme-check:
     if: github.actor != 'github-actions[bot]'
@@ -57,7 +61,10 @@ jobs:
           2. If you find discrepancies: Update README.md with the correct content, then commit and push the fix: git config user.name "github-actions[bot]"; git config user.email "github-actions[bot]@users.noreply.github.com"; git add README.md; git commit -m "docs: sync README with CLI commands"; git push.
           3. Only modify README.md. Do not touch any other file.
           EOF
-          )" --allowedTools "Read,Glob,Grep,Write(README.md),Edit(README.md),Bash(git config *),Bash(git add README.md),Bash(git commit *),Bash(git push *)"
+          )" --allowedTools "Read,Glob,Grep,Write(README.md),Edit(README.md),Bash(git config *),Bash(git add README.md),Bash(git commit -m *),Bash(git push origin *)"
+
+      - name: Pull latest changes
+        run: git pull --rebase
 
       - name: Restore lychee cache
         uses: actions/cache@v4

--- a/tests/scripts/fix-broken-links.spec.ts
+++ b/tests/scripts/fix-broken-links.spec.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   fixBrokenLinks,
   parseBrokenUrls,
@@ -78,6 +78,21 @@ describe("parseBrokenUrls", () => {
     const { lycheeResultsPath } = createTempFiles({}, "");
     const urls = parseBrokenUrls(lycheeResultsPath);
     expect(urls).toEqual(new Set());
+  });
+
+  it("returns empty set and warns on malformed JSON", () => {
+    const dir = mkdtempSync(join(tmpdir(), "fix-broken-links-"));
+    const path = join(dir, "bad.json");
+    writeFileSync(path, "not valid json{{{");
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const urls = parseBrokenUrls(path);
+
+    expect(urls).toEqual(new Set());
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("could not parse lychee results"),
+    );
+    warn.mockRestore();
   });
 });
 
@@ -188,6 +203,44 @@ describe("fixBrokenLinks", () => {
 
     expect(changed).toBe(true);
     expect(readFileSync(markdownPath, "utf8")).toBe("See docs here.");
+  });
+
+  it("skips image links", () => {
+    const { lycheeResultsPath, markdownPath } = createTempFiles(
+      {
+        fail_map: {
+          "README.md": [
+            { url: "https://broken.com/logo.png", status: { code: 404 } },
+          ],
+        },
+      },
+      "Logo: ![alt text](https://broken.com/logo.png) here.",
+    );
+
+    const changed = fixBrokenLinks(lycheeResultsPath, markdownPath);
+
+    expect(changed).toBe(false);
+    expect(readFileSync(markdownPath, "utf8")).toBe(
+      "Logo: ![alt text](https://broken.com/logo.png) here.",
+    );
+  });
+
+  it("strips regular link but skips image link with same URL", () => {
+    const { lycheeResultsPath, markdownPath } = createTempFiles(
+      {
+        fail_map: {
+          "README.md": [{ url: "https://broken.com", status: { code: 404 } }],
+        },
+      },
+      "![img](https://broken.com) and [link](https://broken.com)",
+    );
+
+    const changed = fixBrokenLinks(lycheeResultsPath, markdownPath);
+
+    expect(changed).toBe(true);
+    expect(readFileSync(markdownPath, "utf8")).toBe(
+      "![img](https://broken.com) and link",
+    );
   });
 
   it("handles same URL appearing multiple times", () => {


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR refactors the README check CI workflow to use Claude Code CLI (via `npm install -g`) instead of the `claude-code-action` GitHub Action, and adds a new lychee-based broken link detection step. A new TypeScript script (`fix-broken-links.ts`) is extracted from the workflow to handle stripping broken link markup from markdown files, with a comprehensive Vitest test suite covering edge cases.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [x] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Replaced `anthropics/claude-code-action@v1` with direct Claude Code CLI invocation (`npm install -g @anthropic-ai/claude-code@latest`) using `ANTHROPIC_API_KEY` instead of `CLAUDE_CODE_OAUTH_TOKEN`
> - Added Bun and Node.js setup steps to the workflow
> - Added concurrency control (`cancel-in-progress: true`) to avoid redundant runs
> - Removed `id-token: write` permission (no longer needed)
> - Added lychee link checking step after Claude's README sync, with JSON output and caching
> - Extracted broken link stripping logic into `.github/scripts/fix-broken-links.ts` with exported `fixBrokenLinks` and `parseBrokenUrls` functions
> - Added `git pull --rebase` step between Claude commit and lychee steps to avoid push conflicts
> - Added comprehensive Vitest tests for the new script in `tests/scripts/fix-broken-links.spec.ts` covering `fail_map`, `error_map`, image link skipping, special regex characters, missing files, and malformed JSON
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The broken link fixer preserves image links (`![alt](url)`) intentionally — only regular markdown links are stripped. The script uses a negative lookbehind (`(?<!!)`) to distinguish image links from regular links.
>
> ---
> <sub>🤖 Generated by Claude | 2026-02-26 09:45 UTC</sub>