### PR TITLE
fix(ci): use CLAUDE_CODE_OAUTH_TOKEN for README check

### DIFF
--- a/.github/workflows/readme-check.yml
+++ b/.github/workflows/readme-check.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Run Claude README Check
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           claude -p "$(cat <<'EOF'
           You are checking whether README.md is still accurate after changes on main.


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR fixes the readme-check CI workflow which was failing authentication because it referenced ANTHROPIC_API_KEY, a secret that is not configured in this repository. It switches to CLAUDE_CODE_OAUTH_TOKEN, which is already available and used by other workflows such as manual-publish and daily-error-report. The single-line change aligns the README check workflow with the established authentication pattern in the repo.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Replaced ANTHROPIC_API_KEY env var with CLAUDE_CODE_OAUTH_TOKEN in .github/workflows/readme-check.yml so the Claude CLI can authenticate successfully during CI runs
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (npm test)
>
> ## Checklist
>
> - [x] My code follows the project style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated docs/ (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The CLAUDE_CODE_OAUTH_TOKEN secret is already used by manual-publish.yml and daily-error-report.yml workflows, confirming it is properly configured for this repository. No other changes are required.
>
> ---
> Generated by Claude | 2026-02-26 12:43 UTC