### PR TITLE
debug(ci): add debug output to README check workflow

### DIFF
--- a/.github/workflows/readme-check.yml
+++ b/.github/workflows/readme-check.yml
@@ -64,6 +64,11 @@ jobs:
           EOF
           )" --allowedTools "Read,Glob,Grep,Write(README.md),Edit(README.md)"
 
+      - name: Debug - check README after Claude
+        run: |
+          echo "=== git diff README.md after Claude step ==="
+          git diff README.md || true
+
       - name: Restore lychee cache
         uses: actions/cache@v4
         with:
@@ -88,6 +93,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          echo "=== git status ==="
+          git status
+          echo "=== git diff README.md ==="
+          git diff README.md || true
+
           if git diff --quiet README.md; then
             echo "No README changes to commit"
             exit 0


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This is a temporary debugging PR that adds `git status` and `git diff README.md` output to the README check CI workflow. It helps diagnose why `git diff --quiet README.md` reports no changes even when both Claude and the fix script report that they modified the file. This PR is intended to be reverted once the root cause is identified.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [x] Other (please describe): Temporary CI debug instrumentation
>
> ## Changes Made
>
> - Added a debug step after the Claude step to print `git diff README.md` output
> - Added `git status` and `git diff README.md` debug output before the PR creation step in the README sync job
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> This is a temporary debugging change and should be removed once the issue with `git diff --quiet README.md` returning false negatives is understood and fixed.
>
> ---
> <sub>🤖 Generated by Claude | 2026-03-09 00:00 UTC</sub>