### PR TITLE
added new cursor command to generate reports

### DIFF
--- a/.cursor/commands/error-report-summary.md
+++ b/.cursor/commands/error-report-summary.md
@@ -1,0 +1,57 @@
+# Error Report Summary (last 5 days)
+
+Fetch the last 5 days of error-report issues from the Base44 CLI GitHub repo, produce a summary report with Mermaid graphs, action items, and evaluation. Output is written to `error-reports/` (gitignored).
+
+## Instructions
+
+### 1. Compute the date range
+
+- "Last 5 days" = from today backward (e.g. today 2026-03-08 → `created:>=2026-03-03`).
+- On macOS: `date -v-5d +%Y-%m-%d`. On Linux: `date -d '5 days ago' +%Y-%m-%d`.
+
+### 2. Fetch issues with GitHub CLI only
+
+- List issues:
+  ```bash
+  gh issue list --repo base44/cli --label "error-report" --state all --search "created:>=YYYY-MM-DD" --limit 20
+  ```
+- For each issue number in the list, fetch the full body:
+  ```bash
+  gh issue view <number> --repo base44/cli --json title,number,state,createdAt,body
+  ```
+- Use only the `gh` CLI; no direct GitHub API calls.
+
+### 3. Read and understand each issue
+
+- For each issue: command, error message, stack trace, environment (OS, command), and whether it is a CLI bug, backend issue, or user error (working as designed).
+
+### 4. Ensure report directory is gitignored
+
+- If `error-reports/` is not in `.gitignore`, add:
+  ```text
+  # Error report summaries (generated, do not commit)
+  error-reports/
+  ```
+- Create the directory if needed: `mkdir -p error-reports`.
+
+### 5. Write the report
+
+Write to `error-reports/last-5-days-summary.md` (or `error-reports/YYYY-MM-DD-summary.md` for a date-stamped name) with:
+
+1. **Meta** — Run date, "last 5 days" window, total issue count, table of issues (title, link, created date, state).
+2. **Graphs (Mermaid)** — Embed in the same file:
+   - **Total errors over time:** Bar or xychart with X = date (by day), Y = number of errors. Use each report’s "Total errors" and the report date from the issue title.
+   - **Errors by type:** Pie or bar of count per type. Derive type from issue body (e.g. auth, deploy, backend 428, config not found, timeout, user validation).
+   - **Top N per-error:** Bar chart of the top 5–10 recurring error patterns (normalize issue titles or first error line; group and count).
+3. **Per-issue summary** — Short description of what failed, root cause if evident, 1–2 bullets per issue.
+4. **Main action items** — Grouped by theme (auth, deploy, entities, config, telemetry, UX). Concrete next steps with file/line references where applicable.
+5. **What else to evaluate** — Trends (same error across reports), gaps (missing context, unclear reproduction), suggestions (telemetry, docs, CLI UX).
+
+### 6. Reply to the user
+
+- Give a short summary (e.g. how many issues, main themes) and the path to the report file.
+
+## Output
+
+- Report path: `error-reports/last-5-days-summary.md` (or date-stamped equivalent).
+- All charts are Mermaid code blocks so they render in GitHub and Cursor.

--- a/.gitignore
+++ b/.gitignore
@@ -78,5 +78,8 @@ coverage/
 *.seed
 *.pid.lock
 
+# Error report summaries (generated, do not commit)
+error-reports/
+
 # Worktrees
 .worktrees/


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR adds a new Cursor agent command that automates generating error report summaries from the Base44 CLI GitHub repository. The command fetches the last 5 days of error-report issues via the GitHub CLI, analyzes each issue, and writes a structured Markdown report with Mermaid charts and actionable insights to a local `error-reports/` directory. The `.gitignore` is updated to ensure generated reports are never accidentally committed.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [x] Other (please describe): New Cursor agent command for developer tooling
>
> ## Changes Made
>
> - Added `.cursor/commands/error-report-summary.md`: a Cursor command that instructs an agent to fetch the last 5 days of `error-report`-labeled GitHub issues, classify each one (CLI bug / backend issue / user error), and write a report with Mermaid graphs (errors over time, errors by type, top recurring patterns), per-issue summaries, grouped action items, and trend evaluation.
> - Updated `.gitignore`: added `error-reports/` so generated report files are excluded from version control.
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The command is purely a developer-facing tool — it uses only the `gh` CLI (no direct GitHub API calls) and writes output locally. The report format includes Mermaid diagrams so charts render natively in both GitHub and Cursor.
>
> ---
> <sub>🤖 Generated by Claude | 2026-03-08 00:00 UTC</sub>