### PR TITLE
docs: simplify root README to monorepo overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-./packages/cli/README.md
+# Base44 CLI Monorepo
+
+This repository contains the source code for the [Base44 CLI](packages/cli/README.md) — a command-line tool for creating, managing, and deploying Base44 apps.
+
+## Development
+
+Requires [Bun](https://bun.sh/) installed locally.
+
+```bash
+bun install        # Install dependencies
+bun run build      # Bundle to dist/
+bun run test       # Run tests
+bun run dev        # Run CLI in development mode
+bun run lint       # Lint and format check
+```
+
+For full CLI documentation, see [packages/cli/README.md](packages/cli/README.md).


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR replaces the root `README.md` symlink (which pointed to `packages/cli/README.md`) with a proper standalone monorepo overview. The new README provides a brief project description, a link to the full CLI documentation, and the key development commands needed to get started. This improves the repository's presentation on GitHub, as symlinks to other files don't render the linked content.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [x] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Removed the root `README.md` symlink that previously pointed to `packages/cli/README.md`
> - Added a new root `README.md` as a standalone file with a monorepo overview, development prerequisites, key `bun` commands, and a link to the full CLI docs in `packages/cli/README.md`
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [x] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The detailed CLI documentation remains in `packages/cli/README.md` where it belongs. The root README now serves as a lightweight entry point for the monorepo.
>
> ---
> <sub>🤖 Generated by Claude | 2026-03-09 00:00 UTC</sub>