### PR TITLE
fix: disable timeout for delete secret request

### DIFF
--- a/src/core/resources/secret/api.ts
+++ b/src/core/resources/secret/api.ts
@@ -70,6 +70,7 @@ export async function deleteSecret(
   try {
     response = await appClient.delete("secrets", {
       searchParams: { secret_name: name },
+      timeout: false,
     });
   } catch (error) {
     throw await ApiError.fromHttpError(error, "deleting secret");


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR fixes a potential timeout issue with the `deleteSecret` API call by disabling the default request timeout. The `setSecrets` function already had `timeout: false` set, but `deleteSecret` was missing this option, which could cause failures on slower server responses. This change aligns `deleteSecret` with the existing behavior of `setSecrets`.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added `timeout: false` to the `deleteSecret` request in `src/core/resources/secret/api.ts`, matching the pattern already used in `setSecrets`
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The `ky` HTTP client used by the app client has a default timeout. Disabling it with `timeout: false` ensures that secret deletion requests do not prematurely fail on slow network or server conditions, consistent with how secret creation (`setSecrets`) is already handled.
>
> ---
> <sub>🤖 Generated by Claude | 2026-03-08 00:00 UTC</sub>