### PR TITLE
Revert "docs: simplify root README to monorepo overview"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,1 @@
-# Base44 CLI Monorepo
-
-This repository contains the source code for the [Base44 CLI](packages/cli/README.md) — a command-line tool for creating, managing, and deploying Base44 apps.
-
-## Development
-
-Requires [Bun](https://bun.sh/) installed locally.
-
-```bash
-bun install        # Install dependencies
-bun run build      # Bundle to dist/
-bun run test       # Run tests
-bun run dev        # Run CLI in development mode
-bun run lint       # Lint and format check
-```
-
-For full CLI documentation, see [packages/cli/README.md](packages/cli/README.md).
+./packages/cli/README.md


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR reverts #399 which had replaced the root `README.md` symlink with a standalone monorepo overview document. The revert restores `README.md` as a symlink pointing to `./packages/cli/README.md`, so the root of the repository directly surfaces the full CLI documentation rather than a brief monorepo summary.
>
> ## Related Issue
>
> Reverts #399
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [x] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Removed the standalone root `README.md` that contained a brief monorepo overview (17 lines)
> - Restored `README.md` as a symlink to `./packages/cli/README.md`, pointing visitors directly to the full CLI documentation
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> None
>
> ---
> <sub>🤖 Generated by Claude | 2026-03-11 14:00 UTC</sub>