### PR TITLE
Make function name optional in function.json schema

### DIFF
--- a/src/core/resources/function/config.ts
+++ b/src/core/resources/function/config.ts
@@ -28,9 +28,15 @@ async function readFunctionConfig(configPath: string): Promise<FunctionConfig> {
   return result.data;
 }
 
-async function readFunction(configPath: string): Promise<BackendFunction> {
+async function readFunction(
+  configPath: string,
+  functionsDir: string,
+): Promise<BackendFunction> {
   const config = await readFunctionConfig(configPath);
   const functionDir = dirname(configPath);
+  const name =
+    config.name ??
+    relative(functionsDir, functionDir).split(/[/\\]/).join("/");
   const entryPath = join(functionDir, config.entry);
 
   if (!(await pathExists(entryPath))) {
@@ -47,7 +53,7 @@ async function readFunction(configPath: string): Promise<BackendFunction> {
     absolute: true,
   });
 
-  const functionData: BackendFunction = { ...config, entryPath, filePaths };
+  const functionData: BackendFunction = { ...config, name, entryPath, filePaths };
   return functionData;
 }
 
@@ -76,7 +82,7 @@ export async function readAllFunctions(
   );
 
   const functionsFromConfig = await Promise.all(
-    configFiles.map((configPath) => readFunction(configPath)),
+    configFiles.map((configPath) => readFunction(configPath, functionsDir)),
   );
 
   const functionsWithoutConfig = await Promise.all(

--- a/src/core/resources/function/schema.ts
+++ b/src/core/resources/function/schema.ts
@@ -74,12 +74,13 @@ const AutomationSchema = z.union([
 ]);
 
 export const FunctionConfigSchema = z.object({
-  name: FunctionNameSchema,
+  name: FunctionNameSchema.optional(),
   entry: z.string().min(1, "Entry point cannot be empty"),
   automations: z.array(AutomationSchema).optional(),
 });
 
 const BackendFunctionSchema = FunctionConfigSchema.extend({
+  name: FunctionNameSchema,
   entryPath: z.string().min(1, "Entry path cannot be empty"),
   filePaths: z.array(z.string()).min(1, "Function must have at least one file"),
 });

--- a/tests/core/function-config.spec.ts
+++ b/tests/core/function-config.spec.ts
@@ -16,13 +16,14 @@ describe("readAllFunctions", () => {
     const functionsDir = resolve(FIXTURES_DIR, "function-discovery");
     const result = await readAllFunctions(functionsDir);
 
-    expect(result).toHaveLength(4); // foo/bar, foo/kfir/hello, stam, with-config (config-based)
+    expect(result).toHaveLength(5); // foo/bar, foo/kfir/hello, stam, with-config (config-based), no-name-in-config (config-based, no name)
 
     const names = result.map((f) => f.name).sort();
     expect(names).toContain("foo/bar");
     expect(names).toContain("foo/kfir/hello");
     expect(names).toContain("stam");
     expect(names).toContain("custom-name");
+    expect(names).toContain("no-name-in-config");
 
     const fooBar = result.find((f) => f.name === "foo/bar");
     expect(fooBar).toBeDefined();
@@ -44,6 +45,16 @@ describe("readAllFunctions", () => {
     expect(withConfig?.entryPath).toContain("with-config/entry.ts");
     // Name comes from config, not path "with-config"
     expect(withConfig?.name).toBe("custom-name");
+  });
+
+  it("uses path-based name when function.jsonc omits the name field", async () => {
+    const functionsDir = resolve(FIXTURES_DIR, "function-discovery");
+    const result = await readAllFunctions(functionsDir);
+
+    const noName = result.find((f) => f.name === "no-name-in-config");
+    expect(noName).toBeDefined();
+    expect(noName?.entry).toBe("entry.ts");
+    expect(noName?.entryPath).toContain("no-name-in-config/entry.ts");
   });
 
   it("includes files recursively in filePaths for zero-config functions", async () => {

--- a/tests/fixtures/function-discovery/no-name-in-config/entry.ts
+++ b/tests/fixtures/function-discovery/no-name-in-config/entry.ts
@@ -1,0 +1,3 @@
+export default function handler() {
+  return { ok: true };
+}

--- a/tests/fixtures/function-discovery/no-name-in-config/function.jsonc
+++ b/tests/fixtures/function-discovery/no-name-in-config/function.jsonc
@@ -1,0 +1,3 @@
+{
+  "entry": "entry.ts"
+}


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR makes the `name` field optional in `function.json`/`function.jsonc` config files. When omitted, the function name is automatically derived from the directory path relative to the functions root, matching the existing behavior for zero-config (config-less) functions. This provides a more ergonomic authoring experience where users don't need to repeat the directory name in a config field.
>
> ## Related Issue
>
> Closes #373
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Made `name` field optional in `FunctionConfigSchema` (Zod schema) so `function.jsonc` files can omit it
> - Added `name` as a required field on `BackendFunctionSchema` (the resolved internal type) to enforce it is always present after processing
> - Updated `readFunction()` to accept a `functionsDir` parameter and derive the name from the relative path when `name` is absent in the config
> - Path-based name derivation normalizes separators cross-platform via `relative(functionsDir, functionDir).split(/[/\\]/).join("/")`
> - Added a test fixture (`no-name-in-config/`) with a `function.jsonc` that omits the `name` field
> - Added/updated tests to cover the path-based fallback naming behavior (expected count bumped from 4 to 5)
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The path-based fallback is consistent with how zero-config (config-less) functions already derive their names from the directory structure, so this change makes the two approaches behaviorally equivalent when `name` is omitted.
>
> ---
> <sub>🤖 Generated by Claude | 2026-03-08 09:30 UTC</sub>