### PR TITLE
Watching Entities

### DIFF
--- a/src/cli/dev/dev-server/database.ts
+++ b/src/cli/dev/dev-server/database.ts
@@ -2,10 +2,9 @@ import Datastore from "@seald-io/nedb";
 import type { Entity } from "@/core/resources/entity/schema.js";
 
 export class Database {
-  private collections: Map<string, Datastore>;
+  private collections: Map<string, Datastore> = new Map();
 
-  constructor(entities: Entity[]) {
-    this.collections = new Map();
+  load(entities: Entity[]) {
     for (const entity of entities) {
       this.collections.set(entity.name, new Datastore());
     }
@@ -17,5 +16,12 @@ export class Database {
 
   getCollectionNames(): string[] {
     return Array.from(this.collections.keys());
+  }
+
+  dropAll() {
+    for (const collection of this.collections.values()) {
+      collection.remove({}, { multi: true });
+    }
+    this.collections.clear();
   }
 }

--- a/src/cli/dev/dev-server/main.ts
+++ b/src/cli/dev/dev-server/main.ts
@@ -86,7 +86,8 @@ export async function createDevServer(
     );
   }
 
-  const db = new Database(entities);
+  const db = new Database();
+  db.load(entities);
   if (db.getCollectionNames().length > 0) {
     clackLog.info(`Loaded entities: ${db.getCollectionNames().join(", ")}`);
   }
@@ -152,18 +153,17 @@ export async function createDevServer(
   };
 
   const base44ConfigWatcher = new WatchBase44(
-    [
-      {
-        name: "functions",
-        path: join(dirname(project.configPath), project.functionsDir),
-      },
-    ],
+    {
+      functions: join(dirname(project.configPath), project.functionsDir),
+      entities: join(dirname(project.configPath), project.entitiesDir),
+    },
     devLogger,
   );
   base44ConfigWatcher.on("change", async (name) => {
     try {
+      const { functions, entities } = await options.loadResources();
+
       if (name === "functions") {
-        const { functions } = await options.loadResources();
         const previousFunctionCount = functionManager.getFunctionNames().length;
         functionManager.reload(functions);
 
@@ -172,6 +172,20 @@ export async function createDevServer(
           devLogger.log(`Reloaded functions: ${names.sort().join(", ")}`);
         } else if (previousFunctionCount > 0) {
           devLogger.log("All functions removed");
+        }
+      }
+
+      if (name === "entities") {
+        const previousEntityCount = db.getCollectionNames().length;
+        db.dropAll();
+        if (previousEntityCount > 0) {
+          devLogger.log("Entities directory changed, clearing data...");
+        }
+        db.load(entities);
+        if (db.getCollectionNames().length > 0) {
+          devLogger.log(
+            `Loaded entities: ${db.getCollectionNames().join(", ")}`,
+          );
         }
       }
     } catch (error) {

--- a/src/cli/dev/dev-server/watcher.ts
+++ b/src/cli/dev/dev-server/watcher.ts
@@ -8,41 +8,36 @@ import type { Logger } from "../createDevLogger.js";
 const WATCH_DEBOUNCE_MS = 300;
 const WATCH_QUEUE_DELAY_MS = 500;
 
-type WatchEntryName = "functions";
-
-type WatchEntry = {
-  name: WatchEntryName;
-  path: string;
-};
-
-interface WatchBase44Events {
-  change: [name: WatchEntryName, relativePath: string];
+interface WatchBase44Events<T extends string> {
+  change: [name: T, relativePath: string];
 }
 
-export class WatchBase44 extends EventEmitter<WatchBase44Events> {
-  private watchers: FSWatcher[] = [];
-  private queueWaitForCreation: WatchEntry[] = [];
+export class WatchBase44<T extends string> extends EventEmitter<
+  WatchBase44Events<T>
+> {
+  private entryNames: T[];
+  private watchers: Map<T, FSWatcher> = new Map();
   private queueWaitForCreationTimeout: NodeJS.Timeout | null = null;
 
   constructor(
-    private itemsToWatch: WatchEntry[],
+    private itemsToWatch: Record<T, string>,
     private logger: Logger,
   ) {
     super();
+    this.entryNames = Object.keys(itemsToWatch) as T[];
   }
 
   async start(): Promise<void> {
-    if (this.watchers.length > 0 || this.queueWaitForCreation.length > 0) {
+    if (this.watchers.size > 0) {
       return;
     }
-    for (const item of this.itemsToWatch) {
-      if (await pathExists(item.path)) {
-        this.watchers.push(this.watchTarget(item));
-      } else {
-        this.queueWaitForCreation.push(item);
+    for (const name of this.entryNames) {
+      const targetPath = this.itemsToWatch[name];
+      if (await pathExists(targetPath)) {
+        this.watchers.set(name, this.watchTarget(name, targetPath));
       }
     }
-    this.watchCreationQueue();
+    this.watchEntries();
   }
 
   async close(): Promise<void> {
@@ -50,63 +45,62 @@ export class WatchBase44 extends EventEmitter<WatchBase44Events> {
       clearTimeout(this.queueWaitForCreationTimeout);
       this.queueWaitForCreationTimeout = null;
     }
-    for (const watcher of this.watchers) {
+    for (const watcher of this.watchers.values()) {
       await watcher.close();
     }
-    this.watchers = [];
-    this.queueWaitForCreation = [];
+    this.watchers.clear();
   }
 
-  private watchCreationQueue(): void {
+  private watchEntries(): void {
     if (this.queueWaitForCreationTimeout) {
       clearTimeout(this.queueWaitForCreationTimeout);
     }
     this.queueWaitForCreationTimeout = setTimeout(async () => {
-      const toRemove: WatchEntry[] = [];
-      for (const entry of this.queueWaitForCreation) {
-        if (await pathExists(entry.path)) {
-          this.watchers.push(this.watchTarget(entry));
-          toRemove.push(entry);
+      for (const name of this.entryNames) {
+        const path = this.itemsToWatch[name];
+        const watchItem = this.watchers.get(name);
+        const exists = await pathExists(path);
+
+        // Chokidar does not fire an event when the root directory it is watching is deleted.
+        // The `unlinkDir` event is only triggered for nested directories, not the root.
+        // Therefore, I need to watch for the root deletion separately.
+        if (!watchItem && exists) {
+          this.emit("change", name, path);
+          this.watchers.set(name, this.watchTarget(name, path));
+        } else if (watchItem && !exists) {
+          await watchItem.close();
+          this.emit("change", name, path);
+
+          setTimeout(() => {
+            // Garbage collecting closed watchers.
+            // This needs to happen in the next "tick", so process will not be "stuck".
+            // (User wouldn't be able to exit otherwise)
+            this.watchers.forEach((watcher, watcherName) => {
+              if (watcher.closed) {
+                this.watchers.delete(watcherName);
+              }
+            });
+          });
         }
       }
-      this.queueWaitForCreation = this.queueWaitForCreation.filter(
-        (entry) => !toRemove.includes(entry),
-      );
-      if (this.queueWaitForCreation.length > 0) {
-        this.watchCreationQueue();
-      } else {
-        this.queueWaitForCreationTimeout = null;
-      }
+      this.queueWaitForCreationTimeout = null;
+      this.watchEntries();
     }, WATCH_QUEUE_DELAY_MS);
   }
 
-  private watchTarget(item: WatchEntry): FSWatcher {
-    const handler = debounce(async (_event: string, path: string) => {
-      this.emit("change", item.name, relative(item.path, path));
-    }, WATCH_DEBOUNCE_MS);
-
-    const watcher = watch(item.path, {
+  private watchTarget(name: T, targetPath: string): FSWatcher {
+    const watcher = watch(targetPath, {
       ignoreInitial: true,
     });
-    watcher.on("all", handler);
-    watcher.on("unlinkDir", async (deletedPath) => {
-      if (deletedPath !== item.path) {
-        return;
-      }
-      await watcher.close();
-      this.queueWaitForCreation.push(item);
-      this.watchCreationQueue();
-
-      setTimeout(() => {
-        // Garbage collecting closed watchers.
-        // This needs to happen in the next "tick", so process will not be "stuck".
-        // (User wouldn't be able to exit otherwise)
-        this.watchers = this.watchers.filter((watcher) => !watcher.closed);
-      });
-    });
+    watcher.on(
+      "all",
+      debounce(async (_event: string, path: string) => {
+        this.emit("change", name, relative(targetPath, path));
+      }, WATCH_DEBOUNCE_MS),
+    );
     watcher.on("error", (err) => {
       this.logger.error(
-        `Watch handler failed for ${item.path}`,
+        `Watch handler failed for ${targetPath}`,
         err instanceof Error ? err : undefined,
       );
     });


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR adds live-reload support for the entities directory in the dev server. Previously, only the functions directory was watched for changes; now the entities directory is also watched, and when it changes, the in-memory database is cleared and reloaded automatically. The watcher was refactored to be generic and handle root-directory deletion correctly.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [x] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - **`database.ts`**: Converted `Database` from constructor-based initialization to a `load(entities)` method pattern; added `dropAll()` to clear all in-memory collections.
> - **`main.ts`**: Updated `Database` instantiation to use the new `load()` API; added the entities directory to the file watcher; added an `"entities"` change handler that drops and reloads the database when entity files change.
> - **`watcher.ts`**: Made `WatchBase44` generic (`WatchBase44<T extends string>`) so it accepts any named watch targets via a `Record<T, string>` map instead of a typed array; replaced per-target `unlinkDir` root-deletion handling with a unified polling loop (`watchEntries`) that detects both creation and deletion of watched root directories; switched internal watcher storage from an array to a `Map<T, FSWatcher>` for O(1) lookup by name.
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The watcher refactor addresses a Chokidar limitation: it does not fire an `unlinkDir` event when the **root** directory being watched is deleted (only for nested dirs). The new `watchEntries` polling loop detects this case and emits a `"change"` event accordingly, then cleans up closed watchers asynchronously to avoid blocking the Node.js event loop.
>
> ---
> <sub>🤖 Generated by Claude | 2026-03-04 00:00 UTC</sub>