### PR TITLE
show the base44 secret command in help menu

### DIFF
--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -58,7 +58,7 @@ export function createProgram(context: CLIContext): Command {
   program.addCommand(getFunctionsDeployCommand(context));
 
   // Register secrets commands
-  program.addCommand(getSecretsCommand(context), { hidden: true });
+  program.addCommand(getSecretsCommand(context));
 
   // Register site commands
   program.addCommand(getSiteCommand(context));


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR makes the `secrets` command visible in the CLI help menu by removing the `hidden: true` flag from its registration. Previously, the command existed but was intentionally hidden from help output, making it undiscoverable to users. This change improves the developer experience by surfacing the secrets management functionality alongside other commands.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Removed `{ hidden: true }` option from `getSecretsCommand` registration in `src/cli/program.ts`, making the `secrets` command appear in the CLI help output (`base44 --help`)
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The secrets command itself is unchanged — only its visibility in the help menu is affected. Users who already knew the command existed will see no behavioral difference.
>
> ---
> <sub>🤖 Generated by Claude | 2026-03-02 00:00 UTC</sub>