### PR TITLE
generate a new request id for each request

### DIFF
--- a/src/core/clients/base44-client.ts
+++ b/src/core/clients/base44-client.ts
@@ -64,12 +64,17 @@ async function handleUnauthorized(
   }
 
   // Mark this request as retried and retry with new token.
+  // Preserve X-Request-ID so the retry is traced as the same logical request.
   // Clone the request before passing to ky — `new Request(request, init)` transfers
   // (consumes) the original request's body, which would leave the outer ky's preserved
   // request in an unusable state if this inner call fails and the outer ky tries to retry.
   retriedRequests.add(request);
+  const requestId = request.headers.get("X-Request-ID");
   return ky(request.clone() as Request, {
-    headers: { Authorization: `Bearer ${newAccessToken}` },
+    headers: {
+      ...(requestId && { "X-Request-ID": requestId }),
+      Authorization: `Bearer ${newAccessToken}`,
+    },
   });
 }
 

--- a/src/core/clients/oauth-client.ts
+++ b/src/core/clients/oauth-client.ts
@@ -4,6 +4,7 @@
  * These endpoints don't need Authorization headers - they use client_id + tokens in body.
  */
 
+import { randomUUID } from "node:crypto";
 import ky from "ky";
 import { getBase44ApiUrl } from "@/core/config.js";
 
@@ -11,5 +12,12 @@ export const oauthClient = ky.create({
   prefixUrl: getBase44ApiUrl(),
   headers: {
     "User-Agent": "Base44 CLI",
+  },
+  hooks: {
+    beforeRequest: [
+      (request) => {
+        request.headers.set("X-Request-ID", randomUUID());
+      },
+    ],
   },
 });


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR adds unique `X-Request-ID` headers to all outgoing HTTP requests made by the Base44 CLI, generated via `randomUUID()`. When a 401 triggers a token refresh and retry, the original request ID is preserved on the retried request so the full request lifecycle can be traced as a single logical operation server-side.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added `beforeRequest` hook to `base44Client` that sets a fresh `X-Request-ID` UUID on every request
> - Added `beforeRequest` hook to `oauthClient` that sets a fresh `X-Request-ID` UUID on every request
> - In `handleUnauthorized`, preserved the original `X-Request-ID` header when cloning and retrying a request after token refresh, so the retry shares the same logical request ID
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [x] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The `X-Request-ID` is generated using Node's built-in `node:crypto` module (`randomUUID`), keeping the zero-dependency distribution intact. The ID is preserved across 401-triggered retries intentionally — the retry is part of the same logical request, enabling end-to-end tracing on the server side.
>
> ---
> <sub>🤖 Generated by Claude | 2026-03-08 00:00 UTC</sub>