### PR TITLE
feat: agent skill version validation and update command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ error-reports/
 
 # Claude Code
 .claude/worktrees/
+
+# Superset
+.superset/

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "",
   "license": "MIT",
   "scripts": {
+    "build": "bun run --parallel --filter \"*\" build",
     "lint": "biome check packages/*/src packages/*/tests",
     "lint:fix": "biome check --write packages/*/src packages/*/tests",
     "knip": "knip",

--- a/packages/cli/src/cli/commands/project/create.ts
+++ b/packages/cli/src/cli/commands/project/create.ts
@@ -4,6 +4,7 @@ import { confirm, group, isCancel, select, text } from "@clack/prompts";
 import { Argument, type Command } from "commander";
 import { execa } from "execa";
 import kebabCase from "lodash/kebabCase";
+import { installAllSkills } from "@/cli/commands/skills/update.js";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";
 import {
   Base44Command,
@@ -257,17 +258,14 @@ async function executeCreate(
       await runTask(
         "Installing AI agent skills...",
         async () => {
-          await execa("npx", ["-y", "skills", "add", "base44/skills", "-y"], {
-            cwd: resolvedPath,
-            shell: true,
-          });
+          await installAllSkills(resolvedPath);
         },
         {
           successMessage: theme.colors.base44Orange(
             "AI agent skills added successfully",
           ),
           errorMessage:
-            "Failed to add AI agent skills - you can add them later with: npx skills add base44/skills",
+            "Failed to add agent skills - you can add them later with: base44 agent-skills update",
         },
       );
     } catch {

--- a/packages/cli/src/cli/commands/skills/index.ts
+++ b/packages/cli/src/cli/commands/skills/index.ts
@@ -1,0 +1,8 @@
+import { Command } from "commander";
+import { getSkillsUpdateCommand } from "@/cli/commands/skills/update.js";
+
+export function getAgentSkillsCommand(): Command {
+  return new Command("agent-skills")
+    .description("Manage locally installed agent skills")
+    .addCommand(getSkillsUpdateCommand());
+}

--- a/packages/cli/src/cli/commands/skills/update.ts
+++ b/packages/cli/src/cli/commands/skills/update.ts
@@ -1,0 +1,47 @@
+import type { Command } from "commander";
+import { execa } from "execa";
+import type { CLIContext, RunCommandResult } from "@/cli/types.js";
+import { Base44Command, runTask, theme } from "@/cli/utils/index.js";
+import { findProjectRoot } from "@/core/project/config.js";
+
+const SKILLS_REPO = "base44/skills";
+
+export async function installAllSkills(cwd: string): Promise<void> {
+  await execa("npx", ["-y", "skills", "add", SKILLS_REPO, "--all", "-y"], {
+    cwd,
+  });
+}
+
+async function updateAction(_ctx: CLIContext): Promise<RunCommandResult> {
+  const projectRoot = await findProjectRoot();
+  if (!projectRoot) {
+    return {
+      outroMessage:
+        "Not in a Base44 project. Run this command from a project directory.",
+    };
+  }
+
+  await runTask(
+    "Updating agent skills...",
+    async () => {
+      await installAllSkills(projectRoot.root);
+    },
+    {
+      successMessage: theme.colors.base44Orange(
+        "Agent skills updated successfully",
+      ),
+      errorMessage: "Failed to update agent skills",
+    },
+  );
+
+  return { outroMessage: "Agent skills are up to date" };
+}
+
+export function getSkillsUpdateCommand(): Command {
+  return new Base44Command("update", {
+    requireAuth: false,
+    requireAppConfig: false,
+  })
+    .description("Update locally installed agent skills to the latest version")
+    .action(updateAction);
+}

--- a/packages/cli/src/cli/commands/skills/update.ts
+++ b/packages/cli/src/cli/commands/skills/update.ts
@@ -1,8 +1,7 @@
 import type { Command } from "commander";
 import { execa } from "execa";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";
-import { Base44Command, theme } from "@/cli/utils/index.js";
-import { runTask } from "@/cli/utils/runTask.js";
+import { Base44Command, runTask, theme } from "@/cli/utils/index.js";
 import { findProjectRoot } from "@/core/project/config.js";
 
 const SKILLS_REPO = "base44/skills";

--- a/packages/cli/src/cli/commands/skills/update.ts
+++ b/packages/cli/src/cli/commands/skills/update.ts
@@ -1,7 +1,8 @@
 import type { Command } from "commander";
 import { execa } from "execa";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";
-import { Base44Command, runTask, theme } from "@/cli/utils/index.js";
+import { Base44Command, theme } from "@/cli/utils/index.js";
+import { runTask } from "@/cli/utils/runTask.js";
 import { findProjectRoot } from "@/core/project/config.js";
 
 const SKILLS_REPO = "base44/skills";

--- a/packages/cli/src/cli/commands/skills/update.ts
+++ b/packages/cli/src/cli/commands/skills/update.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import { execa } from "execa";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";
-import { Base44Command, runTask, theme } from "@/cli/utils/index.js";
+import { Base44Command, theme } from "@/cli/utils/index.js";
 import { findProjectRoot } from "@/core/project/config.js";
 
 const SKILLS_REPO = "base44/skills";
@@ -12,7 +12,9 @@ export async function installAllSkills(cwd: string): Promise<void> {
   });
 }
 
-async function updateAction(_ctx: CLIContext): Promise<RunCommandResult> {
+async function updateAction({
+  runTask,
+}: CLIContext): Promise<RunCommandResult> {
   const projectRoot = await findProjectRoot();
   if (!projectRoot) {
     return {

--- a/packages/cli/src/cli/program.ts
+++ b/packages/cli/src/cli/program.ts
@@ -14,6 +14,7 @@ import { getLinkCommand } from "@/cli/commands/project/link.js";
 import { getLogsCommand } from "@/cli/commands/project/logs.js";
 import { getSecretsCommand } from "@/cli/commands/secrets/index.js";
 import { getSiteCommand } from "@/cli/commands/site/index.js";
+import { getAgentSkillsCommand } from "@/cli/commands/skills/index.js";
 import { getTypesCommand } from "@/cli/commands/types/index.js";
 import { Base44Command } from "@/cli/utils/index.js";
 import packageJson from "../../package.json";
@@ -69,6 +70,9 @@ export function createProgram(context: CLIContext): Command {
 
   // Register secrets commands
   program.addCommand(getSecretsCommand());
+
+  // Register agent-skills commands
+  program.addCommand(getAgentSkillsCommand());
 
   // Register auth config commands
   program.addCommand(getAuthCommand());

--- a/packages/cli/src/cli/utils/command/Base44Command.ts
+++ b/packages/cli/src/cli/utils/command/Base44Command.ts
@@ -144,13 +144,15 @@ export class Base44Command extends Command {
           if (result.stdout) {
             process.stdout.write(result.stdout);
           }
-          const upgradeInfo = await upgradeCheckPromise;
+          const [upgradeInfo, staleSkills] = await Promise.all([
+            upgradeCheckPromise,
+            skillCheckPromise,
+          ]);
           if (upgradeInfo) {
             process.stderr.write(
               `${formatPlainUpgradeMessage(upgradeInfo, this.context.distribution)}\n`,
             );
           }
-          const staleSkills = await skillCheckPromise;
           if (staleSkills && staleSkills.length > 0) {
             process.stderr.write(`${formatPlainSkillWarning(staleSkills)}\n`);
           }

--- a/packages/cli/src/cli/utils/command/Base44Command.ts
+++ b/packages/cli/src/cli/utils/command/Base44Command.ts
@@ -7,10 +7,16 @@ import {
   showPlainError,
   showThemedError,
 } from "@/cli/utils/command/render.js";
+import type { StaleSkillInfo } from "@/cli/utils/skill-version-check.js";
+import {
+  formatPlainSkillWarning,
+  startSkillVersionCheck,
+} from "@/cli/utils/skill-version-check.js";
 import {
   formatPlainUpgradeMessage,
   startUpgradeCheck,
 } from "@/cli/utils/upgradeNotification.js";
+import { getAppConfig } from "@/core/project/app-config.js";
 
 interface Base44CommandOptions {
   /**
@@ -108,6 +114,8 @@ export class Base44Command extends Command {
       }
 
       const upgradeCheckPromise = startUpgradeCheck();
+      let skillCheckPromise: Promise<StaleSkillInfo[] | null> =
+        Promise.resolve(null);
 
       try {
         if (this._commandOptions.requireAuth) {
@@ -115,17 +123,20 @@ export class Base44Command extends Command {
         }
         if (this._commandOptions.requireAppConfig) {
           await ensureAppConfig(this.context);
+          skillCheckPromise = startSkillVersionCheck(
+            getAppConfig().projectRoot,
+          );
         }
 
         const result = ((await fn(this.context, ...args)) ??
           {}) as RunCommandResult;
 
         if (!quiet) {
-          await showCommandEnd(
-            result,
-            upgradeCheckPromise,
-            this.context.distribution,
-          );
+          await showCommandEnd(result, {
+            upgradeCheck: upgradeCheckPromise,
+            skillCheck: skillCheckPromise,
+            distribution: this.context.distribution,
+          });
         } else {
           if (result.outroMessage) {
             process.stdout.write(`${result.outroMessage}\n`);
@@ -138,6 +149,10 @@ export class Base44Command extends Command {
             process.stderr.write(
               `${formatPlainUpgradeMessage(upgradeInfo, this.context.distribution)}\n`,
             );
+          }
+          const staleSkills = await skillCheckPromise;
+          if (staleSkills && staleSkills.length > 0) {
+            process.stderr.write(`${formatPlainSkillWarning(staleSkills)}\n`);
           }
         }
       } catch (error) {

--- a/packages/cli/src/cli/utils/command/Base44Command.ts
+++ b/packages/cli/src/cli/utils/command/Base44Command.ts
@@ -123,9 +123,15 @@ export class Base44Command extends Command {
         }
         if (this._commandOptions.requireAppConfig) {
           await ensureAppConfig(this.context);
+          const errorReporter = this.context.errorReporter;
           skillCheckPromise = startSkillVersionCheck(
             getAppConfig().projectRoot,
-          );
+          ).catch((error) => {
+            errorReporter.captureException(
+              error instanceof Error ? error : new Error(String(error)),
+            );
+            return null;
+          });
         }
 
         const result = ((await fn(this.context, ...args)) ??

--- a/packages/cli/src/cli/utils/command/Base44Command.ts
+++ b/packages/cli/src/cli/utils/command/Base44Command.ts
@@ -7,16 +7,16 @@ import {
   showPlainError,
   showThemedError,
 } from "@/cli/utils/command/render.js";
-import type { StaleSkillInfo } from "@/cli/utils/skill-version-check.js";
+import { getAppConfig } from "@/core/project/app-config.js";
+import type { StaleSkillInfo } from "./skill-version-check.js";
 import {
   formatPlainSkillWarning,
   startSkillVersionCheck,
-} from "@/cli/utils/skill-version-check.js";
+} from "./skill-version-check.js";
 import {
   formatPlainUpgradeMessage,
   startUpgradeCheck,
-} from "@/cli/utils/upgradeNotification.js";
-import { getAppConfig } from "@/core/project/app-config.js";
+} from "./upgradeNotification.js";
 
 interface Base44CommandOptions {
   /**

--- a/packages/cli/src/cli/utils/command/Base44Command.ts
+++ b/packages/cli/src/cli/utils/command/Base44Command.ts
@@ -7,16 +7,16 @@ import {
   showPlainError,
   showThemedError,
 } from "@/cli/utils/command/render.js";
-import { getAppConfig } from "@/core/project/app-config.js";
-import type { StaleSkillInfo } from "./skill-version-check.js";
+import type { StaleSkillInfo } from "@/cli/utils/command/skill-version-check.js";
 import {
   formatPlainSkillWarning,
   startSkillVersionCheck,
-} from "./skill-version-check.js";
+} from "@/cli/utils/command/skill-version-check.js";
 import {
   formatPlainUpgradeMessage,
   startUpgradeCheck,
-} from "./upgradeNotification.js";
+} from "@/cli/utils/command/upgradeNotification.js";
+import { getAppConfig } from "@/core/project/app-config.js";
 
 interface Base44CommandOptions {
   /**

--- a/packages/cli/src/cli/utils/command/render.ts
+++ b/packages/cli/src/cli/utils/command/render.ts
@@ -1,12 +1,12 @@
 import { intro, log, outro } from "@clack/prompts";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";
 import { printBanner } from "@/cli/utils/banner.js";
+import type { StaleSkillInfo } from "@/cli/utils/command/skill-version-check.js";
+import { printSkillVersionWarning } from "@/cli/utils/command/skill-version-check.js";
+import { printUpgradeNotification } from "@/cli/utils/command/upgradeNotification.js";
+import type { UpgradeInfo } from "@/cli/utils/command/version-check.js";
 import { theme } from "@/cli/utils/theme.js";
 import { isCLIError } from "@/core/errors.js";
-import type { StaleSkillInfo } from "./skill-version-check.js";
-import { printSkillVersionWarning } from "./skill-version-check.js";
-import { printUpgradeNotification } from "./upgradeNotification.js";
-import type { UpgradeInfo } from "./version-check.js";
 
 /**
  * Show the command start UI: intro banner or simple tag.

--- a/packages/cli/src/cli/utils/command/render.ts
+++ b/packages/cli/src/cli/utils/command/render.ts
@@ -33,8 +33,10 @@ export async function showCommandEnd(
   result: RunCommandResult,
   options: CommandEndOptions,
 ): Promise<void> {
-  await printUpgradeNotification(options.upgradeCheck, options.distribution);
-  await printSkillVersionWarning(options.skillCheck);
+  await Promise.all([
+    printUpgradeNotification(options.upgradeCheck, options.distribution),
+    printSkillVersionWarning(options.skillCheck),
+  ]);
   outro(result.outroMessage || "");
 
   if (result.stdout) {

--- a/packages/cli/src/cli/utils/command/render.ts
+++ b/packages/cli/src/cli/utils/command/render.ts
@@ -1,12 +1,12 @@
 import { intro, log, outro } from "@clack/prompts";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";
 import { printBanner } from "@/cli/utils/banner.js";
-import type { StaleSkillInfo } from "@/cli/utils/skill-version-check.js";
-import { printSkillVersionWarning } from "@/cli/utils/skill-version-check.js";
 import { theme } from "@/cli/utils/theme.js";
-import { printUpgradeNotification } from "@/cli/utils/upgradeNotification.js";
-import type { UpgradeInfo } from "@/cli/utils/version-check.js";
 import { isCLIError } from "@/core/errors.js";
+import type { StaleSkillInfo } from "./skill-version-check.js";
+import { printSkillVersionWarning } from "./skill-version-check.js";
+import { printUpgradeNotification } from "./upgradeNotification.js";
+import type { UpgradeInfo } from "./version-check.js";
 
 /**
  * Show the command start UI: intro banner or simple tag.

--- a/packages/cli/src/cli/utils/command/render.ts
+++ b/packages/cli/src/cli/utils/command/render.ts
@@ -1,6 +1,8 @@
 import { intro, log, outro } from "@clack/prompts";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";
 import { printBanner } from "@/cli/utils/banner.js";
+import type { StaleSkillInfo } from "@/cli/utils/skill-version-check.js";
+import { printSkillVersionWarning } from "@/cli/utils/skill-version-check.js";
 import { theme } from "@/cli/utils/theme.js";
 import { printUpgradeNotification } from "@/cli/utils/upgradeNotification.js";
 import type { UpgradeInfo } from "@/cli/utils/version-check.js";
@@ -21,12 +23,18 @@ export async function showCommandStart(fullBanner: boolean): Promise<void> {
 /**
  * Show the command end UI: upgrade notification, outro message, and stdout.
  */
+interface CommandEndOptions {
+  upgradeCheck: Promise<UpgradeInfo | null>;
+  skillCheck: Promise<StaleSkillInfo[] | null>;
+  distribution: CLIContext["distribution"];
+}
+
 export async function showCommandEnd(
   result: RunCommandResult,
-  upgradeCheckPromise: Promise<UpgradeInfo | null>,
-  distribution: CLIContext["distribution"],
+  options: CommandEndOptions,
 ): Promise<void> {
-  await printUpgradeNotification(upgradeCheckPromise, distribution);
+  await printUpgradeNotification(options.upgradeCheck, options.distribution);
+  await printSkillVersionWarning(options.skillCheck);
   outro(result.outroMessage || "");
 
   if (result.stdout) {

--- a/packages/cli/src/cli/utils/command/skill-version-check.ts
+++ b/packages/cli/src/cli/utils/command/skill-version-check.ts
@@ -5,7 +5,7 @@ import frontmatter from "front-matter";
 import { z } from "zod";
 import { theme } from "@/cli/utils/theme.js";
 import { readTextFile } from "@/core/utils/fs.js";
-import packageJson from "../../../package.json";
+import packageJson from "../../../../package.json";
 
 export interface StaleSkillInfo {
   skillName: string;

--- a/packages/cli/src/cli/utils/command/upgradeNotification.ts
+++ b/packages/cli/src/cli/utils/command/upgradeNotification.ts
@@ -1,8 +1,8 @@
 import { note } from "@clack/prompts";
 import type { Distribution } from "@/cli/types.js";
+import type { UpgradeInfo } from "@/cli/utils/command/version-check.js";
+import { checkForUpgrade } from "@/cli/utils/command/version-check.js";
 import { theme } from "@/cli/utils/theme.js";
-import type { UpgradeInfo } from "./version-check.js";
-import { checkForUpgrade } from "./version-check.js";
 
 type InstallMethod = "npm" | "brew" | "binary";
 

--- a/packages/cli/src/cli/utils/command/upgradeNotification.ts
+++ b/packages/cli/src/cli/utils/command/upgradeNotification.ts
@@ -1,8 +1,8 @@
 import { note } from "@clack/prompts";
 import type { Distribution } from "@/cli/types.js";
 import { theme } from "@/cli/utils/theme.js";
-import type { UpgradeInfo } from "@/cli/utils/version-check.js";
-import { checkForUpgrade } from "@/cli/utils/version-check.js";
+import type { UpgradeInfo } from "./version-check.js";
+import { checkForUpgrade } from "./version-check.js";
 
 type InstallMethod = "npm" | "brew" | "binary";
 

--- a/packages/cli/src/cli/utils/command/version-check.ts
+++ b/packages/cli/src/cli/utils/command/version-check.ts
@@ -1,6 +1,6 @@
 import { execa } from "execa";
 import { getTestOverrides } from "@/core/config.js";
-import packageJson from "../../../package.json";
+import packageJson from "../../../../package.json";
 
 export interface UpgradeInfo {
   currentVersion: string;

--- a/packages/cli/src/cli/utils/skill-version-check.ts
+++ b/packages/cli/src/cli/utils/skill-version-check.ts
@@ -37,7 +37,7 @@ async function listInstalledSkills(
   const { stdout } = await execa("npx", ["-y", "skills", "list", "--json"], {
     cwd,
     timeout: 3000,
-    env: { ...process.env, CI: "1" },
+    env: { CI: "1" },
   });
 
   // npx may emit non-JSON preamble (download progress, warnings) before the array

--- a/packages/cli/src/cli/utils/skill-version-check.ts
+++ b/packages/cli/src/cli/utils/skill-version-check.ts
@@ -37,7 +37,7 @@ async function listInstalledSkills(
   const { stdout } = await execa("npx", ["-y", "skills", "list", "--json"], {
     cwd,
     timeout: 3000,
-    env: { CI: "1" },
+    env: { ...process.env, CI: "1" },
   });
 
   // npx may emit non-JSON preamble (download progress, warnings) before the array

--- a/packages/cli/src/cli/utils/skill-version-check.ts
+++ b/packages/cli/src/cli/utils/skill-version-check.ts
@@ -85,8 +85,8 @@ async function checkSkillVersions(
 
 export function startSkillVersionCheck(
   projectRoot: string,
-): Promise<StaleSkillInfo[] | null> {
-  return checkSkillVersions(projectRoot).catch(() => null);
+): Promise<StaleSkillInfo[]> {
+  return checkSkillVersions(projectRoot);
 }
 
 function formatSkillWarning(staleSkills: StaleSkillInfo[]): string {

--- a/packages/cli/src/cli/utils/skill-version-check.ts
+++ b/packages/cli/src/cli/utils/skill-version-check.ts
@@ -1,0 +1,124 @@
+import { join } from "node:path";
+import { note } from "@clack/prompts";
+import { execa } from "execa";
+import frontmatter from "front-matter";
+import { z } from "zod";
+import { theme } from "@/cli/utils/theme.js";
+import { readTextFile } from "@/core/utils/fs.js";
+import packageJson from "../../../package.json";
+
+export interface StaleSkillInfo {
+  skillName: string;
+  installedVersion: string;
+  currentVersion: string;
+}
+
+const SourcePackageSchema = z.object({
+  name: z.string(),
+  version: z.string(),
+});
+
+const SkillFrontmatterSchema = z.object({
+  metadata: z.object({
+    sourcePackage: SourcePackageSchema,
+  }),
+});
+
+const InstalledSkillSchema = z.object({
+  name: z.string(),
+  path: z.string(),
+});
+
+const InstalledSkillsSchema = z.array(InstalledSkillSchema);
+
+async function listInstalledSkills(
+  cwd: string,
+): Promise<z.infer<typeof InstalledSkillsSchema>> {
+  const { stdout } = await execa("npx", ["-y", "skills", "list", "--json"], {
+    cwd,
+    timeout: 3000,
+    env: { ...process.env, CI: "1" },
+  });
+
+  // npx may emit non-JSON preamble (download progress, warnings) before the array
+  const jsonStart = stdout.indexOf("[");
+  if (jsonStart === -1) return [];
+  const parsed = JSON.parse(stdout.slice(jsonStart));
+  return InstalledSkillsSchema.parse(parsed);
+}
+
+export async function readSkillFrontmatter(
+  skillPath: string,
+): Promise<z.infer<typeof SkillFrontmatterSchema> | null> {
+  try {
+    const content = await readTextFile(join(skillPath, "SKILL.md"));
+    const { attributes } = frontmatter<Record<string, unknown>>(content);
+    const result = SkillFrontmatterSchema.safeParse(attributes);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+async function checkSkillVersions(
+  projectRoot: string,
+): Promise<StaleSkillInfo[]> {
+  const skills = await listInstalledSkills(projectRoot);
+
+  const results = await Promise.all(
+    skills.map(async (skill) => {
+      const fm = await readSkillFrontmatter(skill.path);
+      if (!fm) return null;
+      if (fm.metadata.sourcePackage.name !== packageJson.name) return null;
+      if (fm.metadata.sourcePackage.version === packageJson.version)
+        return null;
+      return {
+        skillName: skill.name,
+        installedVersion: fm.metadata.sourcePackage.version,
+        currentVersion: packageJson.version,
+      };
+    }),
+  );
+
+  return results.filter((r): r is StaleSkillInfo => r !== null);
+}
+
+export function startSkillVersionCheck(
+  projectRoot: string,
+): Promise<StaleSkillInfo[] | null> {
+  return checkSkillVersions(projectRoot).catch(() => null);
+}
+
+function formatSkillWarning(staleSkills: StaleSkillInfo[]): string {
+  const { shinyOrange } = theme.colors;
+  const { bold } = theme.styles;
+
+  const lines = staleSkills.map((s) =>
+    shinyOrange(
+      `Skill "${s.skillName}" was built for v${s.installedVersion}, current CLI is v${bold(s.currentVersion)}`,
+    ),
+  );
+  lines.push(shinyOrange("Run: base44 agent-skills update"));
+
+  return lines.join("\n");
+}
+
+export function formatPlainSkillWarning(staleSkills: StaleSkillInfo[]): string {
+  const lines = staleSkills.map(
+    (s) =>
+      `Skill "${s.skillName}" was built for v${s.installedVersion}, current CLI is v${s.currentVersion}.`,
+  );
+  lines.push("Run: base44 agent-skills update");
+  return lines.join(" ");
+}
+
+export async function printSkillVersionWarning(
+  promise: Promise<StaleSkillInfo[] | null>,
+): Promise<void> {
+  try {
+    const staleSkills = await promise;
+    if (staleSkills && staleSkills.length > 0) {
+      note(formatSkillWarning(staleSkills));
+    }
+  } catch {}
+}

--- a/packages/cli/tests/core/skill-version-check.spec.ts
+++ b/packages/cli/tests/core/skill-version-check.spec.ts
@@ -1,0 +1,94 @@
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { StaleSkillInfo } from "@/cli/utils/skill-version-check.js";
+import {
+  formatPlainSkillWarning,
+  readSkillFrontmatter,
+} from "@/cli/utils/skill-version-check.js";
+
+const FIXTURES_DIR = resolve(__dirname, "../fixtures/with-skills");
+
+describe("readSkillFrontmatter", () => {
+  it("parses sourcePackage from metadata frontmatter", async () => {
+    const result = await readSkillFrontmatter(
+      resolve(FIXTURES_DIR, "skill-with-source-package"),
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.metadata.sourcePackage.name).toBe("base44");
+    expect(result!.metadata.sourcePackage.version).toBe("0.0.1");
+  });
+
+  it("returns null when metadata is missing", async () => {
+    const result = await readSkillFrontmatter(
+      resolve(FIXTURES_DIR, "skill-without-metadata"),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("parses sourcePackage from a different package", async () => {
+    const result = await readSkillFrontmatter(
+      resolve(FIXTURES_DIR, "skill-different-package"),
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.metadata.sourcePackage.name).toBe("other-package");
+    expect(result!.metadata.sourcePackage.version).toBe("1.0.0");
+  });
+
+  it("returns null when skill directory does not exist", async () => {
+    const result = await readSkillFrontmatter(
+      resolve(FIXTURES_DIR, "nonexistent-skill"),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when SKILL.md is missing from directory", async () => {
+    // Use the parent fixtures dir which has no SKILL.md
+    const result = await readSkillFrontmatter(FIXTURES_DIR);
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("formatPlainSkillWarning", () => {
+  it("formats a single stale skill", () => {
+    const staleSkills: StaleSkillInfo[] = [
+      {
+        skillName: "base44-cli",
+        installedVersion: "0.0.1",
+        currentVersion: "0.0.48",
+      },
+    ];
+
+    const result = formatPlainSkillWarning(staleSkills);
+
+    expect(result).toContain("base44-cli");
+    expect(result).toContain("v0.0.1");
+    expect(result).toContain("v0.0.48");
+    expect(result).toContain("base44 agent-skills update");
+  });
+
+  it("formats multiple stale skills", () => {
+    const staleSkills: StaleSkillInfo[] = [
+      {
+        skillName: "base44-cli",
+        installedVersion: "0.0.1",
+        currentVersion: "0.0.48",
+      },
+      {
+        skillName: "base44-sdk",
+        installedVersion: "0.0.2",
+        currentVersion: "0.0.48",
+      },
+    ];
+
+    const result = formatPlainSkillWarning(staleSkills);
+
+    expect(result).toContain("base44-cli");
+    expect(result).toContain("base44-sdk");
+    expect(result).toContain("base44 agent-skills update");
+  });
+});

--- a/packages/cli/tests/core/skill-version-check.spec.ts
+++ b/packages/cli/tests/core/skill-version-check.spec.ts
@@ -1,10 +1,10 @@
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import type { StaleSkillInfo } from "@/cli/utils/skill-version-check.js";
+import type { StaleSkillInfo } from "@/cli/utils/command/skill-version-check.js";
 import {
   formatPlainSkillWarning,
   readSkillFrontmatter,
-} from "@/cli/utils/skill-version-check.js";
+} from "@/cli/utils/command/skill-version-check.js";
 
 const FIXTURES_DIR = resolve(__dirname, "../fixtures/with-skills");
 

--- a/packages/cli/tests/fixtures/with-skills/skill-different-package/SKILL.md
+++ b/packages/cli/tests/fixtures/with-skills/skill-different-package/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: other-tool-skill
+description: A skill from a different package
+metadata:
+  sourcePackage:
+    name: other-package
+    version: 1.0.0
+---
+
+Different package.

--- a/packages/cli/tests/fixtures/with-skills/skill-matching-version/SKILL.md
+++ b/packages/cli/tests/fixtures/with-skills/skill-matching-version/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: base44-cli
+description: A skill matching the current version
+metadata:
+  sourcePackage:
+    name: base44
+    version: 0.0.48
+---
+
+Matching version.

--- a/packages/cli/tests/fixtures/with-skills/skill-with-source-package/SKILL.md
+++ b/packages/cli/tests/fixtures/with-skills/skill-with-source-package/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: base44-cli
+description: A test skill
+metadata:
+  sourcePackage:
+    name: base44
+    version: 0.0.1
+---
+
+Test skill content.

--- a/packages/cli/tests/fixtures/with-skills/skill-without-metadata/SKILL.md
+++ b/packages/cli/tests/fixtures/with-skills/skill-without-metadata/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: some-skill
+description: A skill with no metadata
+---
+
+No metadata here.


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Adds a new `base44 agent-skills update` command for managing locally installed agent skills, and introduces an automatic stale-skill version check that runs after every command. When installed skills were built for an older version of the CLI, a warning is shown at the end of command output prompting users to update. The project creation flow is also updated to use the new skill installation utility.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [x] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added `base44 agent-skills update` command (`packages/cli/src/cli/commands/skills/`) that updates locally installed agent skills to the latest version via `npx skills add base44/skills --all`
> - Added `skill-version-check.ts` utility that reads `SKILL.md` frontmatter to detect skills built for an older CLI version and prints a warning after command execution
> - Integrated skill version check into `Base44Command` — runs in parallel with the existing upgrade check and emits stale-skill warnings in both interactive and quiet (`--quiet`) modes
> - Moved `version-check.ts` and `upgradeNotification.ts` from `cli/utils/` into `cli/utils/command/` to co-locate all command-lifecycle utilities
> - Refactored `showCommandEnd` in `render.ts` to accept an options object (includes both `upgradeCheck` and `skillCheck` promises)
> - Updated `project create` to use the new `installAllSkills()` helper and updated the error message to reference `base44 agent-skills update`
> - Added unit tests for `readSkillFrontmatter` and `formatPlainSkillWarning` with fixture SKILL.md files
> - Added root-level `build` script and `.superset/` to `.gitignore`
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The skill version check is only triggered when a command requires app config (`requireAppConfig: true`), since project root is needed to list installed skills. Errors during the check are silently captured via `errorReporter` to avoid interrupting the user's workflow.
>
> ---
> <sub>🤖 Generated by Claude | 2026-04-09 10:05 UTC</sub>