### PR TITLE
feat: add SSO provider setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-./packages/cli/README.md

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "base44-cli",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -60,6 +60,7 @@ The CLI will guide you through project setup. For step-by-step tutorials, see th
 | [`secrets list`](https://docs.base44.com/developers/references/cli/commands/secrets-list) | List project secret names |
 | [`secrets set`](https://docs.base44.com/developers/references/cli/commands/secrets-set) | Set one or more project secrets |
 | [`secrets delete`](https://docs.base44.com/developers/references/cli/commands/secrets-delete) | Delete a project secret |
+| `sso setup` | Configure SSO identity provider for the app |
 | [`site deploy`](https://docs.base44.com/developers/references/cli/commands/site-deploy) | Deploy built site files to Base44 hosting |
 | [`site open`](https://docs.base44.com/developers/references/cli/commands/site-open) | Open the published site in your browser |
 | [`types generate`](https://docs.base44.com/developers/references/cli/commands/types-generate) | Generate TypeScript types from project resources |

--- a/packages/cli/src/cli/commands/sso/index.ts
+++ b/packages/cli/src/cli/commands/sso/index.ts
@@ -1,0 +1,11 @@
+import { Command } from "commander";
+import type { CLIContext } from "@/cli/types.js";
+import { getSSORemoveCommand } from "./remove.js";
+import { getSSOSetupCommand } from "./setup.js";
+
+export function getSSOCommand(context: CLIContext): Command {
+  return new Command("sso")
+    .description("Manage SSO identity provider configuration")
+    .addCommand(getSSOSetupCommand(context))
+    .addCommand(getSSORemoveCommand(context));
+}

--- a/packages/cli/src/cli/commands/sso/providers/custom.ts
+++ b/packages/cli/src/cli/commands/sso/providers/custom.ts
@@ -1,0 +1,144 @@
+import { isCancel, password, text } from "@clack/prompts";
+import { CLIExitError } from "@/cli/errors.js";
+import type { CustomSSOCredentials } from "./types.js";
+
+const DEFAULT_SSO_SCOPE = "openid email profile";
+const PLACEHOLDER_DISCOVERY_URL =
+  "https://idp.example.com/.well-known/openid-configuration";
+const PLACEHOLDER_AUTH_ENDPOINT = "https://idp.example.com/authorize";
+const PLACEHOLDER_TOKEN_ENDPOINT = "https://idp.example.com/token";
+const PLACEHOLDER_USERINFO_ENDPOINT = "https://idp.example.com/userinfo";
+const PLACEHOLDER_JWKS_URI = "https://idp.example.com/.well-known/jwks.json";
+
+export async function promptCustomCredentials(): Promise<CustomSSOCredentials> {
+  const ssoName = await text({
+    message: "SSO provider name",
+    placeholder: "my-idp",
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Provider name is required";
+      }
+    },
+  });
+
+  if (isCancel(ssoName)) {
+    throw new CLIExitError(0);
+  }
+
+  const clientId = await text({
+    message: "Client ID",
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Client ID is required";
+      }
+    },
+  });
+
+  if (isCancel(clientId)) {
+    throw new CLIExitError(0);
+  }
+
+  const clientSecret = await password({
+    message: "Client Secret",
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Client Secret is required";
+      }
+    },
+  });
+
+  if (isCancel(clientSecret)) {
+    throw new CLIExitError(0);
+  }
+
+  const scope = await text({
+    message: "SSO scope",
+    initialValue: DEFAULT_SSO_SCOPE,
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Scope is required";
+      }
+    },
+  });
+
+  if (isCancel(scope)) {
+    throw new CLIExitError(0);
+  }
+
+  const discoveryUrl = await text({
+    message: "Discovery URL (optional)",
+    placeholder: PLACEHOLDER_DISCOVERY_URL,
+  });
+
+  if (isCancel(discoveryUrl)) {
+    throw new CLIExitError(0);
+  }
+
+  const authEndpoint = await text({
+    message: "Authorization endpoint",
+    placeholder: PLACEHOLDER_AUTH_ENDPOINT,
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Authorization endpoint is required";
+      }
+    },
+  });
+
+  if (isCancel(authEndpoint)) {
+    throw new CLIExitError(0);
+  }
+
+  const tokenEndpoint = await text({
+    message: "Token endpoint",
+    placeholder: PLACEHOLDER_TOKEN_ENDPOINT,
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Token endpoint is required";
+      }
+    },
+  });
+
+  if (isCancel(tokenEndpoint)) {
+    throw new CLIExitError(0);
+  }
+
+  const userinfoEndpoint = await text({
+    message: "Userinfo endpoint",
+    placeholder: PLACEHOLDER_USERINFO_ENDPOINT,
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Userinfo endpoint is required";
+      }
+    },
+  });
+
+  if (isCancel(userinfoEndpoint)) {
+    throw new CLIExitError(0);
+  }
+
+  const jwksUri = await text({
+    message: "JWKS URI",
+    placeholder: PLACEHOLDER_JWKS_URI,
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "JWKS URI is required";
+      }
+    },
+  });
+
+  if (isCancel(jwksUri)) {
+    throw new CLIExitError(0);
+  }
+
+  return {
+    ssoName,
+    ssoClientId: clientId,
+    ssoClientSecret: clientSecret,
+    ssoScope: scope,
+    ssoDiscoveryUrl: discoveryUrl || undefined,
+    ssoAuthEndpoint: authEndpoint,
+    ssoTokenEndpoint: tokenEndpoint,
+    ssoUserinfoEndpoint: userinfoEndpoint,
+    ssoJwksUri: jwksUri,
+  };
+}

--- a/packages/cli/src/cli/commands/sso/providers/github.ts
+++ b/packages/cli/src/cli/commands/sso/providers/github.ts
@@ -1,0 +1,102 @@
+import { isCancel, password, text } from "@clack/prompts";
+import { CLIExitError } from "@/cli/errors.js";
+import type { GitHubSSOCredentials } from "./types.js";
+
+const GITHUB_AUTH_ENDPOINT = "https://github.com/login/oauth/authorize";
+const GITHUB_TOKEN_ENDPOINT = "https://github.com/login/oauth/access_token";
+const GITHUB_USERINFO_ENDPOINT = "https://api.github.com/user";
+const GITHUB_SSO_SCOPE = "user:email";
+
+export async function promptGitHubCredentials(): Promise<GitHubSSOCredentials> {
+  const clientId = await text({
+    message: "GitHub OAuth Client ID",
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Client ID is required";
+      }
+    },
+  });
+
+  if (isCancel(clientId)) {
+    throw new CLIExitError(0);
+  }
+
+  const clientSecret = await password({
+    message: "GitHub OAuth Client Secret",
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Client Secret is required";
+      }
+    },
+  });
+
+  if (isCancel(clientSecret)) {
+    throw new CLIExitError(0);
+  }
+
+  const scope = await text({
+    message: "SSO scope",
+    initialValue: GITHUB_SSO_SCOPE,
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Scope is required";
+      }
+    },
+  });
+
+  if (isCancel(scope)) {
+    throw new CLIExitError(0);
+  }
+
+  const authEndpoint = await text({
+    message: "Authorization endpoint",
+    initialValue: GITHUB_AUTH_ENDPOINT,
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Authorization endpoint is required";
+      }
+    },
+  });
+
+  if (isCancel(authEndpoint)) {
+    throw new CLIExitError(0);
+  }
+
+  const tokenEndpoint = await text({
+    message: "Token endpoint",
+    initialValue: GITHUB_TOKEN_ENDPOINT,
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Token endpoint is required";
+      }
+    },
+  });
+
+  if (isCancel(tokenEndpoint)) {
+    throw new CLIExitError(0);
+  }
+
+  const userinfoEndpoint = await text({
+    message: "Userinfo endpoint",
+    initialValue: GITHUB_USERINFO_ENDPOINT,
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Userinfo endpoint is required";
+      }
+    },
+  });
+
+  if (isCancel(userinfoEndpoint)) {
+    throw new CLIExitError(0);
+  }
+
+  return {
+    ssoName: "github",
+    ssoClientId: clientId,
+    ssoClientSecret: clientSecret,
+    ssoScope: scope,
+    ssoAuthEndpoint: authEndpoint,
+    ssoTokenEndpoint: tokenEndpoint,
+    ssoUserinfoEndpoint: userinfoEndpoint,
+  };
+}

--- a/packages/cli/src/cli/commands/sso/providers/google.ts
+++ b/packages/cli/src/cli/commands/sso/providers/google.ts
@@ -1,0 +1,73 @@
+import { isCancel, password, text } from "@clack/prompts";
+import { CLIExitError } from "@/cli/errors.js";
+import type { GoogleSSOCredentials } from "./types.js";
+
+const DEFAULT_DISCOVERY_URL =
+  "https://accounts.google.com/.well-known/openid-configuration";
+const DEFAULT_SSO_SCOPE = "openid email profile";
+const PLACEHOLDER_CLIENT_ID = "xxxx.apps.googleusercontent.com";
+
+export async function promptGoogleCredentials(): Promise<GoogleSSOCredentials> {
+  const clientId = await text({
+    message: "Google OAuth Client ID",
+    placeholder: PLACEHOLDER_CLIENT_ID,
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Client ID is required";
+      }
+    },
+  });
+
+  if (isCancel(clientId)) {
+    throw new CLIExitError(0);
+  }
+
+  const clientSecret = await password({
+    message: "Google OAuth Client Secret",
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Client Secret is required";
+      }
+    },
+  });
+
+  if (isCancel(clientSecret)) {
+    throw new CLIExitError(0);
+  }
+
+  const discoveryUrl = await text({
+    message: "Discovery URL",
+    initialValue: DEFAULT_DISCOVERY_URL,
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Discovery URL is required";
+      }
+    },
+  });
+
+  if (isCancel(discoveryUrl)) {
+    throw new CLIExitError(0);
+  }
+
+  const scope = await text({
+    message: "SSO scope",
+    initialValue: DEFAULT_SSO_SCOPE,
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Scope is required";
+      }
+    },
+  });
+
+  if (isCancel(scope)) {
+    throw new CLIExitError(0);
+  }
+
+  return {
+    ssoName: "google",
+    ssoClientId: clientId,
+    ssoClientSecret: clientSecret,
+    ssoDiscoveryUrl: discoveryUrl,
+    ssoScope: scope,
+  };
+}

--- a/packages/cli/src/cli/commands/sso/providers/index.ts
+++ b/packages/cli/src/cli/commands/sso/providers/index.ts
@@ -1,0 +1,6 @@
+export { promptCustomCredentials } from "./custom.js";
+export { promptGitHubCredentials } from "./github.js";
+export { promptGoogleCredentials } from "./google.js";
+export { promptMicrosoftCredentials } from "./microsoft.js";
+export { promptOktaCredentials } from "./okta.js";
+export type { SSOCredentials } from "./types.js";

--- a/packages/cli/src/cli/commands/sso/providers/microsoft.ts
+++ b/packages/cli/src/cli/commands/sso/providers/microsoft.ts
@@ -1,0 +1,91 @@
+import { isCancel, password, text } from "@clack/prompts";
+import { CLIExitError } from "@/cli/errors.js";
+import type { MicrosoftSSOCredentials } from "./types.js";
+
+const DEFAULT_SSO_SCOPE = "openid email profile";
+const MICROSOFT_DISCOVERY_URL_BASE = "https://login.microsoftonline.com";
+const PLACEHOLDER_UUID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx";
+
+function buildDiscoveryUrl(tenantId: string): string {
+  return `${MICROSOFT_DISCOVERY_URL_BASE}/${tenantId}/v2.0/.well-known/openid-configuration`;
+}
+
+export async function promptMicrosoftCredentials(): Promise<MicrosoftSSOCredentials> {
+  const tenantId = await text({
+    message: "Microsoft Tenant ID",
+    placeholder: PLACEHOLDER_UUID,
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Tenant ID is required";
+      }
+    },
+  });
+
+  if (isCancel(tenantId)) {
+    throw new CLIExitError(0);
+  }
+
+  const clientId = await text({
+    message: "Microsoft Application (Client) ID",
+    placeholder: PLACEHOLDER_UUID,
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Client ID is required";
+      }
+    },
+  });
+
+  if (isCancel(clientId)) {
+    throw new CLIExitError(0);
+  }
+
+  const clientSecret = await password({
+    message: "Microsoft Client Secret",
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Client Secret is required";
+      }
+    },
+  });
+
+  if (isCancel(clientSecret)) {
+    throw new CLIExitError(0);
+  }
+
+  const discoveryUrl = await text({
+    message: "Discovery URL",
+    initialValue: buildDiscoveryUrl(tenantId),
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Discovery URL is required";
+      }
+    },
+  });
+
+  if (isCancel(discoveryUrl)) {
+    throw new CLIExitError(0);
+  }
+
+  const scope = await text({
+    message: "SSO scope",
+    initialValue: DEFAULT_SSO_SCOPE,
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Scope is required";
+      }
+    },
+  });
+
+  if (isCancel(scope)) {
+    throw new CLIExitError(0);
+  }
+
+  return {
+    ssoName: "microsoft",
+    ssoClientId: clientId,
+    ssoClientSecret: clientSecret,
+    ssoDiscoveryUrl: discoveryUrl,
+    ssoScope: scope,
+    ssoTenantId: tenantId,
+  };
+}

--- a/packages/cli/src/cli/commands/sso/providers/okta.ts
+++ b/packages/cli/src/cli/commands/sso/providers/okta.ts
@@ -1,0 +1,89 @@
+import { isCancel, password, text } from "@clack/prompts";
+import { CLIExitError } from "@/cli/errors.js";
+import type { OktaSSOCredentials } from "./types.js";
+
+const DEFAULT_SSO_SCOPE = "openid email profile";
+const PLACEHOLDER_OKTA_DOMAIN = "your-org.okta.com";
+
+function buildDiscoveryUrl(domain: string): string {
+  return `https://${domain}/.well-known/openid-configuration`;
+}
+
+export async function promptOktaCredentials(): Promise<OktaSSOCredentials> {
+  const oktaDomain = await text({
+    message: "Okta domain",
+    placeholder: PLACEHOLDER_OKTA_DOMAIN,
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Okta domain is required";
+      }
+    },
+  });
+
+  if (isCancel(oktaDomain)) {
+    throw new CLIExitError(0);
+  }
+
+  const clientId = await text({
+    message: "Okta Client ID",
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Client ID is required";
+      }
+    },
+  });
+
+  if (isCancel(clientId)) {
+    throw new CLIExitError(0);
+  }
+
+  const clientSecret = await password({
+    message: "Okta Client Secret",
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Client Secret is required";
+      }
+    },
+  });
+
+  if (isCancel(clientSecret)) {
+    throw new CLIExitError(0);
+  }
+
+  const discoveryUrl = await text({
+    message: "Discovery URL",
+    initialValue: buildDiscoveryUrl(oktaDomain),
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Discovery URL is required";
+      }
+    },
+  });
+
+  if (isCancel(discoveryUrl)) {
+    throw new CLIExitError(0);
+  }
+
+  const scope = await text({
+    message: "SSO scope",
+    initialValue: DEFAULT_SSO_SCOPE,
+    validate: (value) => {
+      if (!value || value.trim().length === 0) {
+        return "Scope is required";
+      }
+    },
+  });
+
+  if (isCancel(scope)) {
+    throw new CLIExitError(0);
+  }
+
+  return {
+    ssoName: "okta",
+    ssoClientId: clientId,
+    ssoClientSecret: clientSecret,
+    ssoDiscoveryUrl: discoveryUrl,
+    ssoScope: scope,
+    ssoOktaDomain: oktaDomain,
+  };
+}

--- a/packages/cli/src/cli/commands/sso/providers/types.ts
+++ b/packages/cli/src/cli/commands/sso/providers/types.ts
@@ -1,0 +1,41 @@
+interface SSOCredentialsBase {
+  ssoName: string;
+  ssoClientId: string;
+  ssoClientSecret: string;
+  ssoScope: string;
+}
+
+export interface GoogleSSOCredentials extends SSOCredentialsBase {
+  ssoDiscoveryUrl: string;
+}
+
+export interface MicrosoftSSOCredentials extends SSOCredentialsBase {
+  ssoDiscoveryUrl: string;
+  ssoTenantId: string;
+}
+
+export interface GitHubSSOCredentials extends SSOCredentialsBase {
+  ssoAuthEndpoint: string;
+  ssoTokenEndpoint: string;
+  ssoUserinfoEndpoint: string;
+}
+
+export interface OktaSSOCredentials extends SSOCredentialsBase {
+  ssoDiscoveryUrl: string;
+  ssoOktaDomain: string;
+}
+
+export interface CustomSSOCredentials extends SSOCredentialsBase {
+  ssoDiscoveryUrl?: string;
+  ssoAuthEndpoint: string;
+  ssoTokenEndpoint: string;
+  ssoUserinfoEndpoint: string;
+  ssoJwksUri: string;
+}
+
+export type SSOCredentials =
+  | GoogleSSOCredentials
+  | MicrosoftSSOCredentials
+  | GitHubSSOCredentials
+  | OktaSSOCredentials
+  | CustomSSOCredentials;

--- a/packages/cli/src/cli/commands/sso/remove.ts
+++ b/packages/cli/src/cli/commands/sso/remove.ts
@@ -1,0 +1,37 @@
+import { log } from "@clack/prompts";
+import { Command } from "commander";
+import type { CLIContext } from "@/cli/types.js";
+import { runCommand, runTask, theme } from "@/cli/utils/index.js";
+import type { RunCommandResult } from "@/cli/utils/runCommand.js";
+import { getAuthConfig, removeSSOConfig } from "@/core/auth-config/index.js";
+
+async function removeSSOAction(): Promise<RunCommandResult> {
+  const current = await runTask(
+    "Fetching current auth config",
+    async () => await getAuthConfig(),
+  );
+
+  if (!current.enableSSOLogin) {
+    log.warn("SSO is not currently enabled for this app.");
+    return { outroMessage: "No changes made" };
+  }
+
+  log.info(
+    `Removing SSO provider: ${theme.styles.bold(current.ssoProviderName ?? "unknown")}`,
+  );
+
+  await runTask(
+    "Removing SSO configuration",
+    async () => await removeSSOConfig(),
+  );
+
+  return { outroMessage: "SSO has been disabled and credentials removed" };
+}
+
+export function getSSORemoveCommand(context: CLIContext): Command {
+  return new Command("remove")
+    .description("Remove SSO identity provider configuration")
+    .action(async () => {
+      await runCommand(removeSSOAction, { requireAuth: true }, context);
+    });
+}

--- a/packages/cli/src/cli/commands/sso/setup.ts
+++ b/packages/cli/src/cli/commands/sso/setup.ts
@@ -1,0 +1,143 @@
+import { confirm, isCancel, log, select } from "@clack/prompts";
+import { Command } from "commander";
+import { CLIExitError } from "@/cli/errors.js";
+import type { CLIContext } from "@/cli/types.js";
+import { runCommand, runTask, theme } from "@/cli/utils/index.js";
+import type { RunCommandResult } from "@/cli/utils/runCommand.js";
+import {
+  type AuthConfig,
+  CREDENTIALS_KEY_MAP,
+  getAuthConfig,
+  type KnownSSOProvider,
+  submitSSOConfig,
+} from "@/core/auth-config/index.js";
+import {
+  promptCustomCredentials,
+  promptGitHubCredentials,
+  promptGoogleCredentials,
+  promptMicrosoftCredentials,
+  promptOktaCredentials,
+  type SSOCredentials,
+} from "./providers/index.js";
+
+async function promptSSOProvider(): Promise<KnownSSOProvider> {
+  const provider = await select({
+    message: "Select SSO provider",
+    options: [
+      {
+        value: "google" as const,
+        label: "Google",
+        hint: "Google Workspace / Google Identity",
+      },
+      {
+        value: "microsoft" as const,
+        label: "Microsoft",
+        hint: "Microsoft Entra ID / Azure AD",
+      },
+      {
+        value: "github" as const,
+        label: "GitHub",
+        hint: "GitHub OAuth",
+      },
+      {
+        value: "okta" as const,
+        label: "Okta",
+        hint: "Okta OIDC",
+      },
+      {
+        value: "custom" as const,
+        label: "Custom",
+        hint: "Manual OIDC / OAuth configuration",
+      },
+    ],
+  });
+
+  if (isCancel(provider)) {
+    throw new CLIExitError(0);
+  }
+
+  return provider;
+}
+
+const credentialPrompters: Record<
+  KnownSSOProvider,
+  () => Promise<SSOCredentials>
+> = {
+  google: promptGoogleCredentials,
+  microsoft: promptMicrosoftCredentials,
+  github: promptGitHubCredentials,
+  okta: promptOktaCredentials,
+  custom: promptCustomCredentials,
+};
+
+function buildSecretsPayload(
+  credentials: SSOCredentials,
+): Record<string, string> {
+  const secrets: Record<string, string> = {};
+
+  for (const [camelKey, snakeKey] of Object.entries(CREDENTIALS_KEY_MAP)) {
+    const value = (credentials as unknown as Record<string, unknown>)[camelKey];
+    if (typeof value === "string" && value.length > 0) {
+      secrets[snakeKey] = value;
+    }
+  }
+
+  return secrets;
+}
+
+function printAuthConfigSummary(config: AuthConfig): void {
+  log.info(theme.styles.bold("Updated authentication config:"));
+  log.info(
+    `  SSO Login:      ${config.enableSSOLogin ? "enabled" : "disabled"}`,
+  );
+  log.info(`  SSO Provider:   ${config.ssoProviderName ?? "none"}`);
+}
+
+async function setupSSOAction(): Promise<RunCommandResult> {
+  const current = await runTask(
+    "Fetching current auth config",
+    async () => await getAuthConfig(),
+  );
+
+  if (current.enableSSOLogin) {
+    log.warn(
+      `SSO is already enabled with provider: ${theme.styles.bold(current.ssoProviderName ?? "unknown")}`,
+    );
+
+    const shouldContinue = await confirm({
+      message: "Do you want to replace the existing SSO configuration?",
+    });
+
+    if (isCancel(shouldContinue) || !shouldContinue) {
+      throw new CLIExitError(0);
+    }
+  }
+
+  const provider = await promptSSOProvider();
+  const credentials = await credentialPrompters[provider]();
+  const secrets = buildSecretsPayload(credentials);
+
+  const updated = await runTask(
+    "Configuring SSO",
+    async () =>
+      await submitSSOConfig(secrets, {
+        ssoProviderName: credentials.ssoName,
+        enableSSOLogin: true,
+        useWorkspaceSSO: false,
+      }),
+  );
+
+  printAuthConfigSummary(updated);
+
+  return {
+    outroMessage: `SSO configured with ${provider}`,
+  };
+}
+
+export function getSSOSetupCommand(context: CLIContext): Command {
+  return new Command("setup")
+    .description("Configure SSO identity provider for the app")
+    .action(async () => {
+      await runCommand(setupSSOAction, { requireAuth: true }, context);
+    });
+}

--- a/packages/cli/src/cli/program.ts
+++ b/packages/cli/src/cli/program.ts
@@ -13,6 +13,7 @@ import { getLinkCommand } from "@/cli/commands/project/link.js";
 import { getLogsCommand } from "@/cli/commands/project/logs.js";
 import { getSecretsCommand } from "@/cli/commands/secrets/index.js";
 import { getSiteCommand } from "@/cli/commands/site/index.js";
+import { getSSOCommand } from "@/cli/commands/sso/index.js";
 import { getTypesCommand } from "@/cli/commands/types/index.js";
 import packageJson from "../../package.json";
 import { getDevCommand } from "./commands/dev.js";
@@ -59,6 +60,9 @@ export function createProgram(context: CLIContext): Command {
 
   // Register secrets commands
   program.addCommand(getSecretsCommand(context));
+
+  // Register SSO commands
+  program.addCommand(getSSOCommand(context));
 
   // Register site commands
   program.addCommand(getSiteCommand(context));

--- a/packages/cli/src/core/auth-config/api.ts
+++ b/packages/cli/src/core/auth-config/api.ts
@@ -1,0 +1,121 @@
+import type { KyResponse } from "ky";
+import { base44Client } from "@/core/clients/index.js";
+import { ApiError, SchemaValidationError } from "@/core/errors.js";
+import { getAppConfig } from "@/core/project/index.js";
+import { deleteSecret, setSecrets } from "@/core/resources/secret/index.js";
+import type { AuthConfig } from "./schema.js";
+import { AppAuthConfigResponseSchema, toAuthConfigPayload } from "./schema.js";
+
+/**
+ * Fetches the current auth config for the app.
+ */
+export async function getAuthConfig(): Promise<AuthConfig> {
+  const { id } = getAppConfig();
+
+  let response: KyResponse;
+  try {
+    response = await base44Client.get(`api/apps/${id}`);
+  } catch (error) {
+    throw await ApiError.fromHttpError(error, "fetching auth config");
+  }
+
+  const result = AppAuthConfigResponseSchema.safeParse(await response.json());
+
+  if (!result.success) {
+    throw new SchemaValidationError(
+      "Invalid response from server",
+      result.error,
+    );
+  }
+
+  return result.data.authConfig;
+}
+
+/**
+ * Updates the auth config for the app.
+ * Merges the partial update with the current config via a read-modify-write cycle.
+ */
+async function updateAuthConfig(
+  updates: Partial<AuthConfig>,
+): Promise<AuthConfig> {
+  const current = await getAuthConfig();
+  const merged: AuthConfig = { ...current, ...updates };
+
+  const { id } = getAppConfig();
+
+  let response: KyResponse;
+  try {
+    response = await base44Client.put(`api/apps/${id}`, {
+      json: { auth_config: toAuthConfigPayload(merged) },
+    });
+  } catch (error) {
+    throw await ApiError.fromHttpError(error, "updating auth config");
+  }
+
+  const result = AppAuthConfigResponseSchema.safeParse(await response.json());
+
+  if (!result.success) {
+    throw new SchemaValidationError(
+      "Invalid response from server",
+      result.error,
+    );
+  }
+
+  return result.data.authConfig;
+}
+
+/**
+ * Single source of truth for the mapping between camelCase credential keys
+ * (used in SSOCredentials types) and snake_case secret keys (used by the API).
+ */
+export const CREDENTIALS_KEY_MAP: Record<string, string> = {
+  ssoName: "sso_name",
+  ssoClientId: "sso_client_id",
+  ssoClientSecret: "sso_client_secret",
+  ssoScope: "sso_scope",
+  ssoDiscoveryUrl: "sso_discovery_url",
+  ssoTenantId: "sso_tenant_id",
+  ssoAuthEndpoint: "sso_auth_endpoint",
+  ssoTokenEndpoint: "sso_token_endpoint",
+  ssoUserinfoEndpoint: "sso_userinfo_endpoint",
+  ssoOktaDomain: "sso_okta_domain",
+  ssoJwksUri: "sso_jwks_uri",
+};
+
+/** All possible SSO secret keys, derived from CREDENTIALS_KEY_MAP. */
+const SSO_SECRET_KEYS = Object.values(CREDENTIALS_KEY_MAP);
+
+/**
+ * Removes SSO configuration: disables SSO in auth config and deletes all SSO secrets.
+ */
+export async function removeSSOConfig(): Promise<AuthConfig> {
+  const updated = await updateAuthConfig({
+    enableSSOLogin: false,
+    ssoProviderName: null,
+  });
+
+  // Best-effort cleanup of all SSO secrets
+  await Promise.allSettled(SSO_SECRET_KEYS.map((key) => deleteSecret(key)));
+
+  return updated;
+}
+
+/**
+ * Sets SSO secrets and updates auth config atomically.
+ * If the auth config update fails, rolls back the secrets that were set.
+ */
+export async function submitSSOConfig(
+  secrets: Record<string, string>,
+  authConfigUpdates: Partial<AuthConfig>,
+): Promise<AuthConfig> {
+  await setSecrets(secrets);
+
+  try {
+    return await updateAuthConfig(authConfigUpdates);
+  } catch (error) {
+    // Best-effort rollback — don't mask the original error
+    const secretKeys = Object.keys(secrets);
+    await Promise.allSettled(secretKeys.map((key) => deleteSecret(key)));
+    throw error;
+  }
+}

--- a/packages/cli/src/core/auth-config/index.ts
+++ b/packages/cli/src/core/auth-config/index.ts
@@ -1,0 +1,15 @@
+export {
+  CREDENTIALS_KEY_MAP,
+  getAuthConfig,
+  removeSSOConfig,
+  submitSSOConfig,
+} from "./api.js";
+export type {
+  AuthConfig,
+  KnownSSOProvider,
+} from "./schema.js";
+export {
+  AppAuthConfigResponseSchema,
+  AuthConfigSchema,
+  toAuthConfigPayload,
+} from "./schema.js";

--- a/packages/cli/src/core/auth-config/schema.ts
+++ b/packages/cli/src/core/auth-config/schema.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+const KnownSSOProviders = [
+  "google",
+  "microsoft",
+  "github",
+  "okta",
+  "custom",
+] as const;
+
+export type KnownSSOProvider = (typeof KnownSSOProviders)[number];
+
+const GoogleOAuthMode = z.enum(["default", "custom"]);
+
+/**
+ * Schema for the auth_config object returned by the API (snake_case).
+ * Transforms to camelCase for internal use.
+ */
+export const AuthConfigSchema = z
+  .object({
+    enable_username_password: z.boolean(),
+    enable_google_login: z.boolean(),
+    enable_microsoft_login: z.boolean(),
+    enable_facebook_login: z.boolean(),
+    enable_apple_login: z.boolean(),
+    sso_provider_name: z.string().nullable(),
+    enable_sso_login: z.boolean(),
+    google_oauth_mode: GoogleOAuthMode,
+    google_oauth_client_id: z.string().nullable(),
+    use_workspace_sso: z.boolean(),
+  })
+  .transform((data) => ({
+    enableUsernamePassword: data.enable_username_password,
+    enableGoogleLogin: data.enable_google_login,
+    enableMicrosoftLogin: data.enable_microsoft_login,
+    enableFacebookLogin: data.enable_facebook_login,
+    enableAppleLogin: data.enable_apple_login,
+    ssoProviderName: data.sso_provider_name,
+    enableSSOLogin: data.enable_sso_login,
+    googleOAuthMode: data.google_oauth_mode,
+    googleOAuthClientId: data.google_oauth_client_id,
+    useWorkspaceSSO: data.use_workspace_sso,
+  }));
+
+export type AuthConfig = z.infer<typeof AuthConfigSchema>;
+
+/**
+ * Schema for the app response — we only care about auth_config.
+ */
+export const AppAuthConfigResponseSchema = z
+  .object({
+    auth_config: AuthConfigSchema,
+  })
+  .transform((data) => ({
+    authConfig: data.auth_config,
+  }));
+
+/**
+ * Converts camelCase AuthConfig back to snake_case for the API request body.
+ */
+export function toAuthConfigPayload(
+  config: AuthConfig,
+): Record<string, unknown> {
+  return {
+    enable_username_password: config.enableUsernamePassword,
+    enable_google_login: config.enableGoogleLogin,
+    enable_microsoft_login: config.enableMicrosoftLogin,
+    enable_facebook_login: config.enableFacebookLogin,
+    enable_apple_login: config.enableAppleLogin,
+    sso_provider_name: config.ssoProviderName,
+    enable_sso_login: config.enableSSOLogin,
+    google_oauth_mode: config.googleOAuthMode,
+    google_oauth_client_id: config.googleOAuthClientId,
+    use_workspace_sso: config.useWorkspaceSSO,
+  };
+}

--- a/packages/cli/src/core/index.ts
+++ b/packages/cli/src/core/index.ts
@@ -1,4 +1,5 @@
 export * from "./auth/index.js";
+export * from "./auth-config/index.js";
 export * from "./clients/index.js";
 export * from "./config.js";
 export * from "./consts.js";

--- a/packages/cli/tests/cli/sso_remove.spec.ts
+++ b/packages/cli/tests/cli/sso_remove.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it } from "vitest";
+import { setupCLITests } from "./testkit/index.js";
+
+describe("sso remove command", () => {
+  const t = setupCLITests();
+
+  it("fails when not in a project directory", async () => {
+    await t.givenLoggedIn({ email: "test@example.com", name: "Test User" });
+
+    const result = await t.run("sso", "remove");
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("No Base44 project found");
+  });
+
+  it("shows help with --help flag", async () => {
+    const result = await t.run("sso", "remove", "--help");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("Remove SSO identity provider");
+  });
+
+  it("shows remove in sso subcommands", async () => {
+    const result = await t.run("sso", "--help");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("remove");
+  });
+});

--- a/packages/cli/tests/cli/sso_setup.spec.ts
+++ b/packages/cli/tests/cli/sso_setup.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it } from "vitest";
+import { setupCLITests } from "./testkit/index.js";
+
+describe("sso setup command", () => {
+  const t = setupCLITests();
+
+  it("fails when not in a project directory", async () => {
+    await t.givenLoggedIn({ email: "test@example.com", name: "Test User" });
+
+    const result = await t.run("sso", "setup");
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("No Base44 project found");
+  });
+
+  it("shows help with --help flag", async () => {
+    const result = await t.run("sso", "setup", "--help");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("Configure SSO identity provider");
+  });
+
+  it("shows sso subcommands with --help on parent", async () => {
+    const result = await t.run("sso", "--help");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("setup");
+    t.expectResult(result).toContain("Manage SSO identity provider");
+  });
+});

--- a/packages/cli/tests/core/auth-config.spec.ts
+++ b/packages/cli/tests/core/auth-config.spec.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  AppAuthConfigResponseSchema,
+  AuthConfigSchema,
+  toAuthConfigPayload,
+} from "../../src/core/auth-config/schema.js";
+
+describe("AuthConfigSchema", () => {
+  const validApiResponse = {
+    enable_username_password: true,
+    enable_google_login: true,
+    enable_microsoft_login: false,
+    enable_facebook_login: false,
+    enable_apple_login: false,
+    sso_provider_name: "google",
+    enable_sso_login: true,
+    google_oauth_mode: "default",
+    google_oauth_client_id: null,
+    use_workspace_sso: false,
+  };
+
+  it("transforms snake_case API response to camelCase", () => {
+    const result = AuthConfigSchema.safeParse(validApiResponse);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.data).toEqual({
+      enableUsernamePassword: true,
+      enableGoogleLogin: true,
+      enableMicrosoftLogin: false,
+      enableFacebookLogin: false,
+      enableAppleLogin: false,
+      ssoProviderName: "google",
+      enableSSOLogin: true,
+      googleOAuthMode: "default",
+      googleOAuthClientId: null,
+      useWorkspaceSSO: false,
+    });
+  });
+
+  it("accepts null sso_provider_name", () => {
+    const response = { ...validApiResponse, sso_provider_name: null };
+    const result = AuthConfigSchema.safeParse(response);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.ssoProviderName).toBeNull();
+  });
+
+  it("accepts any string as sso_provider_name", () => {
+    const response = {
+      ...validApiResponse,
+      sso_provider_name: "my-custom-idp",
+    };
+    const result = AuthConfigSchema.safeParse(response);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.ssoProviderName).toBe("my-custom-idp");
+  });
+
+  it("rejects missing required fields", () => {
+    const result = AuthConfigSchema.safeParse({
+      enable_username_password: true,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("AppAuthConfigResponseSchema", () => {
+  it("extracts and transforms auth_config from app response", () => {
+    const appResponse = {
+      auth_config: {
+        enable_username_password: true,
+        enable_google_login: false,
+        enable_microsoft_login: false,
+        enable_facebook_login: false,
+        enable_apple_login: false,
+        sso_provider_name: "okta",
+        enable_sso_login: true,
+        google_oauth_mode: "default",
+        google_oauth_client_id: null,
+        use_workspace_sso: true,
+      },
+    };
+
+    const result = AppAuthConfigResponseSchema.safeParse(appResponse);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.authConfig.ssoProviderName).toBe("okta");
+    expect(result.data.authConfig.enableSSOLogin).toBe(true);
+    expect(result.data.authConfig.useWorkspaceSSO).toBe(true);
+  });
+});
+
+describe("toAuthConfigPayload", () => {
+  it("converts camelCase back to snake_case", () => {
+    const config = {
+      enableUsernamePassword: true,
+      enableGoogleLogin: true,
+      enableMicrosoftLogin: false,
+      enableFacebookLogin: false,
+      enableAppleLogin: false,
+      ssoProviderName: "github",
+      enableSSOLogin: true,
+      googleOAuthMode: "default" as const,
+      googleOAuthClientId: null,
+      useWorkspaceSSO: false,
+    };
+
+    const payload = toAuthConfigPayload(config);
+
+    expect(payload).toEqual({
+      enable_username_password: true,
+      enable_google_login: true,
+      enable_microsoft_login: false,
+      enable_facebook_login: false,
+      enable_apple_login: false,
+      sso_provider_name: "github",
+      enable_sso_login: true,
+      google_oauth_mode: "default",
+      google_oauth_client_id: null,
+      use_workspace_sso: false,
+    });
+  });
+});

--- a/packages/cli/tests/core/sso-providers.spec.ts
+++ b/packages/cli/tests/core/sso-providers.spec.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import type {
+  CustomSSOCredentials,
+  GitHubSSOCredentials,
+  GoogleSSOCredentials,
+  MicrosoftSSOCredentials,
+  OktaSSOCredentials,
+  SSOCredentials,
+} from "../../src/cli/commands/sso/providers/types.js";
+
+/**
+ * These tests verify the SSOCredentials type system:
+ * - Each provider type has only its required fields
+ * - The union type accepts all provider types
+ * - The buildSecretsPayload-compatible key mapping works
+ */
+
+const CREDENTIALS_KEY_MAP: Record<string, string> = {
+  ssoName: "sso_name",
+  ssoClientId: "sso_client_id",
+  ssoClientSecret: "sso_client_secret",
+  ssoScope: "sso_scope",
+  ssoDiscoveryUrl: "sso_discovery_url",
+  ssoTenantId: "sso_tenant_id",
+  ssoAuthEndpoint: "sso_auth_endpoint",
+  ssoTokenEndpoint: "sso_token_endpoint",
+  ssoUserinfoEndpoint: "sso_userinfo_endpoint",
+  ssoOktaDomain: "sso_okta_domain",
+  ssoJwksUri: "sso_jwks_uri",
+};
+
+function buildSecretsPayload(
+  credentials: SSOCredentials,
+): Record<string, string> {
+  const secrets: Record<string, string> = {};
+  for (const [camelKey, snakeKey] of Object.entries(CREDENTIALS_KEY_MAP)) {
+    const value = (credentials as unknown as Record<string, unknown>)[camelKey];
+    if (typeof value === "string" && value.length > 0) {
+      secrets[snakeKey] = value;
+    }
+  }
+  return secrets;
+}
+
+describe("Google SSO credentials", () => {
+  const google: GoogleSSOCredentials = {
+    ssoName: "google",
+    ssoClientId: "client-id",
+    ssoClientSecret: "client-secret",
+    ssoScope: "openid email profile",
+    ssoDiscoveryUrl:
+      "https://accounts.google.com/.well-known/openid-configuration",
+  };
+
+  it("builds correct secrets payload", () => {
+    const payload = buildSecretsPayload(google);
+
+    expect(payload).toEqual({
+      sso_name: "google",
+      sso_client_id: "client-id",
+      sso_client_secret: "client-secret",
+      sso_scope: "openid email profile",
+      sso_discovery_url:
+        "https://accounts.google.com/.well-known/openid-configuration",
+    });
+  });
+
+  it("does not include provider-specific fields from other providers", () => {
+    const payload = buildSecretsPayload(google);
+
+    expect(payload).not.toHaveProperty("sso_tenant_id");
+    expect(payload).not.toHaveProperty("sso_auth_endpoint");
+    expect(payload).not.toHaveProperty("sso_okta_domain");
+    expect(payload).not.toHaveProperty("sso_jwks_uri");
+  });
+});
+
+describe("Microsoft SSO credentials", () => {
+  const microsoft: MicrosoftSSOCredentials = {
+    ssoName: "microsoft",
+    ssoClientId: "client-id",
+    ssoClientSecret: "client-secret",
+    ssoScope: "openid email profile",
+    ssoDiscoveryUrl:
+      "https://login.microsoftonline.com/tenant-123/v2.0/.well-known/openid-configuration",
+    ssoTenantId: "tenant-123",
+  };
+
+  it("builds correct secrets payload with tenant ID", () => {
+    const payload = buildSecretsPayload(microsoft);
+
+    expect(payload).toEqual({
+      sso_name: "microsoft",
+      sso_client_id: "client-id",
+      sso_client_secret: "client-secret",
+      sso_scope: "openid email profile",
+      sso_discovery_url:
+        "https://login.microsoftonline.com/tenant-123/v2.0/.well-known/openid-configuration",
+      sso_tenant_id: "tenant-123",
+    });
+  });
+});
+
+describe("GitHub SSO credentials", () => {
+  const github: GitHubSSOCredentials = {
+    ssoName: "github",
+    ssoClientId: "client-id",
+    ssoClientSecret: "client-secret",
+    ssoScope: "user:email",
+    ssoAuthEndpoint: "https://github.com/login/oauth/authorize",
+    ssoTokenEndpoint: "https://github.com/login/oauth/access_token",
+    ssoUserinfoEndpoint: "https://api.github.com/user",
+  };
+
+  it("builds correct secrets payload with endpoints", () => {
+    const payload = buildSecretsPayload(github);
+
+    expect(payload).toEqual({
+      sso_name: "github",
+      sso_client_id: "client-id",
+      sso_client_secret: "client-secret",
+      sso_scope: "user:email",
+      sso_auth_endpoint: "https://github.com/login/oauth/authorize",
+      sso_token_endpoint: "https://github.com/login/oauth/access_token",
+      sso_userinfo_endpoint: "https://api.github.com/user",
+    });
+  });
+
+  it("does not include discovery URL", () => {
+    const payload = buildSecretsPayload(github);
+    expect(payload).not.toHaveProperty("sso_discovery_url");
+  });
+});
+
+describe("Okta SSO credentials", () => {
+  const okta: OktaSSOCredentials = {
+    ssoName: "okta",
+    ssoClientId: "client-id",
+    ssoClientSecret: "client-secret",
+    ssoScope: "openid email profile",
+    ssoDiscoveryUrl: "https://my-org.okta.com/.well-known/openid-configuration",
+    ssoOktaDomain: "my-org.okta.com",
+  };
+
+  it("builds correct secrets payload with Okta domain", () => {
+    const payload = buildSecretsPayload(okta);
+
+    expect(payload).toEqual({
+      sso_name: "okta",
+      sso_client_id: "client-id",
+      sso_client_secret: "client-secret",
+      sso_scope: "openid email profile",
+      sso_discovery_url:
+        "https://my-org.okta.com/.well-known/openid-configuration",
+      sso_okta_domain: "my-org.okta.com",
+    });
+  });
+});
+
+describe("Custom SSO credentials", () => {
+  it("builds correct secrets payload with all manual fields", () => {
+    const custom: CustomSSOCredentials = {
+      ssoName: "my-idp",
+      ssoClientId: "client-id",
+      ssoClientSecret: "client-secret",
+      ssoScope: "openid email profile",
+      ssoDiscoveryUrl:
+        "https://idp.example.com/.well-known/openid-configuration",
+      ssoAuthEndpoint: "https://idp.example.com/authorize",
+      ssoTokenEndpoint: "https://idp.example.com/token",
+      ssoUserinfoEndpoint: "https://idp.example.com/userinfo",
+      ssoJwksUri: "https://idp.example.com/.well-known/jwks.json",
+    };
+
+    const payload = buildSecretsPayload(custom);
+
+    expect(payload).toEqual({
+      sso_name: "my-idp",
+      sso_client_id: "client-id",
+      sso_client_secret: "client-secret",
+      sso_scope: "openid email profile",
+      sso_discovery_url:
+        "https://idp.example.com/.well-known/openid-configuration",
+      sso_auth_endpoint: "https://idp.example.com/authorize",
+      sso_token_endpoint: "https://idp.example.com/token",
+      sso_userinfo_endpoint: "https://idp.example.com/userinfo",
+      sso_jwks_uri: "https://idp.example.com/.well-known/jwks.json",
+    });
+  });
+
+  it("omits optional discovery URL when not provided", () => {
+    const custom: CustomSSOCredentials = {
+      ssoName: "my-idp",
+      ssoClientId: "client-id",
+      ssoClientSecret: "client-secret",
+      ssoScope: "openid email profile",
+      ssoAuthEndpoint: "https://idp.example.com/authorize",
+      ssoTokenEndpoint: "https://idp.example.com/token",
+      ssoUserinfoEndpoint: "https://idp.example.com/userinfo",
+      ssoJwksUri: "https://idp.example.com/.well-known/jwks.json",
+    };
+
+    const payload = buildSecretsPayload(custom);
+
+    expect(payload).not.toHaveProperty("sso_discovery_url");
+  });
+});

--- a/packages/cli/tests/core/sso-submit.spec.ts
+++ b/packages/cli/tests/core/sso-submit.spec.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthConfig } from "../../src/core/auth-config/schema.js";
+
+// Mock project config
+vi.mock("../../src/core/project/index.js", () => ({
+  getAppConfig: () => ({ id: "test-app-id" }),
+  initAppConfig: () => ({ id: "test-app-id" }),
+}));
+
+// Mock HTTP client
+const mockGet = vi.fn();
+const mockPut = vi.fn();
+vi.mock("../../src/core/clients/index.js", () => ({
+  base44Client: {
+    get: (...args: unknown[]) => mockGet(...args),
+    put: (...args: unknown[]) => mockPut(...args),
+  },
+}));
+
+// Mock secrets
+const mockSetSecrets = vi.fn();
+const mockDeleteSecret = vi.fn();
+vi.mock("../../src/core/resources/secret/index.js", () => ({
+  setSecrets: (...args: unknown[]) => mockSetSecrets(...args),
+  deleteSecret: (...args: unknown[]) => mockDeleteSecret(...args),
+}));
+
+import {
+  removeSSOConfig,
+  submitSSOConfig,
+} from "../../src/core/auth-config/api.js";
+
+const DEFAULT_AUTH_CONFIG = {
+  enable_username_password: true,
+  enable_google_login: false,
+  enable_microsoft_login: false,
+  enable_facebook_login: false,
+  enable_apple_login: false,
+  sso_provider_name: null,
+  enable_sso_login: false,
+  google_oauth_mode: "default",
+  google_oauth_client_id: null,
+  use_workspace_sso: false,
+};
+
+function mockAppResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    json: () =>
+      Promise.resolve({
+        auth_config: { ...DEFAULT_AUTH_CONFIG, ...overrides },
+      }),
+  };
+}
+
+describe("submitSSOConfig", () => {
+  const secrets = {
+    sso_name: "google",
+    sso_client_id: "client-id",
+    sso_client_secret: "client-secret",
+    sso_scope: "openid email profile",
+    sso_discovery_url:
+      "https://accounts.google.com/.well-known/openid-configuration",
+  };
+
+  const authConfigUpdates: Partial<AuthConfig> = {
+    ssoProviderName: "google",
+    enableSSOLogin: true,
+    useWorkspaceSSO: false,
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockSetSecrets.mockResolvedValue({ success: true });
+    mockDeleteSecret.mockResolvedValue({ success: true });
+  });
+
+  it("sets secrets and updates auth config on success", async () => {
+    // GET for updateAuthConfig's internal getAuthConfig call
+    mockGet.mockResolvedValue(mockAppResponse());
+    // PUT for updateAuthConfig
+    mockPut.mockResolvedValue(
+      mockAppResponse({
+        sso_provider_name: "google",
+        enable_sso_login: true,
+      }),
+    );
+
+    const result = await submitSSOConfig(secrets, authConfigUpdates);
+
+    expect(mockSetSecrets).toHaveBeenCalledWith(secrets);
+    expect(mockPut).toHaveBeenCalledOnce();
+    expect(result.ssoProviderName).toBe("google");
+    expect(result.enableSSOLogin).toBe(true);
+    // No rollback should have happened
+    expect(mockDeleteSecret).not.toHaveBeenCalled();
+  });
+
+  it("rolls back secrets when auth config update fails", async () => {
+    // GET for updateAuthConfig's internal getAuthConfig call
+    mockGet.mockResolvedValue(mockAppResponse());
+    // PUT fails
+    mockPut.mockRejectedValue(new Error("Server error"));
+
+    await expect(submitSSOConfig(secrets, authConfigUpdates)).rejects.toThrow();
+
+    // Secrets were set first
+    expect(mockSetSecrets).toHaveBeenCalledWith(secrets);
+    // All secret keys were deleted as rollback
+    expect(mockDeleteSecret).toHaveBeenCalledTimes(Object.keys(secrets).length);
+    for (const key of Object.keys(secrets)) {
+      expect(mockDeleteSecret).toHaveBeenCalledWith(key);
+    }
+  });
+
+  it("does not roll back secrets when setSecrets itself fails", async () => {
+    mockSetSecrets.mockRejectedValue(new Error("Secrets API error"));
+
+    await expect(submitSSOConfig(secrets, authConfigUpdates)).rejects.toThrow(
+      "Secrets API error",
+    );
+
+    // No auth config update or rollback should have happened
+    expect(mockGet).not.toHaveBeenCalled();
+    expect(mockPut).not.toHaveBeenCalled();
+    expect(mockDeleteSecret).not.toHaveBeenCalled();
+  });
+
+  it("still throws original error if rollback also fails", async () => {
+    mockGet.mockResolvedValue(mockAppResponse());
+    mockPut.mockRejectedValue(new Error("Auth config failed"));
+    mockDeleteSecret.mockRejectedValue(new Error("Delete failed"));
+
+    await expect(submitSSOConfig(secrets, authConfigUpdates)).rejects.toThrow(
+      "Auth config failed",
+    );
+
+    // Rollback was attempted
+    expect(mockDeleteSecret).toHaveBeenCalled();
+  });
+});
+
+describe("removeSSOConfig", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockDeleteSecret.mockResolvedValue({ success: true });
+  });
+
+  it("disables SSO and deletes all SSO secrets", async () => {
+    // GET for updateAuthConfig's internal getAuthConfig
+    mockGet.mockResolvedValue(
+      mockAppResponse({
+        sso_provider_name: "google",
+        enable_sso_login: true,
+      }),
+    );
+    // PUT to disable SSO
+    mockPut.mockResolvedValue(
+      mockAppResponse({
+        sso_provider_name: null,
+        enable_sso_login: false,
+      }),
+    );
+
+    const result = await removeSSOConfig();
+
+    expect(result.enableSSOLogin).toBe(false);
+    expect(result.ssoProviderName).toBeNull();
+    // Should attempt to delete all possible SSO secret keys
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_name");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_client_id");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_client_secret");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_scope");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_discovery_url");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_tenant_id");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_auth_endpoint");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_token_endpoint");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_userinfo_endpoint");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_okta_domain");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_jwks_uri");
+  });
+
+  it("still succeeds if some secret deletions fail", async () => {
+    mockGet.mockResolvedValue(
+      mockAppResponse({
+        sso_provider_name: "google",
+        enable_sso_login: true,
+      }),
+    );
+    mockPut.mockResolvedValue(
+      mockAppResponse({
+        sso_provider_name: null,
+        enable_sso_login: false,
+      }),
+    );
+    // Some secrets don't exist — delete fails for them
+    mockDeleteSecret.mockRejectedValue(new Error("Not found"));
+
+    const result = await removeSSOConfig();
+
+    // Should still succeed — secret deletion is best-effort
+    expect(result.enableSSOLogin).toBe(false);
+    expect(result.ssoProviderName).toBeNull();
+  });
+
+  it("throws if auth config update fails", async () => {
+    mockGet.mockResolvedValue(mockAppResponse());
+    mockPut.mockRejectedValue(new Error("Server error"));
+
+    await expect(removeSSOConfig()).rejects.toThrow();
+
+    // Secret deletion should not have been attempted
+    expect(mockDeleteSecret).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Adds a new `base44 sso` command group that enables users to configure and remove SSO (Single Sign-On) identity provider settings for their Base44 apps directly from the CLI. The `sso setup` subcommand provides an interactive wizard supporting Google, Microsoft, GitHub, Okta, and custom OIDC providers, while `sso remove` disables SSO and cleans up stored secrets.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added `packages/cli/src/cli/commands/sso/` command group with `setup` and `remove` subcommands
> - Added provider-specific credential prompt flows for Google, Microsoft, GitHub, Okta, and custom OIDC
> - Added `packages/cli/src/core/auth-config/` module with Zod schemas, API functions (`getAuthConfig`, `submitSSOConfig`, `removeSSOConfig`), and a `CREDENTIALS_KEY_MAP` for camelCase <-> snake_case translation
> - `submitSSOConfig` sets secrets then updates auth config with rollback on failure; `removeSSOConfig` does best-effort cleanup of all SSO secrets
> - Registered the new `sso` command in `program.ts`
> - Added CLI integration tests (`sso_setup.spec.ts`, `sso_remove.spec.ts`) and core unit tests (`auth-config.spec.ts`, `sso-providers.spec.ts`, `sso-submit.spec.ts`)
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The `sso setup` command performs a read-modify-write cycle on the auth config (fetches current config, merges updates, PUTs back) so existing non-SSO auth settings are preserved. If the app already has SSO configured, the user is prompted to confirm replacement before proceeding.
>
> ---
> <sub>Generated by Claude | 2026-03-09 00:00 UTC</sub>