### PR TITLE
fix(ci): use action's format param for lychee JSON output

### DIFF
--- a/.github/workflows/readme-check.yml
+++ b/.github/workflows/readme-check.yml
@@ -74,8 +74,9 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress --cache --max-cache-age 1d --format json README.md
+          args: --verbose --no-progress --cache --max-cache-age 1d README.md
           output: .lychee-results.json
+          format: json
           fail: false
           jobSummary: true
 


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR fixes a CI bug in the README broken-link detection workflow where lychee was writing markdown output to `.lychee-results.json` instead of JSON. The root cause was that the `lycheeverse/lychee-action` `format` parameter defaults to `markdown` and silently overrides `--format json` passed via `args`. The fix moves the format setting from `args` to the dedicated `format: json` action input parameter so the downstream JSON parsing step works correctly.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Removed `--format json` from the lychee `args` string in `.github/workflows/readme-check.yml`
> - Added `format: json` as a dedicated action input so the action correctly outputs JSON to `.lychee-results.json`
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The previous behavior caused a silent failure: the broken-link detection step would log a JSON parse warning but exit with code 0, meaning broken links could go undetected.
>
> ---
> <sub>Generated by Claude | 2026-02-26 13:20 UTC</sub>