### PR TITLE
Forward service token header from Authorization in base44 dev

### DIFF
--- a/packages/cli/src/cli/dev/dev-server/routes/functions.ts
+++ b/packages/cli/src/cli/dev/dev-server/routes/functions.ts
@@ -19,8 +19,13 @@ export function createFunctionRouter(
     on: {
       proxyReq: (proxyReq, req) => {
         const xAppId = req.headers["x-app-id"];
+        const authorization = req.headers.authorization;
+
         if (xAppId) {
           proxyReq.setHeader("Base44-App-Id", xAppId as string);
+        }
+        if (authorization) {
+          proxyReq.setHeader("Base44-Service-Authorization", authorization);
         }
         proxyReq.setHeader(
           "Base44-Api-Url",

--- a/packages/cli/tests/cli/dev.spec.ts
+++ b/packages/cli/tests/cli/dev.spec.ts
@@ -1,4 +1,6 @@
-import { describe, it } from "vitest";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
 import { waitForDevServer } from "./testkit/dev-utils.js";
 import { fixture, setupCLITests } from "./testkit/index.js";
 
@@ -21,6 +23,43 @@ describe("dev command", () => {
     await waitForDevServer(handle);
     const result = await handle.stop();
 
+    t.expectResult(result).toSucceed();
+  });
+
+  it("forwards the service authorization header to local functions", async () => {
+    await t.givenLoggedInWithProject(fixture("full-project"));
+
+    await writeFile(
+      join(t.getTempDir(), "project", "base44/functions/hello/index.ts"),
+      `Deno.serve((req: Request) =>
+  Response.json({
+    authorization: req.headers.get("authorization"),
+    serviceAuthorization: req.headers.get("base44-service-authorization"),
+  }),
+);
+`,
+    );
+
+    const handle = await t.runLive("dev");
+    const devServerUrl = await waitForDevServer(handle);
+
+    const response = await fetch(
+      `${devServerUrl}/api/apps/${t.api.appId}/functions/hello`,
+      {
+        headers: {
+          Authorization: "Bearer test-app-token",
+          "X-App-Id": t.api.appId,
+        },
+      },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      authorization: "Bearer test-app-token",
+      serviceAuthorization: "Bearer test-app-token",
+    });
+
+    const result = await handle.stop();
     t.expectResult(result).toSucceed();
   });
 });

--- a/packages/cli/tests/cli/dev.spec.ts
+++ b/packages/cli/tests/cli/dev.spec.ts
@@ -26,7 +26,7 @@ describe("dev command", () => {
     t.expectResult(result).toSucceed();
   });
 
-  it("forwards the service authorization header to local functions", async () => {
+  it("forwards the service token header from Authorization to local functions", async () => {
     await t.givenLoggedInWithProject(fixture("full-project"));
 
     await writeFile(


### PR DESCRIPTION
## Summary
- forward `Base44-Service-Authorization` to local functions in `base44 dev`
- derive the service token header from the incoming `Authorization` header
- add an integration test covering the `base44 dev` function proxy path

## Testing
- `bun run build`
- `bun run test tests/cli/dev.spec.ts`
- `bunx @biomejs/biome check packages/cli/src/cli/dev/dev-server/routes/functions.ts packages/cli/tests/cli/dev.spec.ts`

Closes #460