### PR TITLE
fix: allow gremlins bot to trigger Claude-based workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,7 +40,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          allowed_bots: 'claude[bot]'
+          allowed_bots: 'claude[bot],base44-os-gremlins[bot]'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,6 +44,7 @@ jobs:
           # prompt: 'Update the pull request description to include a summary of changes.'
 
           # Allow Claude to run bun and gh commands
+          allowed_bots: 'base44-os-gremlins[bot]'
           claude_args: |
             --allowedTools "Bash(bun:*),Bash(gh pr:*),Bash(gh issue:*)",Bash(git:*)
 

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -95,4 +95,4 @@ jobs:
             - For Checklist items: check them based on your code analysis (e.g., check "style guidelines" if code follows existing patterns)
             - Be concise but informative in the Description and Changes Made sections
           claude_args: '--allowed-tools "Bash(gh pr:*)" "Bash(git diff:*)" "Bash(git log:*)" Read Glob Grep'
-          allowed_bots: 'claude[bot]'
+          allowed_bots: 'claude[bot],base44-os-gremlins[bot]'


### PR DESCRIPTION
## Summary

- Adds `base44-os-gremlins[bot]` to `allowed_bots` in `claude.yml`, `claude-code-review.yml`, and `pr-description.yml`
- Fixes failing CI checks on gremlins-authored PRs (e.g. #370) where Claude code review and auto PR description workflows were skipping because the bot actor wasn't allowlisted

## Test plan

- [ ] Verify that the next push/sync on a gremlins PR (e.g. #370) triggers the Claude Code Review and Auto PR Description workflows successfully

Made with [Cursor](https://cursor.com)