### PR TITLE
fix(ci): expand README check trigger to all src/cli changes

### DIFF
--- a/.github/workflows/readme-check.yml
+++ b/.github/workflows/readme-check.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - "src/cli/commands/**"
+      - "src/cli/**"
       - "README.md"
   workflow_dispatch:
 
@@ -74,8 +74,9 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress --cache --max-cache-age 1d --format json README.md
+          args: --verbose --no-progress --cache --max-cache-age 1d README.md
           output: .lychee-results.json
+          format: json
           fail: false
           jobSummary: true
 


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR fixes two issues in the README check CI workflow. First, it broadens the `paths` trigger from `src/cli/commands/**` to `src/cli/**` so the workflow fires on any CLI-layer change (e.g. `program.ts`, utilities, telemetry), not just command files. Second, it corrects the lychee link-checker format configuration by moving `--format json` out of the `args` string and into the action's dedicated `format` input field, preventing the default markdown format from silently overriding it.
>
> ## Related Issue
>
> Supersedes #349
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [x] Other (please describe): CI/workflow fix
>
> ## Changes Made
>
> - Expanded `paths` filter in `readme-check.yml` from `src/cli/commands/**` to `src/cli/**` to trigger on all CLI source changes
> - Moved lychee `--format json` from the `args` string to the action's `format` input field to ensure JSON output is used correctly
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> No application code is changed — this is a pure CI configuration fix. The lychee fix prevents the workflow from silently producing markdown-format output instead of the expected JSON used by downstream steps.
>
> ---
> <sub>🤖 Generated by Claude | 2026-03-03 10:10 UTC</sub>