### PR TITLE
chore: unhide auth command from top-level help

### DIFF
--- a/packages/cli/src/cli/program.ts
+++ b/packages/cli/src/cli/program.ts
@@ -71,7 +71,7 @@ export function createProgram(context: CLIContext): Command {
   program.addCommand(getSecretsCommand());
 
   // Register auth config commands
-  program.addCommand(getAuthCommand(), { hidden: true });
+  program.addCommand(getAuthCommand());
 
   // Register site commands
   program.addCommand(getSiteCommand());


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR makes the `auth` command visible in the top-level help output by removing the `{ hidden: true }` option from its registration in `program.ts`. Previously, the command was registered but hidden, meaning users could not discover it via `base44 --help`. This change improves discoverability for users who need to manage their authentication.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [x] Other (please describe): Unhides an existing command from the help output
>
> ## Changes Made
>
> - Removed `{ hidden: true }` from `program.addCommand(getAuthCommand())` in `packages/cli/src/cli/program.ts` so the `auth` command appears in `base44 --help`
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The `auth` command itself is unchanged — only its visibility in the help menu is affected. No behavioral changes for users who were already using the command directly.
>
> ---
> <sub>🤖 Generated by Claude | 2026-03-25 17:10 UTC</sub>