### PR TITLE
fix: increase secrets set timeout to match functions push

### DIFF
--- a/src/core/resources/secret/api.ts
+++ b/src/core/resources/secret/api.ts
@@ -43,6 +43,7 @@ export async function setSecrets(
   try {
     response = await appClient.post("secrets", {
       json: secrets,
+      timeout: false,
     });
   } catch (error) {
     throw await ApiError.fromHttpError(error, "setting secrets");


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR fixes a timeout issue in the `setSecrets` API call by disabling the default 10-second ky HTTP timeout. Setting many secrets (or secrets with large values) could fail prematurely due to this timeout. The fix aligns the behavior with `deployFunctions`, which already uses `timeout: false` for its long-running push operation.
>
> ## Related Issue
>
> Closes #358
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added `timeout: false` to the `appClient.post("secrets", ...)` call in `src/core/resources/secret/api.ts` to disable the default ky timeout for the `setSecrets` request
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The `deployFunctions` operation already used `timeout: false` for the same reason — server-side processing can take longer than the default 10-second window. This one-line change brings `setSecrets` in line with that established pattern.
>
> ---
> <sub>🤖 Generated by Claude | 2026-03-03 00:00 UTC</sub>