### PR TITLE
Add connector automation support to backend functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ error-reports/
 
 # Claude Code
 .claude/worktrees/
+.superset/

--- a/packages/cli/src/core/resources/function/schema.ts
+++ b/packages/cli/src/core/resources/function/schema.ts
@@ -66,10 +66,36 @@ const EntityAutomationSchema = AutomationBaseSchema.extend({
     .min(1, "At least one event type is required"),
 });
 
+// Known operators — kept in sync with backend ConditionOperator enum.
+// The union with z.string() ensures unknown future operators still parse.
+const KnownConditionOperators = [
+  "equals",
+  "not_equals",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+  "contains",
+  "not_contains",
+  "starts_with",
+  "ends_with",
+  "in_list",
+  "not_in_list",
+  "exists",
+  "not_exists",
+  "is_empty",
+  "is_not_empty",
+] as const;
+
+const ConditionOperatorSchema = z.union([
+  z.enum(KnownConditionOperators),
+  z.string().min(1),
+]);
+
 // Trigger condition (field-level filter)
 const TriggerConditionSchema = z.object({
   field: z.string().min(1),
-  operator: z.string().min(1),
+  operator: ConditionOperatorSchema,
   value: z.unknown().nullable().optional(),
 });
 

--- a/packages/cli/src/core/resources/function/schema.ts
+++ b/packages/cli/src/core/resources/function/schema.ts
@@ -92,28 +92,13 @@ const TriggerConditionGroupSchema: z.ZodType<TriggerConditionGroup> = z.lazy(
     }),
 );
 
-// The backend also accepts `{}` and `{ conditions: [] }` as "clear conditions"
-// requests, so the schema must allow those forms when parsing local config or
-// remote payloads.
-const EmptyTriggerConditionsSchema = z
-  .object({
-    logic: TriggerLogicSchema.optional(),
-    conditions: z.array(z.unknown()).length(0).optional(),
-  })
-  .passthrough();
-
-const TriggerConditionsSchema = z.union([
-  TriggerConditionGroupSchema,
-  EmptyTriggerConditionsSchema,
-]);
-
 // Connector automation (webhook-triggered)
 const ConnectorAutomationSchema = AutomationBaseSchema.extend({
   type: z.literal("connector"),
   integration_type: IntegrationTypeSchema,
   events: z.array(z.string()),
   resource_id: z.string().nullable().optional(),
-  trigger_conditions: TriggerConditionsSchema.nullable().optional(),
+  trigger_conditions: TriggerConditionGroupSchema.nullable().optional(),
 });
 
 // Union of all automation types

--- a/packages/cli/src/core/resources/function/schema.ts
+++ b/packages/cli/src/core/resources/function/schema.ts
@@ -65,12 +65,34 @@ const EntityAutomationSchema = AutomationBaseSchema.extend({
     .min(1, "At least one event type is required"),
 });
 
+// Trigger condition (field-level filter)
+const TriggerConditionSchema = z.object({
+  field: z.string().min(1),
+  operator: z.string().min(1),
+  value: z.unknown(),
+});
+
+// Condition group wrapping an array of conditions
+const TriggerConditionsSchema = z.object({
+  conditions: z.array(TriggerConditionSchema).min(1),
+});
+
+// Connector automation (webhook-triggered)
+const ConnectorAutomationSchema = AutomationBaseSchema.extend({
+  type: z.literal("connector"),
+  integration_type: z.string().min(1, "Integration type cannot be empty"),
+  events: z.array(z.string()).min(1, "At least one event is required"),
+  resource_id: z.string().nullable().optional(),
+  trigger_conditions: TriggerConditionsSchema.nullable().optional(),
+});
+
 // Union of all automation types
 const AutomationSchema = z.union([
   ScheduledOneTimeSchema,
   ScheduledCronSchema,
   ScheduledSimpleSchema,
   EntityAutomationSchema,
+  ConnectorAutomationSchema,
 ]);
 
 export const FunctionConfigSchema = z.object({

--- a/packages/cli/src/core/resources/function/schema.ts
+++ b/packages/cli/src/core/resources/function/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { IntegrationTypeSchema } from "@/core/resources/connector/schema.js";
 
 const FunctionNameSchema = z
   .string()
@@ -80,40 +81,36 @@ type TriggerConditionGroup = {
   conditions: Array<TriggerCondition | TriggerConditionGroup>;
 };
 
-// Recursive condition group for trigger filtering. The backend also accepts
-// `{}` and `{ conditions: [] }` as "clear conditions" requests, so the schema
-// must allow those forms when parsing local config or remote payloads.
+// Recursive condition group for trigger filtering.
 const TriggerConditionGroupSchema: z.ZodType<TriggerConditionGroup> = z.lazy(
   () =>
-    z
-      .object({
-        logic: TriggerLogicSchema.optional(),
-        conditions: z
-          .array(z.union([TriggerConditionSchema, TriggerConditionGroupSchema]))
-          .min(1),
-      })
-      .strict(),
+    z.object({
+      logic: TriggerLogicSchema.optional(),
+      conditions: z
+        .array(z.union([TriggerConditionSchema, TriggerConditionGroupSchema]))
+        .min(1),
+    }),
 );
 
-const EmptyTriggerConditionsSchema = z.union([
-  z.object({}).strict(),
-  z
-    .object({
-      logic: TriggerLogicSchema.optional(),
-      conditions: z.array(z.unknown()).length(0),
-    })
-    .strict(),
-]);
+// The backend also accepts `{}` and `{ conditions: [] }` as "clear conditions"
+// requests, so the schema must allow those forms when parsing local config or
+// remote payloads.
+const EmptyTriggerConditionsSchema = z
+  .object({
+    logic: TriggerLogicSchema.optional(),
+    conditions: z.array(z.unknown()).length(0).optional(),
+  })
+  .passthrough();
 
 const TriggerConditionsSchema = z.union([
-  EmptyTriggerConditionsSchema,
   TriggerConditionGroupSchema,
+  EmptyTriggerConditionsSchema,
 ]);
 
 // Connector automation (webhook-triggered)
 const ConnectorAutomationSchema = AutomationBaseSchema.extend({
   type: z.literal("connector"),
-  integration_type: z.string().min(1, "Integration type cannot be empty"),
+  integration_type: IntegrationTypeSchema,
   events: z.array(z.string()),
   resource_id: z.string().nullable().optional(),
   trigger_conditions: TriggerConditionsSchema.nullable().optional(),

--- a/packages/cli/src/core/resources/function/schema.ts
+++ b/packages/cli/src/core/resources/function/schema.ts
@@ -69,19 +69,52 @@ const EntityAutomationSchema = AutomationBaseSchema.extend({
 const TriggerConditionSchema = z.object({
   field: z.string().min(1),
   operator: z.string().min(1),
-  value: z.unknown(),
+  value: z.unknown().nullable().optional(),
 });
 
-// Condition group wrapping an array of conditions
-const TriggerConditionsSchema = z.object({
-  conditions: z.array(TriggerConditionSchema).min(1),
-});
+const TriggerLogicSchema = z.enum(["and", "or"]);
+
+type TriggerCondition = z.infer<typeof TriggerConditionSchema>;
+type TriggerConditionGroup = {
+  logic?: z.infer<typeof TriggerLogicSchema>;
+  conditions: Array<TriggerCondition | TriggerConditionGroup>;
+};
+
+// Recursive condition group for trigger filtering. The backend also accepts
+// `{}` and `{ conditions: [] }` as "clear conditions" requests, so the schema
+// must allow those forms when parsing local config or remote payloads.
+const TriggerConditionGroupSchema: z.ZodType<TriggerConditionGroup> = z.lazy(
+  () =>
+    z
+      .object({
+        logic: TriggerLogicSchema.optional(),
+        conditions: z
+          .array(z.union([TriggerConditionSchema, TriggerConditionGroupSchema]))
+          .min(1),
+      })
+      .strict(),
+);
+
+const EmptyTriggerConditionsSchema = z.union([
+  z.object({}).strict(),
+  z
+    .object({
+      logic: TriggerLogicSchema.optional(),
+      conditions: z.array(z.unknown()).length(0),
+    })
+    .strict(),
+]);
+
+const TriggerConditionsSchema = z.union([
+  EmptyTriggerConditionsSchema,
+  TriggerConditionGroupSchema,
+]);
 
 // Connector automation (webhook-triggered)
 const ConnectorAutomationSchema = AutomationBaseSchema.extend({
   type: z.literal("connector"),
   integration_type: z.string().min(1, "Integration type cannot be empty"),
-  events: z.array(z.string()).min(1, "At least one event is required"),
+  events: z.array(z.string()),
   resource_id: z.string().nullable().optional(),
   trigger_conditions: TriggerConditionsSchema.nullable().optional(),
 });

--- a/packages/cli/src/core/resources/function/schema.ts
+++ b/packages/cli/src/core/resources/function/schema.ts
@@ -96,6 +96,7 @@ const TriggerConditionGroupSchema: z.ZodType<TriggerConditionGroup> = z.lazy(
 const ConnectorAutomationSchema = AutomationBaseSchema.extend({
   type: z.literal("connector"),
   integration_type: IntegrationTypeSchema,
+  // No .min(1) — empty means catch-all; the server enforces per-integration.
   events: z.array(z.string()),
   resource_id: z.string().nullable().optional(),
   trigger_conditions: TriggerConditionGroupSchema.nullable().optional(),

--- a/packages/cli/tests/core/function-schema.spec.ts
+++ b/packages/cli/tests/core/function-schema.spec.ts
@@ -173,6 +173,58 @@ describe("Function connector automation schemas", () => {
     expect(result.success).toBe(true);
   });
 
+  it("rejects connector automation missing integration_type", () => {
+    const result = FunctionConfigSchema.safeParse({
+      name: "missing-integration",
+      entry: "index.ts",
+      automations: [
+        {
+          name: "bad-connector",
+          type: "connector",
+          events: ["message"],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects condition group with zero conditions", () => {
+    const result = FunctionConfigSchema.safeParse({
+      name: "empty-group",
+      entry: "index.ts",
+      automations: [
+        {
+          name: "empty-conditions",
+          type: "connector",
+          integration_type: "slack",
+          events: ["message"],
+          trigger_conditions: {
+            conditions: [],
+          },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown automation type", () => {
+    const result = FunctionConfigSchema.safeParse({
+      name: "unknown-type",
+      entry: "index.ts",
+      automations: [
+        {
+          name: "mystery",
+          type: "webhook",
+          url: "https://example.com",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it("parses list responses with connector automations unchanged", () => {
     const result = ListFunctionsResponseSchema.safeParse({
       functions: [

--- a/packages/cli/tests/core/function-schema.spec.ts
+++ b/packages/cli/tests/core/function-schema.spec.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+import {
+  FunctionConfigSchema,
+  ListFunctionsResponseSchema,
+} from "@/core/resources/function/schema.js";
+
+describe("Function connector automation schemas", () => {
+  it("parses recursive trigger conditions without losing logic", () => {
+    const result = FunctionConfigSchema.safeParse({
+      name: "handle-slack-events",
+      entry: "index.ts",
+      automations: [
+        {
+          name: "slack-router",
+          type: "connector",
+          integration_type: "slack",
+          events: ["message"],
+          trigger_conditions: {
+            logic: "or",
+            conditions: [
+              {
+                logic: "and",
+                conditions: [
+                  {
+                    field: "event.channel",
+                    operator: "equals",
+                    value: "C_GENERAL",
+                  },
+                  {
+                    field: "event.user",
+                    operator: "equals",
+                    value: "U_ALICE",
+                  },
+                ],
+              },
+              {
+                field: "event.channel",
+                operator: "equals",
+                value: "C_SUPPORT",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error("Expected connector automation config to parse");
+    }
+
+    expect(result.data.automations).toEqual([
+      {
+        name: "slack-router",
+        type: "connector",
+        integration_type: "slack",
+        events: ["message"],
+        is_active: true,
+        trigger_conditions: {
+          logic: "or",
+          conditions: [
+            {
+              logic: "and",
+              conditions: [
+                {
+                  field: "event.channel",
+                  operator: "equals",
+                  value: "C_GENERAL",
+                },
+                {
+                  field: "event.user",
+                  operator: "equals",
+                  value: "U_ALICE",
+                },
+              ],
+            },
+            {
+              field: "event.channel",
+              operator: "equals",
+              value: "C_SUPPORT",
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("accepts catch-all connector automations with empty events", () => {
+    const result = FunctionConfigSchema.safeParse({
+      name: "handle-calendar-events",
+      entry: "index.ts",
+      automations: [
+        {
+          name: "calendar-catch-all",
+          type: "connector",
+          integration_type: "googlecalendar",
+          events: [],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts backend-supported clear forms for trigger conditions", () => {
+    const clearForms = [
+      null,
+      {},
+      { conditions: [] },
+      { logic: "and", conditions: [] },
+    ];
+
+    for (const triggerConditions of clearForms) {
+      const result = FunctionConfigSchema.safeParse({
+        name: "clear-conditions",
+        entry: "index.ts",
+        automations: [
+          {
+            name: "clearable-connector",
+            type: "connector",
+            integration_type: "slack",
+            events: ["message"],
+            trigger_conditions: triggerConditions,
+          },
+        ],
+      });
+
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("accepts exists-style conditions without a value", () => {
+    const result = FunctionConfigSchema.safeParse({
+      name: "exists-filter",
+      entry: "index.ts",
+      automations: [
+        {
+          name: "slack-has-thread-ts",
+          type: "connector",
+          integration_type: "slack",
+          events: ["message"],
+          trigger_conditions: {
+            conditions: [
+              {
+                field: "event.thread_ts",
+                operator: "exists",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("parses list responses with connector automations unchanged", () => {
+    const result = ListFunctionsResponseSchema.safeParse({
+      functions: [
+        {
+          name: "handle-webhooks",
+          deployment_id: "dep_123",
+          entry: "index.ts",
+          files: [{ path: "index.ts", content: "Deno.serve(() => {})" }],
+          automations: [
+            {
+              name: "slack-filter",
+              type: "connector",
+              integration_type: "slack",
+              events: [],
+              trigger_conditions: {
+                logic: "and",
+                conditions: [
+                  {
+                    field: "event.channel",
+                    operator: "equals",
+                    value: "C_GENERAL",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error("Expected functions list response to parse");
+    }
+
+    expect(result.data.functions[0]?.automations).toEqual([
+      {
+        name: "slack-filter",
+        type: "connector",
+        integration_type: "slack",
+        events: [],
+        is_active: true,
+        trigger_conditions: {
+          logic: "and",
+          conditions: [
+            {
+              field: "event.channel",
+              operator: "equals",
+              value: "C_GENERAL",
+            },
+          ],
+        },
+      },
+    ]);
+  });
+});

--- a/packages/cli/tests/core/function-schema.spec.ts
+++ b/packages/cli/tests/core/function-schema.spec.ts
@@ -102,15 +102,8 @@ describe("Function connector automation schemas", () => {
     expect(result.success).toBe(true);
   });
 
-  it("accepts backend-supported clear forms for trigger conditions", () => {
-    const clearForms = [
-      null,
-      {},
-      { conditions: [] },
-      { logic: "and", conditions: [] },
-    ];
-
-    for (const triggerConditions of clearForms) {
+  it("accepts null and undefined to clear trigger conditions", () => {
+    for (const triggerConditions of [null, undefined]) {
       const result = FunctionConfigSchema.safeParse({
         name: "clear-conditions",
         entry: "index.ts",
@@ -126,6 +119,32 @@ describe("Function connector automation schemas", () => {
       });
 
       expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects empty trigger condition forms that the backend also rejects", () => {
+    const invalidForms = [
+      {},
+      { conditions: [] },
+      { logic: "and", conditions: [] },
+    ];
+
+    for (const triggerConditions of invalidForms) {
+      const result = FunctionConfigSchema.safeParse({
+        name: "bad-conditions",
+        entry: "index.ts",
+        automations: [
+          {
+            name: "bad-connector",
+            type: "connector",
+            integration_type: "slack",
+            events: ["message"],
+            trigger_conditions: triggerConditions,
+          },
+        ],
+      });
+
+      expect(result.success).toBe(false);
     }
   });
 


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Adds Zod schema support for connector (webhook-triggered) automations in the function configuration, including a recursive `trigger_conditions` structure for field-level filtering. The schema uses a forward-compatible operator union so that unknown future operators from the backend still parse without errors. An empty `trigger_conditions` form is rejected (mirroring backend validation), while `null`/`undefined` are accepted to clear conditions.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added `ConnectorAutomationSchema` to `function/schema.ts` covering `type: "connector"` automations with `integration_type`, `events`, `resource_id`, and `trigger_conditions` fields
> - Added `TriggerConditionSchema` and recursive `TriggerConditionGroupSchema` (via `z.lazy`) for arbitrarily nested and/or condition trees
> - Added `ConditionOperatorSchema` with all known backend operators enumerated plus a forward-compat `z.string()` fallback
> - Included `ConnectorAutomationSchema` in the `AutomationSchema` union alongside existing scheduled and entity types
> - Added `packages/cli/tests/core/function-schema.spec.ts` with 9 tests covering valid, null/undefined, catch-all, recursive, exists-style, and rejection cases
> - Added `.superset/` to `.gitignore`
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [x] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [x] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The `events` array intentionally has no `.min(1)` constraint — an empty array means "catch-all" for a connector integration, and per-integration enforcement is handled server-side. The `KnownConditionOperators` list is kept in sync with the backend `ConditionOperator` enum; the `z.string().min(1)` fallback ensures forward compatibility when new operators are added.
>
> ---
> <sub>🤖 Generated by Claude | 2026-04-13 08:06 UTC</sub>