### PR TITLE
feat: add binary test infrastructure (tests/binary/)

### DIFF
--- a/packages/cli/tests/binary/deploy.spec.ts
+++ b/packages/cli/tests/binary/deploy.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Binary integration tests for the deploy command.
+ *
+ * These tests spawn the real `bin/run.js` process against a local
+ * Express mock server, verifying the full binary end-to-end.
+ *
+ * **Prerequisite:** Run `bun run build` before executing these tests.
+ * The suite is skipped automatically when the dist is not built.
+ */
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "vitest";
+import { fixture, setupBinaryTests } from "./testkit/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const distExists = existsSync(
+  join(__dirname, "../../dist/cli/index.js"),
+);
+
+describe.skipIf(!distExists)("deploy command (binary)", () => {
+  const t = setupBinaryTests();
+
+  it("reports no resources when project is empty", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+
+    const result = await t.run("deploy", "-y");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("No resources found to deploy");
+  });
+
+  it("fails when not in a project directory", async () => {
+    await t.givenLoggedIn({ email: "test@example.com", name: "Test User" });
+
+    const result = await t.run("deploy", "-y");
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("No Base44 project found");
+  });
+
+  it("deploys entities successfully with -y flag", async () => {
+    await t.givenLoggedInWithProject(fixture("with-entities"));
+    t.api.mockEntitiesPush({
+      created: ["Customer", "Product"],
+      updated: [],
+      deleted: [],
+    });
+    t.api.mockAgentsPush({ created: [], updated: [], deleted: [] });
+    t.api.mockConnectorsList({ integrations: [] });
+
+    const result = await t.run("deploy", "-y");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("Deployment completed");
+    t.expectResult(result).toContain("App deployed successfully");
+  });
+
+  it("deploys entities, functions, and site together", async () => {
+    await t.givenLoggedInWithProject(fixture("full-project"));
+    t.api.mockEntitiesPush({ created: ["Task"], updated: [], deleted: [] });
+    t.api.mockFunctionsPush({ deployed: ["hello"], deleted: [], errors: null });
+    t.api.mockAgentsPush({ created: [], updated: [], deleted: [] });
+    t.api.mockConnectorsList({ integrations: [] });
+    t.api.mockSiteDeploy({ app_url: "https://full-project.base44.app" });
+
+    const result = await t.run("deploy", "-y");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("Deployment completed");
+    t.expectResult(result).toContain("https://full-project.base44.app");
+  });
+
+  it("deploys agents successfully", async () => {
+    await t.givenLoggedInWithProject(fixture("with-agents"));
+    t.api.mockEntitiesPush({ created: [], updated: [], deleted: [] });
+    t.api.mockFunctionsPush({ deployed: [], deleted: [], errors: null });
+    t.api.mockAgentsPush({
+      created: ["customer_support", "order_assistant", "data_analyst"],
+      updated: [],
+      deleted: [],
+    });
+    t.api.mockConnectorsList({ integrations: [] });
+
+    const result = await t.run("deploy", "-y");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("Deployment completed");
+    t.expectResult(result).toContain("App deployed successfully");
+  });
+
+  it("fails gracefully when API returns an error", async () => {
+    await t.givenLoggedInWithProject(fixture("with-entities"));
+    t.api.mockEntitiesPushError({ status: 500, body: { error: "Server error" } });
+    t.api.mockAgentsPush({ created: [], updated: [], deleted: [] });
+    t.api.mockConnectorsList({ integrations: [] });
+
+    const result = await t.run("deploy", "-y");
+
+    t.expectResult(result).toFail();
+  });
+});

--- a/packages/cli/tests/binary/testkit/BinaryAPIServer.ts
+++ b/packages/cli/tests/binary/testkit/BinaryAPIServer.ts
@@ -1,0 +1,388 @@
+import { createServer } from "node:http";
+import type { Server } from "node:http";
+import express from "express";
+import type { Application, Request, Response } from "express";
+import getPort from "get-port";
+
+// ─── RESPONSE TYPES ──────────────────────────────────────────
+
+interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+}
+
+interface TokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  token_type: string;
+}
+
+interface UserInfoResponse {
+  email: string;
+  name?: string;
+}
+
+interface EntitiesPushResponse {
+  created: string[];
+  updated: string[];
+  deleted: string[];
+}
+
+interface FunctionsPushResponse {
+  deployed: string[];
+  deleted: string[];
+  errors: Array<{ name: string; message: string }> | null;
+}
+
+interface SiteDeployResponse {
+  app_url: string;
+}
+
+interface SiteUrlResponse {
+  url: string;
+}
+
+interface AgentsPushResponse {
+  created: string[];
+  updated: string[];
+  deleted: string[];
+}
+
+interface AgentsFetchResponse {
+  items: Array<{ name: string; [key: string]: unknown }>;
+  total: number;
+}
+
+interface FunctionLogEntry {
+  time: string;
+  level: "info" | "warning" | "error" | "debug";
+  message: string;
+}
+
+type FunctionLogsResponse = FunctionLogEntry[];
+
+type SecretsListResponse = Record<string, string>;
+
+interface SecretsSetResponse {
+  success: boolean;
+}
+
+interface SecretsDeleteResponse {
+  success: boolean;
+}
+
+interface ConnectorsListResponse {
+  integrations: Array<{
+    integration_type: string;
+    status: string;
+    scopes: string[];
+    user_email?: string;
+  }>;
+}
+
+interface ConnectorSetResponse {
+  redirect_url: string | null;
+  connection_id: string | null;
+  already_authorized: boolean;
+  error?: "different_user";
+  error_message?: string;
+  other_user_email?: string;
+}
+
+interface ConnectorRemoveResponse {
+  status: "removed";
+  integration_type: string;
+}
+
+interface CreateAppResponse {
+  id: string;
+  name: string;
+}
+
+interface ListProjectsResponse {
+  id: string;
+  name: string;
+  user_description?: string | null;
+  is_managed_source_code?: boolean;
+}
+
+interface ErrorResponse {
+  status: number;
+  body?: unknown;
+}
+
+// ─── SERVER CLASS ──────────────────────────────────────────────
+
+/**
+ * Real HTTP server that serves mocked Base44 API responses.
+ * Used by BinaryTestkit to test the actual CLI binary end-to-end.
+ *
+ * Each mock method registers an Express route on the server.
+ * Since a fresh BinaryAPIServer is created per test, route isolation
+ * is automatic — no reset needed.
+ *
+ * @example
+ * ```typescript
+ * const server = new BinaryAPIServer("my-app-id");
+ * await server.start();
+ * server.mockEntitiesPush({ created: ["User"], updated: [], deleted: [] });
+ * // ... run binary with BASE44_API_URL=server.baseUrl ...
+ * await server.stop();
+ * ```
+ */
+export class BinaryAPIServer {
+  private app: Application;
+  private server: Server | null = null;
+  private _port = 0;
+
+  constructor(readonly appId: string) {
+    this.app = express();
+    this.app.use(express.json());
+  }
+
+  get baseUrl(): string {
+    return `http://localhost:${this._port}`;
+  }
+
+  async start(): Promise<void> {
+    this._port = await getPort();
+    await new Promise<void>((resolve, reject) => {
+      this.server = this.app.listen(this._port, () => resolve());
+      this.server!.on("error", reject);
+    });
+  }
+
+  async stop(): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      if (!this.server) {
+        resolve();
+        return;
+      }
+      this.server.close((err) => (err ? reject(err) : resolve()));
+    });
+    this.server = null;
+  }
+
+  private addRoute(
+    method: "get" | "post" | "put" | "delete",
+    path: string,
+    body: unknown,
+    status = 200,
+  ): this {
+    this.app[method](path, (_req: Request, res: Response) => {
+      res.status(status).json(body);
+    });
+    return this;
+  }
+
+  // ─── AUTH ENDPOINTS ────────────────────────────────────────
+
+  /** Mock POST /oauth/device/code */
+  mockDeviceCode(response: DeviceCodeResponse): this {
+    return this.addRoute("post", "/oauth/device/code", response);
+  }
+
+  /** Mock POST /oauth/token */
+  mockToken(response: TokenResponse): this {
+    return this.addRoute("post", "/oauth/token", response);
+  }
+
+  /** Mock GET /oauth/userinfo */
+  mockUserInfo(response: UserInfoResponse): this {
+    return this.addRoute("get", "/oauth/userinfo", response);
+  }
+
+  // ─── APP-SCOPED ENDPOINTS ──────────────────────────────────
+
+  /** Mock PUT /api/apps/{appId}/entity-schemas */
+  mockEntitiesPush(response: EntitiesPushResponse): this {
+    return this.addRoute(
+      "put",
+      `/api/apps/${this.appId}/entity-schemas`,
+      response,
+    );
+  }
+
+  /** Mock PUT /api/apps/{appId}/backend-functions */
+  mockFunctionsPush(response: FunctionsPushResponse): this {
+    return this.addRoute(
+      "put",
+      `/api/apps/${this.appId}/backend-functions`,
+      response,
+    );
+  }
+
+  /** Mock POST /api/apps/{appId}/deploy-dist */
+  mockSiteDeploy(response: SiteDeployResponse): this {
+    return this.addRoute(
+      "post",
+      `/api/apps/${this.appId}/deploy-dist`,
+      response,
+    );
+  }
+
+  /** Mock GET /api/apps/platform/{appId}/published-url */
+  mockSiteUrl(response: SiteUrlResponse): this {
+    return this.addRoute(
+      "get",
+      `/api/apps/platform/${this.appId}/published-url`,
+      response,
+    );
+  }
+
+  /** Mock PUT /api/apps/{appId}/agent-configs */
+  mockAgentsPush(response: AgentsPushResponse): this {
+    return this.addRoute(
+      "put",
+      `/api/apps/${this.appId}/agent-configs`,
+      response,
+    );
+  }
+
+  /** Mock GET /api/apps/{appId}/agent-configs */
+  mockAgentsFetch(response: AgentsFetchResponse): this {
+    return this.addRoute(
+      "get",
+      `/api/apps/${this.appId}/agent-configs`,
+      response,
+    );
+  }
+
+  // ─── CONNECTOR ENDPOINTS ──────────────────────────────────
+
+  /** Mock GET /api/apps/{appId}/external-auth/list */
+  mockConnectorsList(response: ConnectorsListResponse): this {
+    return this.addRoute(
+      "get",
+      `/api/apps/${this.appId}/external-auth/list`,
+      response,
+    );
+  }
+
+  /** Mock PUT /api/apps/{appId}/external-auth/integrations/:type */
+  mockConnectorSet(response: ConnectorSetResponse): this {
+    return this.addRoute(
+      "put",
+      `/api/apps/${this.appId}/external-auth/integrations/:type`,
+      { error: null, error_message: null, other_user_email: null, ...response },
+    );
+  }
+
+  /** Mock DELETE /api/apps/{appId}/external-auth/integrations/:type/remove */
+  mockConnectorRemove(response: ConnectorRemoveResponse): this {
+    return this.addRoute(
+      "delete",
+      `/api/apps/${this.appId}/external-auth/integrations/:type/remove`,
+      response,
+    );
+  }
+
+  // ─── SECRETS ENDPOINTS ──────────────────────────────────────
+
+  /** Mock GET /api/apps/{appId}/secrets */
+  mockSecretsList(response: SecretsListResponse): this {
+    return this.addRoute("get", `/api/apps/${this.appId}/secrets`, response);
+  }
+
+  /** Mock POST /api/apps/{appId}/secrets */
+  mockSecretsSet(response: SecretsSetResponse): this {
+    return this.addRoute("post", `/api/apps/${this.appId}/secrets`, response);
+  }
+
+  /** Mock DELETE /api/apps/{appId}/secrets */
+  mockSecretsDelete(response: SecretsDeleteResponse): this {
+    return this.addRoute(
+      "delete",
+      `/api/apps/${this.appId}/secrets`,
+      response,
+    );
+  }
+
+  // ─── LOGS ENDPOINTS ─────────────────────────────────────────
+
+  /** Mock GET /api/apps/{appId}/functions-mgmt/{functionName}/logs */
+  mockFunctionLogs(functionName: string, response: FunctionLogsResponse): this {
+    return this.addRoute(
+      "get",
+      `/api/apps/${this.appId}/functions-mgmt/${functionName}/logs`,
+      response,
+    );
+  }
+
+  // ─── GENERAL ENDPOINTS ─────────────────────────────────────
+
+  /** Mock POST /api/apps */
+  mockCreateApp(response: CreateAppResponse): this {
+    return this.addRoute("post", "/api/apps", response);
+  }
+
+  /** Mock GET /api/apps */
+  mockListProjects(response: ListProjectsResponse[]): this {
+    return this.addRoute("get", "/api/apps", response);
+  }
+
+  // ─── ERROR HELPERS ──────────────────────────────────────────
+
+  /** Mock any endpoint to return an error */
+  mockError(
+    method: "get" | "post" | "put" | "delete",
+    path: string,
+    error: ErrorResponse,
+  ): this {
+    return this.addRoute(
+      method,
+      path,
+      error.body ?? { error: "Error" },
+      error.status,
+    );
+  }
+
+  /** Mock entities push to return an error */
+  mockEntitiesPushError(error: ErrorResponse): this {
+    return this.mockError(
+      "put",
+      `/api/apps/${this.appId}/entity-schemas`,
+      error,
+    );
+  }
+
+  /** Mock functions push to return an error */
+  mockFunctionsPushError(error: ErrorResponse): this {
+    return this.mockError(
+      "put",
+      `/api/apps/${this.appId}/backend-functions`,
+      error,
+    );
+  }
+
+  /** Mock site deploy to return an error */
+  mockSiteDeployError(error: ErrorResponse): this {
+    return this.mockError(
+      "post",
+      `/api/apps/${this.appId}/deploy-dist`,
+      error,
+    );
+  }
+
+  /** Mock agents push to return an error */
+  mockAgentsPushError(error: ErrorResponse): this {
+    return this.mockError(
+      "put",
+      `/api/apps/${this.appId}/agent-configs`,
+      error,
+    );
+  }
+
+  /** Mock connectors list to return an error */
+  mockConnectorsListError(error: ErrorResponse): this {
+    return this.mockError(
+      "get",
+      `/api/apps/${this.appId}/external-auth/list`,
+      error,
+    );
+  }
+}

--- a/packages/cli/tests/binary/testkit/BinaryTestkit.ts
+++ b/packages/cli/tests/binary/testkit/BinaryTestkit.ts
@@ -1,0 +1,193 @@
+import { access, cp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execa } from "execa";
+import { dir } from "tmp-promise";
+import { BinaryAPIServer } from "./BinaryAPIServer.js";
+import type { CLIResult } from "../../cli/testkit/CLIResultMatcher.js";
+import { CLIResultMatcher } from "../../cli/testkit/CLIResultMatcher.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Path to the CLI entry point (requires dist to be built first) */
+const BIN_PATH = join(__dirname, "../../../bin/run.js");
+
+interface TestOverrides {
+  latestVersion?: string | null;
+  appConfig?: { id: string; projectRoot: string };
+}
+
+/**
+ * Testkit for end-to-end binary tests.
+ *
+ * Spawns the real `bin/run.js` process and points it at a local
+ * Express mock server instead of the real Base44 API.
+ *
+ * **Prerequisite:** `bun run build` must be run before binary tests.
+ *
+ * @example
+ * ```typescript
+ * const kit = await BinaryTestkit.create();
+ * await kit.api.start();
+ * await kit.givenLoggedIn({ email: "test@example.com", name: "Test" });
+ * await kit.givenProject(fixture("with-entities"));
+ * kit.api.mockEntitiesPush({ created: ["User"], updated: [], deleted: [] });
+ * kit.api.mockAgentsPush({ created: [], updated: [], deleted: [] });
+ * kit.api.mockConnectorsList({ integrations: [] });
+ * const result = await kit.run("deploy", "-y");
+ * kit.expect(result).toSucceed();
+ * await kit.cleanup();
+ * ```
+ */
+export class BinaryTestkit {
+  private tempDir: string;
+  private cleanupFn: () => Promise<void>;
+  private projectDir?: string;
+  // Default latestVersion to null to skip npm version check in tests
+  private testOverrides: TestOverrides = { latestVersion: null };
+
+  /** Mock HTTP server for Base44 API endpoints */
+  readonly api: BinaryAPIServer;
+
+  private constructor(
+    tempDir: string,
+    cleanupFn: () => Promise<void>,
+    appId: string,
+  ) {
+    this.tempDir = tempDir;
+    this.cleanupFn = cleanupFn;
+    this.api = new BinaryAPIServer(appId);
+  }
+
+  /** Factory method - creates isolated test environment */
+  static async create(appId = "test-app-id"): Promise<BinaryTestkit> {
+    const { path, cleanup } = await dir({ unsafeCleanup: true });
+    return new BinaryTestkit(path, cleanup, appId);
+  }
+
+  /** Get the temp directory path */
+  getTempDir(): string {
+    return this.tempDir;
+  }
+
+  // ─── GIVEN METHODS ────────────────────────────────────────────
+
+  /** Set up authenticated user state */
+  async givenLoggedIn(user: { email: string; name: string }): Promise<void> {
+    const authDir = join(this.tempDir, ".base44", "auth");
+    await mkdir(authDir, { recursive: true });
+    await writeFile(
+      join(authDir, "auth.json"),
+      JSON.stringify({
+        accessToken: "test-access-token",
+        refreshToken: "test-refresh-token",
+        expiresAt: Date.now() + 3600000, // 1 hour from now
+        email: user.email,
+        name: user.name,
+      }),
+    );
+  }
+
+  /** Set up project directory by copying fixture to temp dir */
+  async givenProject(fixturePath: string): Promise<void> {
+    this.projectDir = join(this.tempDir, "project");
+    await cp(fixturePath, this.projectDir, { recursive: true });
+  }
+
+  /**
+   * Set the latest version for upgrade check.
+   * - Pass a version string (e.g., "1.0.0") to simulate an upgrade available
+   * - Pass null to simulate no upgrade available (default)
+   * - Pass undefined to test the real npm version check (not recommended)
+   */
+  givenLatestVersion(version: string | null | undefined): void {
+    this.testOverrides.latestVersion = version;
+  }
+
+  // ─── WHEN METHODS ─────────────────────────────────────────────
+
+  /** Execute the real CLI binary with the given arguments */
+  async run(...args: string[]): Promise<CLIResult> {
+    if (this.projectDir) {
+      this.testOverrides.appConfig = {
+        id: this.api.appId,
+        projectRoot: this.projectDir,
+      };
+    }
+
+    const env: Record<string, string> = {
+      HOME: this.tempDir,
+      CI: "true",
+      BASE44_DISABLE_TELEMETRY: "1",
+      BASE44_API_URL: this.api.baseUrl,
+      BASE44_CLI_TEST_OVERRIDES: JSON.stringify(this.testOverrides),
+      // Forward PATH so node can be found
+      PATH: process.env.PATH ?? "",
+    };
+
+    const result = await execa("node", [BIN_PATH, ...args], {
+      env,
+      cwd: this.projectDir ?? this.tempDir,
+      // Don't throw on non-zero exit — let the test assert on exitCode
+      reject: false,
+      // Capture output as strings
+      all: false,
+    });
+
+    return {
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: result.exitCode ?? 1,
+    };
+  }
+
+  // ─── THEN METHODS ─────────────────────────────────────────────
+
+  /** Create assertion helper for CLI result */
+  expect(result: CLIResult): CLIResultMatcher {
+    return new CLIResultMatcher(result);
+  }
+
+  /** Read the auth file created by login */
+  async readAuthFile(): Promise<Record<string, unknown> | null> {
+    const authPath = join(this.tempDir, ".base44", "auth", "auth.json");
+    try {
+      const content = await readFile(authPath, "utf-8");
+      return JSON.parse(content);
+    } catch {
+      return null;
+    }
+  }
+
+  /** Read a file from the project directory */
+  async readProjectFile(relativePath: string): Promise<string | null> {
+    if (!this.projectDir) {
+      throw new Error("No project set up. Call givenProject() first.");
+    }
+    try {
+      return await readFile(join(this.projectDir, relativePath), "utf-8");
+    } catch {
+      return null;
+    }
+  }
+
+  /** Check if a file exists in the project directory */
+  async fileExists(relativePath: string): Promise<boolean> {
+    if (!this.projectDir) {
+      throw new Error("No project set up. Call givenProject() first.");
+    }
+    try {
+      await access(join(this.projectDir, relativePath));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // ─── CLEANUP ──────────────────────────────────────────────────
+
+  async cleanup(): Promise<void> {
+    await this.api.stop();
+    await this.cleanupFn();
+  }
+}

--- a/packages/cli/tests/binary/testkit/index.ts
+++ b/packages/cli/tests/binary/testkit/index.ts
@@ -1,0 +1,154 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach } from "vitest";
+import type { CLIResult } from "../../cli/testkit/CLIResultMatcher.js";
+import type { CLIResultMatcher } from "../../cli/testkit/CLIResultMatcher.js";
+import { BinaryAPIServer } from "./BinaryAPIServer.js";
+import { BinaryTestkit } from "./BinaryTestkit.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = resolve(__dirname, "../../fixtures");
+
+/** Resolve a fixture path by name */
+export function fixture(name: string): string {
+  return resolve(FIXTURES_DIR, name);
+}
+
+/**
+ * Test context returned by setupBinaryTests.
+ * Mirrors the TestContext interface from the CLI testkit.
+ */
+export interface BinaryTestContext {
+  /** Get the raw BinaryTestkit instance (rarely needed) */
+  kit: BinaryTestkit;
+
+  // ─── GIVEN METHODS ─────────────────────────────────────────
+
+  /** Set up authenticated user state */
+  givenLoggedIn: (user: { email: string; name: string }) => Promise<void>;
+
+  /** Set up project directory by copying fixture to temp dir */
+  givenProject: (fixturePath: string) => Promise<void>;
+
+  /** Combined: login + project setup (most common pattern) */
+  givenLoggedInWithProject: (
+    fixturePath: string,
+    user?: { email: string; name: string },
+  ) => Promise<void>;
+
+  givenLatestVersion: (version: string | null | undefined) => void;
+
+  // ─── WHEN METHODS ──────────────────────────────────────────
+
+  /** Execute the real CLI binary with the given arguments */
+  run: (...args: string[]) => Promise<CLIResult>;
+
+  // ─── THEN METHODS ──────────────────────────────────────────
+
+  /** Create assertion helper for CLI result */
+  expectResult: (result: CLIResult) => CLIResultMatcher;
+
+  /** Read the auth file (for login tests) */
+  readAuthFile: () => Promise<Record<string, unknown> | null>;
+
+  /** Read a file from the project directory */
+  readProjectFile: (relativePath: string) => Promise<string | null>;
+
+  /** Check if a file exists in the project directory */
+  fileExists: (relativePath: string) => Promise<boolean>;
+
+  /** Get the temp directory path */
+  getTempDir: () => string;
+
+  // ─── API MOCKS ─────────────────────────────────────────────
+
+  /** API mock helpers (real HTTP server) */
+  api: BinaryTestkit["api"];
+}
+
+/**
+ * Sets up the binary test environment for a describe block.
+ *
+ * Each test gets a fresh isolated environment:
+ * - A new temp directory (used as HOME)
+ * - A new Express mock server on a random port
+ * - A fresh BinaryTestkit instance
+ *
+ * **Prerequisite:** Run `bun run build` before executing binary tests.
+ * Tests are skipped automatically when the dist is not built.
+ *
+ * @example
+ * ```typescript
+ * const t = setupBinaryTests();
+ *
+ * it("deploys entities", async () => {
+ *   await t.givenLoggedInWithProject(fixture("with-entities"));
+ *   t.api.mockEntitiesPush({ created: ["User"], updated: [], deleted: [] });
+ *   t.api.mockAgentsPush({ created: [], updated: [], deleted: [] });
+ *   t.api.mockConnectorsList({ integrations: [] });
+ *   const result = await t.run("deploy", "-y");
+ *   t.expectResult(result).toSucceed();
+ * });
+ * ```
+ */
+export function setupBinaryTests(): BinaryTestContext {
+  let currentKit: BinaryTestkit | null = null;
+
+  const getKit = (): BinaryTestkit => {
+    if (!currentKit) {
+      throw new Error(
+        "BinaryTestkit not initialized. Make sure setupBinaryTests() is called inside describe()",
+      );
+    }
+    return currentKit;
+  };
+
+  beforeEach(async () => {
+    currentKit = await BinaryTestkit.create();
+    await currentKit.api.start();
+  });
+
+  afterEach(async () => {
+    if (currentKit) {
+      await currentKit.cleanup();
+      currentKit = null;
+    }
+  });
+
+  const defaultUser = { email: "test@example.com", name: "Test User" };
+
+  return {
+    get kit() {
+      return getKit();
+    },
+
+    // Given methods
+    givenLoggedIn: (user) => getKit().givenLoggedIn(user),
+    givenProject: (fixturePath) => getKit().givenProject(fixturePath),
+    givenLoggedInWithProject: async (fixturePath, user = defaultUser) => {
+      await getKit().givenLoggedIn(user);
+      await getKit().givenProject(fixturePath);
+    },
+    givenLatestVersion: (version) => getKit().givenLatestVersion(version),
+
+    // When methods
+    run: (...args) => getKit().run(...args),
+
+    // Then methods
+    expectResult: (result) => getKit().expect(result),
+    readAuthFile: () => getKit().readAuthFile(),
+    readProjectFile: (relativePath) => getKit().readProjectFile(relativePath),
+    fileExists: (relativePath) => getKit().fileExists(relativePath),
+    getTempDir: () => getKit().getTempDir(),
+
+    // API mocks
+    get api() {
+      return getKit().api;
+    },
+  };
+}
+
+export { BinaryAPIServer } from "./BinaryAPIServer.js";
+export { BinaryTestkit } from "./BinaryTestkit.js";
+export type { CLIResult } from "../../cli/testkit/CLIResultMatcher.js";
+export { CLIResultMatcher } from "../../cli/testkit/CLIResultMatcher.js";


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR introduces a binary test infrastructure that enables end-to-end integration testing of the actual compiled CLI binary (`bin/run.js`). Tests spawn the real Node.js process against a local Express mock server, verifying the full CLI execution path including auth state, project config, and API interactions. Tests are automatically skipped when the dist hasn't been built yet.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added `BinaryAPIServer` — a real Express HTTP server with typed mock methods for all Base44 API endpoints (auth, entities, functions, agents, connectors, secrets, logs, site deploy)
> - Added `BinaryTestkit` — spawns `bin/run.js` via `execa` with an isolated `HOME` temp dir, injecting `BASE44_API_URL` and `BASE44_CLI_TEST_OVERRIDES` to control auth state and app config
> - Added `testkit/index.ts` — `setupBinaryTests()` factory with `beforeEach`/`afterEach` lifecycle, `fixture()` helper, and a `BinaryTestContext` interface following the same Given/When/Then pattern as the existing CLI testkit
> - Added `deploy.spec.ts` — initial binary test suite covering: empty project deploy, missing project directory, entity deploy, full project deploy (entities + functions + site), agent deploy, and API error handling
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [x] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> Binary tests require `bun run build` to be run first — the test suite uses `describe.skipIf(!distExists)` to skip gracefully when the dist is absent. The testkit reuses `CLIResultMatcher` from the existing CLI testkit for consistent assertion ergonomics.
>
> ---
> <sub>🤖 Generated by Claude | 2026-03-09 14:14 UTC</sub>