### PR TITLE
fix(ci): fix lychee output conflict and remove pull step

### DIFF
--- a/.github/workflows/readme-check.yml
+++ b/.github/workflows/readme-check.yml
@@ -63,9 +63,6 @@ jobs:
           EOF
           )" --allowedTools "Read,Glob,Grep,Write(README.md),Edit(README.md),Bash(git config *),Bash(git add README.md),Bash(git commit -m *),Bash(git push origin *)"
 
-      - name: Pull latest changes
-        run: git pull --rebase
-
       - name: Restore lychee cache
         uses: actions/cache@v4
         with:
@@ -77,7 +74,8 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress --cache --max-cache-age 1d --format json --output .lychee-results.json README.md
+          args: --verbose --no-progress --cache --max-cache-age 1d --format json README.md
+          output: .lychee-results.json
           fail: false
           jobSummary: true
 


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR fixes a failing CI step in the README check workflow where `lychee-action` was erroring because `--output` was specified both in the `args` string and implicitly by the action's default configuration. It also removes an unnecessary `git pull --rebase` step that was redundant since Claude pushes from the same checkout, keeping local and remote in sync.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Moved `--output .lychee-results.json` from the `args` parameter to the dedicated `output:` parameter in `lychee-action` to resolve the conflict error
> - Removed the `Pull latest changes` step (`git pull --rebase`) as it is unnecessary when Claude commits and pushes from the same checkout
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The `lychee-action` action's default behavior already sets an output path; passing `--output` in `args` as well causes a conflict error that breaks the workflow. Using the `output:` action input is the correct way to configure the output file path.
>
> ---
> <sub>🤖 Generated by Claude | 2026-02-26 12:48 UTC</sub>