### PR TITLE
fix: convert function path to file URL for Windows

### DIFF
--- a/packages/cli/src/cli/dev/dev-server/function-manager.ts
+++ b/packages/cli/src/cli/dev/dev-server/function-manager.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
+import { pathToFileURL } from "node:url";
 import getPort from "get-port";
 import type { DevLogger } from "@/cli/dev/createDevLogger.js";
 import { InternalError, InvalidInputError } from "@/core/errors.js";
@@ -117,7 +118,7 @@ export class FunctionManager {
     const process = spawn("deno", ["run", "--allow-all", this.wrapperPath], {
       env: {
         ...globalThis.process.env,
-        FUNCTION_PATH: func.entryPath,
+        FUNCTION_PATH: pathToFileURL(func.entryPath).href,
         FUNCTION_PORT: String(port),
         FUNCTION_NAME: func.name,
       },


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR fixes a Windows compatibility issue in the dev server's function manager where function entry paths were passed as raw filesystem paths to Deno. On Windows, absolute paths like `C:\path\to\file.ts` are not valid module specifiers in Deno, so the fix converts the path to a `file://` URL before passing it as `FUNCTION_PATH`.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Imported `pathToFileURL` from Node.js built-in `node:url` module in `function-manager.ts`
> - Converted `func.entryPath` to a `file://` URL via `pathToFileURL(func.entryPath).href` before assigning it to the `FUNCTION_PATH` environment variable passed to the spawned Deno process
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> `pathToFileURL` is a Node.js built-in that correctly handles platform differences (e.g., drive letters and backslashes on Windows), producing a standards-compliant `file:///C:/path/to/file.ts` URL that Deno can import without issue. On POSIX systems the behavior is unchanged.
>
> ---
> <sub>🤖 Generated by Claude | 2026-04-15 11:44 UTC | 7d46c5c</sub>