### PR TITLE
feat: make logs command discoverable

### DIFF
--- a/packages/cli/src/cli/program.ts
+++ b/packages/cli/src/cli/program.ts
@@ -82,7 +82,7 @@ export function createProgram(context: CLIContext): Command {
   program.addCommand(getDevCommand(), { hidden: true });
 
   // Register logs command
-  program.addCommand(getLogsCommand(), { hidden: true });
+  program.addCommand(getLogsCommand());
 
   return program;
 }


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR makes the `logs` command visible in the CLI's help output by removing the `hidden: true` option when registering it. Previously, the command existed but was not discoverable via `base44 --help` or `base44 help`, making it hard for users to find. This small change improves the developer experience by surfacing the command in the standard help listing.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Removed `{ hidden: true }` option from `program.addCommand(getLogsCommand())` in `packages/cli/src/cli/program.ts` so the `logs` command now appears in CLI help output
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The `dev` command remains hidden (`{ hidden: true }`), which is intentional — it is an internal/development-only command. The `logs` command, by contrast, is a user-facing feature that benefits from discoverability.
>
> ---
> <sub>🤖 Generated by Claude | 2026-03-19 00:00 UTC</sub>