### PR TITLE
feat: add `auth sso` command for SSO provider configuration

### DIFF
--- a/packages/cli/src/cli/commands/auth/index.ts
+++ b/packages/cli/src/cli/commands/auth/index.ts
@@ -3,12 +3,14 @@ import { getPasswordLoginCommand } from "./password-login.js";
 import { getAuthPullCommand } from "./pull.js";
 import { getAuthPushCommand } from "./push.js";
 import { getSocialLoginCommand } from "./social-login.js";
+import { getSSOCommand } from "./sso.js";
 
 export function getAuthCommand(): Command {
   return new Command("auth")
     .description("Manage app authentication settings")
     .addCommand(getPasswordLoginCommand())
     .addCommand(getSocialLoginCommand())
+    .addCommand(getSSOCommand())
     .addCommand(getAuthPullCommand())
     .addCommand(getAuthPushCommand());
 }

--- a/packages/cli/src/cli/commands/auth/sso.ts
+++ b/packages/cli/src/cli/commands/auth/sso.ts
@@ -3,13 +3,15 @@ import { Argument, type Command, Option } from "commander";
 import { z } from "zod";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";
 import { Base44Command, resolveSecret } from "@/cli/utils/index.js";
-import { InvalidInputError } from "@/core/errors.js";
+import { InvalidInputError, SchemaValidationError } from "@/core/errors.js";
 import { readProjectConfig } from "@/core/project/index.js";
 import {
   buildSSOSecrets,
   deleteSSOSecrets,
+  hasAnyLoginMethod,
   KNOWN_SSO_PROVIDERS,
   type KnownSSOProvider,
+  MissingSSOFieldsError,
   pushSSOSecrets,
   type SSOSecretOptions,
   updateSSOConfig,
@@ -20,7 +22,12 @@ import { parseEnvFile } from "@/core/utils/index.js";
 // -- File input schema (CLI concern: user-facing file format) ----------------
 
 const SSOConfigFileSchema = z.object({
-  provider: z.enum(["google", "microsoft", "github", "okta", "custom"]),
+  provider: z.enum(
+    Object.values(KNOWN_SSO_PROVIDERS) as [
+      KnownSSOProvider,
+      ...KnownSSOProvider[],
+    ],
+  ),
   clientId: z.string(),
   clientSecret: z.string(),
   scope: z.string().optional(),
@@ -42,11 +49,10 @@ async function loadSSOConfigFile(filePath: string): Promise<SSOConfigFile> {
   const result = SSOConfigFileSchema.safeParse(raw);
 
   if (!result.success) {
-    const issues = result.error.issues
-      .map((i) => `  ${i.path.join(".")}: ${i.message}`)
-      .join("\n");
-    throw new InvalidInputError(
-      `Invalid SSO config file ${filePath}:\n${issues}`,
+    throw new SchemaValidationError(
+      "Invalid SSO config file",
+      result.error,
+      filePath,
     );
   }
 
@@ -204,19 +210,19 @@ async function ssoEnableAction(
   try {
     secrets = buildSSOSecrets(provider, secretOptions);
   } catch (error) {
-    if (error instanceof InvalidInputError) {
-      // Re-throw with CLI flag names and an example command
-      const flagMessage = error.message.replace(/sso_[a-z_]+/g, (key) =>
-        secretKeyToFlag(key),
+    if (error instanceof MissingSSOFieldsError) {
+      const flagNames = error.missingKeys.map(secretKeyToFlag);
+      throw new InvalidInputError(
+        `Missing required fields for ${error.provider}: ${flagNames.join(", ")}`,
+        {
+          hints: [
+            {
+              message: `Example: ${exampleCommand(provider)}`,
+              command: exampleCommand(provider),
+            },
+          ],
+        },
       );
-      throw new InvalidInputError(flagMessage, {
-        hints: [
-          {
-            message: `Example: ${exampleCommand(provider)}`,
-            command: exampleCommand(provider),
-          },
-        ],
-      });
     }
     throw error;
   }
@@ -238,18 +244,52 @@ async function ssoEnableAction(
   };
 }
 
-async function ssoDisableAction({
-  runTask,
-}: CLIContext): Promise<RunCommandResult> {
+/** Returns true if any flag intended for `enable` was passed. */
+function hasEnableOnlyOptions(options: SSOOptions): boolean {
+  return Boolean(
+    options.provider ||
+      options.clientId ||
+      options.clientSecret ||
+      options.clientSecretStdin ||
+      options.envFile ||
+      options.file ||
+      options.scope ||
+      options.discoveryUrl ||
+      options.tenantId ||
+      options.oktaDomain ||
+      options.authEndpoint ||
+      options.tokenEndpoint ||
+      options.userinfoEndpoint ||
+      options.jwksUri ||
+      options.ssoName,
+  );
+}
+
+async function ssoDisableAction(
+  { log, runTask }: CLIContext,
+  options: SSOOptions,
+): Promise<RunCommandResult> {
+  if (hasEnableOnlyOptions(options)) {
+    throw new InvalidInputError(
+      "Configuration options cannot be used with disable. To disable SSO: base44 auth sso disable",
+    );
+  }
+
   const { project } = await readProjectConfig();
   const configDir = dirname(project.configPath);
   const authDir = join(configDir, project.authDir);
 
-  await runTask("Updating local auth config", async () =>
+  const updated = await runTask("Updating local auth config", async () =>
     updateSSOConfig(authDir, null, false),
   );
 
   await runTask("Removing SSO credentials", async () => deleteSSOSecrets());
+
+  if (!hasAnyLoginMethod(updated)) {
+    log.warn(
+      "Disabling SSO will leave no login methods enabled. Users will be locked out.",
+    );
+  }
 
   return {
     outroMessage:
@@ -263,7 +303,7 @@ async function ssoAction(
   options: SSOOptions,
 ): Promise<RunCommandResult> {
   if (action === "disable") {
-    return ssoDisableAction(context);
+    return ssoDisableAction(context, options);
   }
   return ssoEnableAction(context, options);
 }
@@ -271,7 +311,7 @@ async function ssoAction(
 export function getSSOCommand(): Command {
   return new Base44Command("sso")
     .description(
-      "Configure SSO identity provider (google, microsoft, github, okta, custom)",
+      "Configure SSO identity provider (google, microsoft, github, okta, custom). SSO and social login are mutually exclusive — enabling one disables the other in the local auth config.",
     )
     .addArgument(
       new Argument("<action>", "enable or disable SSO").choices([
@@ -289,7 +329,7 @@ export function getSSOCommand(): Command {
     .option("--client-secret-stdin", "Read client secret from stdin")
     .option(
       "--env-file <path>",
-      "Read client secret from a .env file (key: sso_client_secret)",
+      "Read client secret from a .env file (key: sso_client_secret). Ignored if --client-secret is provided directly or via --file.",
     )
     .option("--file <path>", "JSON config file with all SSO settings")
     .option("--scope <scope>", "OAuth scope (defaults per provider)")

--- a/packages/cli/src/cli/commands/auth/sso.ts
+++ b/packages/cli/src/cli/commands/auth/sso.ts
@@ -95,6 +95,21 @@ function mergeFileWithFlags(
 
 const providerNames = Object.keys(KNOWN_SSO_PROVIDERS);
 
+/** Converts an API secret key like "sso_tenant_id" to a CLI flag like "--tenant-id". */
+function secretKeyToFlag(key: string): string {
+  return `--${key.replace(/^sso_/, "").replace(/_/g, "-")}`;
+}
+
+function exampleCommand(provider: KnownSSOProvider): string {
+  let cmd = `base44 auth sso enable --provider ${provider} --client-id <id> --client-secret <secret>`;
+  if (provider === KNOWN_SSO_PROVIDERS.microsoft) cmd += " --tenant-id <id>";
+  if (provider === KNOWN_SSO_PROVIDERS.okta) cmd += " --okta-domain <domain>";
+  if (provider === KNOWN_SSO_PROVIDERS.custom)
+    cmd +=
+      " --sso-name <name> --auth-endpoint <url> --token-endpoint <url> --userinfo-endpoint <url> --jwks-uri <url>";
+  return cmd;
+}
+
 function validateProvider(provider: string | undefined): KnownSSOProvider {
   if (!provider) {
     throw new InvalidInputError("Missing --provider.", {
@@ -111,6 +126,14 @@ function validateProvider(provider: string | undefined): KnownSSOProvider {
   if (!(provider in KNOWN_SSO_PROVIDERS)) {
     throw new InvalidInputError(
       `Unknown provider "${provider}". Valid providers: ${providerNames.join(", ")}`,
+      {
+        hints: [
+          {
+            message: `Example: base44 auth sso enable --provider ${providerNames[0]} --client-id <id> --client-secret <secret>`,
+            command: `base44 auth sso enable --provider <provider> --client-id <id> --client-secret <secret>`,
+          },
+        ],
+      },
     );
   }
 
@@ -191,7 +214,26 @@ async function ssoEnableAction(
     ssoName: merged.ssoName,
   };
 
-  const secrets = buildSSOSecrets(provider, secretOptions);
+  let secrets: Record<string, string>;
+  try {
+    secrets = buildSSOSecrets(provider, secretOptions);
+  } catch (error) {
+    if (error instanceof InvalidInputError) {
+      // Re-throw with CLI flag names and an example command
+      const flagMessage = error.message.replace(/sso_[a-z_]+/g, (key) =>
+        secretKeyToFlag(key),
+      );
+      throw new InvalidInputError(flagMessage, {
+        hints: [
+          {
+            message: `Example: ${exampleCommand(provider)}`,
+            command: exampleCommand(provider),
+          },
+        ],
+      });
+    }
+    throw error;
+  }
 
   // Update local auth config
   const { project } = await readProjectConfig();

--- a/packages/cli/src/cli/commands/auth/sso.ts
+++ b/packages/cli/src/cli/commands/auth/sso.ts
@@ -1,0 +1,282 @@
+import { dirname, join, resolve } from "node:path";
+import { Argument, type Command } from "commander";
+import { z } from "zod";
+import type { CLIContext, RunCommandResult } from "@/cli/types.js";
+import { Base44Command, resolveSecret } from "@/cli/utils/index.js";
+import { InvalidInputError } from "@/core/errors.js";
+import { readProjectConfig } from "@/core/project/index.js";
+import {
+  buildSSOSecrets,
+  deleteSSOSecrets,
+  KNOWN_SSO_PROVIDERS,
+  type KnownSSOProvider,
+  pushSSOSecrets,
+  type SSOSecretOptions,
+  updateSSOConfig,
+} from "@/core/resources/auth-config/index.js";
+import { readJsonFile } from "@/core/utils/fs.js";
+import { parseEnvFile } from "@/core/utils/index.js";
+
+// -- File input schema (CLI concern: user-facing file format) ----------------
+
+const SSOConfigFileSchema = z.object({
+  provider: z.enum(["google", "microsoft", "github", "okta", "custom"]),
+  clientId: z.string(),
+  clientSecret: z.string(),
+  scope: z.string().optional(),
+  discoveryUrl: z.string().optional(),
+  tenantId: z.string().optional(),
+  oktaDomain: z.string().optional(),
+  authEndpoint: z.string().optional(),
+  tokenEndpoint: z.string().optional(),
+  userinfoEndpoint: z.string().optional(),
+  jwksUri: z.string().optional(),
+  ssoName: z.string().optional(),
+});
+
+type SSOConfigFile = z.infer<typeof SSOConfigFileSchema>;
+
+async function loadSSOConfigFile(filePath: string): Promise<SSOConfigFile> {
+  const resolved = resolve(filePath);
+  const raw = await readJsonFile(resolved);
+  const result = SSOConfigFileSchema.safeParse(raw);
+
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `  ${i.path.join(".")}: ${i.message}`)
+      .join("\n");
+    throw new InvalidInputError(
+      `Invalid SSO config file ${filePath}:\n${issues}`,
+    );
+  }
+
+  return result.data;
+}
+
+interface SSOOptions {
+  provider?: string;
+  clientId?: string;
+  clientSecret?: string;
+  clientSecretStdin?: boolean;
+  envFile?: string;
+  file?: string;
+  scope?: string;
+  discoveryUrl?: string;
+  tenantId?: string;
+  oktaDomain?: string;
+  authEndpoint?: string;
+  tokenEndpoint?: string;
+  userinfoEndpoint?: string;
+  jwksUri?: string;
+  ssoName?: string;
+}
+
+function mergeFileWithFlags(
+  fileConfig: SSOConfigFile,
+  options: SSOOptions,
+): SSOOptions {
+  return {
+    provider: options.provider ?? fileConfig.provider,
+    clientId: options.clientId ?? fileConfig.clientId,
+    clientSecret: options.clientSecret ?? fileConfig.clientSecret,
+    clientSecretStdin: options.clientSecretStdin,
+    envFile: options.envFile,
+    scope: options.scope ?? fileConfig.scope,
+    discoveryUrl: options.discoveryUrl ?? fileConfig.discoveryUrl,
+    tenantId: options.tenantId ?? fileConfig.tenantId,
+    oktaDomain: options.oktaDomain ?? fileConfig.oktaDomain,
+    authEndpoint: options.authEndpoint ?? fileConfig.authEndpoint,
+    tokenEndpoint: options.tokenEndpoint ?? fileConfig.tokenEndpoint,
+    userinfoEndpoint: options.userinfoEndpoint ?? fileConfig.userinfoEndpoint,
+    jwksUri: options.jwksUri ?? fileConfig.jwksUri,
+    ssoName: options.ssoName ?? fileConfig.ssoName,
+  };
+}
+
+const providerNames = Object.keys(KNOWN_SSO_PROVIDERS);
+
+function validateProvider(provider: string | undefined): KnownSSOProvider {
+  if (!provider) {
+    throw new InvalidInputError("Missing --provider.", {
+      hints: [
+        {
+          message: `Valid providers: ${providerNames.join(", ")}`,
+          command:
+            "base44 auth sso enable --provider <provider> --client-id <id> --client-secret <secret>",
+        },
+      ],
+    });
+  }
+
+  if (!(provider in KNOWN_SSO_PROVIDERS)) {
+    throw new InvalidInputError(
+      `Unknown provider "${provider}". Valid providers: ${providerNames.join(", ")}`,
+    );
+  }
+
+  return provider as KnownSSOProvider;
+}
+
+async function ssoEnableAction(
+  { isNonInteractive, runTask }: CLIContext,
+  options: SSOOptions,
+): Promise<RunCommandResult> {
+  // Load file config if provided
+  let merged = options;
+  if (options.file) {
+    const fileConfig = await loadSSOConfigFile(options.file);
+    merged = mergeFileWithFlags(fileConfig, options);
+  }
+
+  const provider = validateProvider(merged.provider);
+
+  // Validate --client-id is present
+  if (!merged.clientId) {
+    throw new InvalidInputError("Missing --client-id.", {
+      hints: [
+        {
+          message: `Example: base44 auth sso enable --provider ${provider} --client-id <id> --client-secret <secret>`,
+          command: `base44 auth sso enable --provider ${provider} --client-id <id> --client-secret <secret>`,
+        },
+      ],
+    });
+  }
+
+  // Resolve client secret via flag, stdin, env file, or env var
+  let clientSecret: string;
+  if (merged.envFile && !merged.clientSecret) {
+    const secrets = await parseEnvFile(resolve(merged.envFile));
+    const value = secrets.sso_client_secret;
+    if (!value) {
+      throw new InvalidInputError(
+        `Key "sso_client_secret" not found in ${merged.envFile}.`,
+      );
+    }
+    clientSecret = value;
+  } else {
+    clientSecret = await resolveSecret({
+      flagValue: merged.clientSecret,
+      fromStdin: merged.clientSecretStdin,
+      envVar: "sso_client_secret",
+      promptMessage: "Enter SSO client secret",
+      isNonInteractive,
+      name: "client secret",
+      hints: [
+        {
+          message: `Provide via flag:   base44 auth sso enable --provider ${provider} --client-id <id> --client-secret <secret>`,
+          command: `base44 auth sso enable --provider ${provider} --client-id <id> --client-secret <secret>`,
+        },
+        {
+          message: `Provide via stdin:  echo <secret> | base44 auth sso enable --provider ${provider} --client-id <id> --client-secret-stdin`,
+        },
+        {
+          message: `Provide via env:    sso_client_secret=<secret> base44 auth sso enable --provider ${provider} --client-id <id>`,
+        },
+      ],
+    });
+  }
+
+  // Build and validate secrets payload
+  const secretOptions: SSOSecretOptions = {
+    clientId: merged.clientId,
+    clientSecret,
+    scope: merged.scope,
+    discoveryUrl: merged.discoveryUrl,
+    tenantId: merged.tenantId,
+    oktaDomain: merged.oktaDomain,
+    authEndpoint: merged.authEndpoint,
+    tokenEndpoint: merged.tokenEndpoint,
+    userinfoEndpoint: merged.userinfoEndpoint,
+    jwksUri: merged.jwksUri,
+    ssoName: merged.ssoName,
+  };
+
+  const secrets = buildSSOSecrets(provider, secretOptions);
+
+  // Update local auth config
+  const { project } = await readProjectConfig();
+  const configDir = dirname(project.configPath);
+  const authDir = join(configDir, project.authDir);
+
+  await runTask("Updating local auth config", async () =>
+    updateSSOConfig(authDir, provider, true),
+  );
+
+  // Push secrets to backend
+  await runTask("Saving SSO credentials", async () => pushSSOSecrets(secrets));
+
+  return {
+    outroMessage: `SSO configured with ${provider} in local config. Run \`base44 auth push\` or \`base44 deploy\` to apply.`,
+  };
+}
+
+async function ssoDisableAction({
+  runTask,
+}: CLIContext): Promise<RunCommandResult> {
+  const { project } = await readProjectConfig();
+  const configDir = dirname(project.configPath);
+  const authDir = join(configDir, project.authDir);
+
+  await runTask("Updating local auth config", async () =>
+    updateSSOConfig(authDir, null, false),
+  );
+
+  await runTask("Removing SSO credentials", async () => deleteSSOSecrets());
+
+  return {
+    outroMessage:
+      "SSO disabled in local config and credentials removed. Run `base44 auth push` or `base44 deploy` to apply.",
+  };
+}
+
+async function ssoAction(
+  context: CLIContext,
+  action: "enable" | "disable",
+  options: SSOOptions,
+): Promise<RunCommandResult> {
+  if (action === "disable") {
+    return ssoDisableAction(context);
+  }
+  return ssoEnableAction(context, options);
+}
+
+export function getSSOCommand(): Command {
+  return new Base44Command("sso")
+    .description(
+      "Configure SSO identity provider (google, microsoft, github, okta, custom)",
+    )
+    .addArgument(
+      new Argument("<action>", "enable or disable SSO").choices([
+        "enable",
+        "disable",
+      ]),
+    )
+    .option(
+      "--provider <provider>",
+      "SSO provider: google, microsoft, github, okta, custom",
+    )
+    .option("--client-id <id>", "OAuth client ID")
+    .option("--client-secret <secret>", "OAuth client secret")
+    .option("--client-secret-stdin", "Read client secret from stdin")
+    .option(
+      "--env-file <path>",
+      "Read client secret from a .env file (key: sso_client_secret)",
+    )
+    .option("--file <path>", "JSON config file with all SSO settings")
+    .option("--scope <scope>", "OAuth scope (defaults per provider)")
+    .option("--discovery-url <url>", "OIDC discovery URL")
+    .option("--tenant-id <id>", "Microsoft tenant ID (required for microsoft)")
+    .option("--okta-domain <domain>", "Okta domain (required for okta)")
+    .option(
+      "--auth-endpoint <url>",
+      "Authorization endpoint (required for custom)",
+    )
+    .option("--token-endpoint <url>", "Token endpoint (required for custom)")
+    .option(
+      "--userinfo-endpoint <url>",
+      "Userinfo endpoint (required for custom)",
+    )
+    .option("--jwks-uri <url>", "JWKS URI (required for custom)")
+    .option("--sso-name <name>", "Provider display name (required for custom)")
+    .action(ssoAction);
+}

--- a/packages/cli/src/cli/commands/auth/sso.ts
+++ b/packages/cli/src/cli/commands/auth/sso.ts
@@ -1,5 +1,5 @@
 import { dirname, join, resolve } from "node:path";
-import { Argument, type Command } from "commander";
+import { Argument, type Command, Option } from "commander";
 import { z } from "zod";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";
 import { Base44Command, resolveSecret } from "@/cli/utils/index.js";
@@ -121,20 +121,6 @@ function validateProvider(provider: string | undefined): KnownSSOProvider {
         },
       ],
     });
-  }
-
-  if (!(provider in KNOWN_SSO_PROVIDERS)) {
-    throw new InvalidInputError(
-      `Unknown provider "${provider}". Valid providers: ${providerNames.join(", ")}`,
-      {
-        hints: [
-          {
-            message: `Example: base44 auth sso enable --provider ${providerNames[0]} --client-id <id> --client-secret <secret>`,
-            command: `base44 auth sso enable --provider <provider> --client-id <id> --client-secret <secret>`,
-          },
-        ],
-      },
-    );
   }
 
   return provider as KnownSSOProvider;
@@ -293,9 +279,10 @@ export function getSSOCommand(): Command {
         "disable",
       ]),
     )
-    .option(
-      "--provider <provider>",
-      "SSO provider: google, microsoft, github, okta, custom",
+    .addOption(
+      new Option("--provider <provider>", "SSO provider").choices(
+        Object.values(KNOWN_SSO_PROVIDERS),
+      ),
     )
     .option("--client-id <id>", "OAuth client ID")
     .option("--client-secret <secret>", "OAuth client secret")

--- a/packages/cli/src/cli/commands/auth/sso.ts
+++ b/packages/cli/src/cli/commands/auth/sso.ts
@@ -13,6 +13,7 @@ import {
   type KnownSSOProvider,
   MissingSSOFieldsError,
   pushSSOSecrets,
+  SSOSecretKey,
   type SSOSecretOptions,
   updateSSOConfig,
 } from "@/core/resources/auth-config/index.js";
@@ -101,9 +102,27 @@ function mergeFileWithFlags(
 
 const providerNames = Object.keys(KNOWN_SSO_PROVIDERS);
 
-/** Converts an API secret key like "sso_tenant_id" to a CLI flag like "--tenant-id". */
-function secretKeyToFlag(key: string): string {
-  return `--${key.replace(/^sso_/, "").replace(/_/g, "-")}`;
+/**
+ * Maps each API secret key to its CLI flag name.
+ * Note: `sso_name` intentionally maps to `--sso-name` (not `--name`) to avoid
+ * collisions with potential future generic flags.
+ */
+const SECRET_KEY_TO_FLAG: Record<SSOSecretKey, string> = {
+  [SSOSecretKey.Name]: "--sso-name",
+  [SSOSecretKey.ClientId]: "--client-id",
+  [SSOSecretKey.ClientSecret]: "--client-secret",
+  [SSOSecretKey.Scope]: "--scope",
+  [SSOSecretKey.DiscoveryUrl]: "--discovery-url",
+  [SSOSecretKey.TenantId]: "--tenant-id",
+  [SSOSecretKey.AuthEndpoint]: "--auth-endpoint",
+  [SSOSecretKey.TokenEndpoint]: "--token-endpoint",
+  [SSOSecretKey.UserinfoEndpoint]: "--userinfo-endpoint",
+  [SSOSecretKey.OktaDomain]: "--okta-domain",
+  [SSOSecretKey.JwksUri]: "--jwks-uri",
+};
+
+function secretKeyToFlag(key: SSOSecretKey): string {
+  return SECRET_KEY_TO_FLAG[key];
 }
 
 function exampleCommand(provider: KnownSSOProvider): string {

--- a/packages/cli/src/cli/commands/auth/sso.ts
+++ b/packages/cli/src/cli/commands/auth/sso.ts
@@ -136,6 +136,12 @@ async function ssoEnableAction(
   { isNonInteractive, runTask }: CLIContext,
   options: SSOOptions,
 ): Promise<RunCommandResult> {
+  if (options.file && options.envFile) {
+    throw new InvalidInputError(
+      "--file and --env-file cannot be used together. Provide the client secret either inside --file or via --env-file.",
+    );
+  }
+
   // Load file config if provided
   let merged = options;
   if (options.file) {
@@ -329,7 +335,7 @@ export function getSSOCommand(): Command {
     .option("--client-secret-stdin", "Read client secret from stdin")
     .option(
       "--env-file <path>",
-      "Read client secret from a .env file (key: sso_client_secret). Ignored if --client-secret is provided directly or via --file.",
+      "Read client secret from a .env file (key: sso_client_secret)",
     )
     .option("--file <path>", "JSON config file with all SSO settings")
     .option("--scope <scope>", "OAuth scope (defaults per provider)")

--- a/packages/cli/src/core/resources/auth-config/index.ts
+++ b/packages/cli/src/core/resources/auth-config/index.ts
@@ -5,3 +5,4 @@ export * from "./push.js";
 export * from "./resource.js";
 export * from "./schema.js";
 export * from "./social-login.js";
+export * from "./sso/index.js";

--- a/packages/cli/src/core/resources/auth-config/social-login.ts
+++ b/packages/cli/src/core/resources/auth-config/social-login.ts
@@ -30,6 +30,11 @@ export async function updateSocialLoginConfig(
   const merged: AuthConfig = {
     ...current,
     [providerInfo.field]: enable,
+    // SSO and social login are mutually exclusive
+    ...(enable && {
+      enableSSOLogin: false,
+      ssoProviderName: null,
+    }),
   };
 
   if (providerInfo.customOAuth) {

--- a/packages/cli/src/core/resources/auth-config/sso/index.ts
+++ b/packages/cli/src/core/resources/auth-config/sso/index.ts
@@ -1,0 +1,14 @@
+export {
+  buildSSOSecrets,
+  deleteSSOSecrets,
+  pushSSOSecrets,
+  updateSSOConfig,
+} from "./operations.js";
+export { SSO_PROVIDER_SCHEMAS } from "./providers/index.js";
+export { ALL_SSO_SECRET_KEYS, SSOSecretKey } from "./secret-keys.js";
+export type {
+  KnownSSOProvider,
+  SSOProviderSchema,
+  SSOSecretOptions,
+} from "./types.js";
+export { KNOWN_SSO_PROVIDERS } from "./types.js";

--- a/packages/cli/src/core/resources/auth-config/sso/index.ts
+++ b/packages/cli/src/core/resources/auth-config/sso/index.ts
@@ -1,6 +1,7 @@
 export {
   buildSSOSecrets,
   deleteSSOSecrets,
+  MissingSSOFieldsError,
   pushSSOSecrets,
   updateSSOConfig,
 } from "./operations.js";

--- a/packages/cli/src/core/resources/auth-config/sso/operations.ts
+++ b/packages/cli/src/core/resources/auth-config/sso/operations.ts
@@ -1,0 +1,136 @@
+import { InvalidInputError } from "@/core/errors.js";
+import { deleteSecret, setSecrets } from "@/core/resources/secret/index.js";
+import {
+  DEFAULT_AUTH_CONFIG,
+  readAuthConfig,
+  writeAuthConfig,
+} from "../config.js";
+import type { AuthConfig } from "../schema.js";
+import { SSO_PROVIDER_SCHEMAS } from "./providers/index.js";
+import { ALL_SSO_SECRET_KEYS, SSOSecretKey } from "./secret-keys.js";
+import type { KnownSSOProvider, SSOSecretOptions } from "./types.js";
+import { KNOWN_SSO_PROVIDERS } from "./types.js";
+
+/** Maps SSOSecretOptions fields to API secret keys. */
+const OPTION_TO_SECRET_KEY: Record<string, SSOSecretKey> = {
+  scope: SSOSecretKey.Scope,
+  discoveryUrl: SSOSecretKey.DiscoveryUrl,
+  tenantId: SSOSecretKey.TenantId,
+  oktaDomain: SSOSecretKey.OktaDomain,
+  authEndpoint: SSOSecretKey.AuthEndpoint,
+  tokenEndpoint: SSOSecretKey.TokenEndpoint,
+  userinfoEndpoint: SSOSecretKey.UserinfoEndpoint,
+  jwksUri: SSOSecretKey.JwksUri,
+};
+
+/**
+ * Updates the local auth config to enable or disable SSO.
+ * Enabling SSO disables all social login providers (mutually exclusive).
+ */
+export async function updateSSOConfig(
+  authDir: string,
+  provider: KnownSSOProvider | null,
+  enable: boolean,
+): Promise<AuthConfig> {
+  const current = (await readAuthConfig(authDir)) ?? DEFAULT_AUTH_CONFIG;
+
+  const merged: AuthConfig = {
+    ...current,
+    enableSSOLogin: enable,
+    ssoProviderName: enable && provider ? provider : null,
+    // SSO and social login are mutually exclusive
+    ...(enable && {
+      enableGoogleLogin: false,
+      enableMicrosoftLogin: false,
+      enableFacebookLogin: false,
+      enableAppleLogin: false,
+    }),
+  };
+
+  await writeAuthConfig(authDir, merged);
+  return merged;
+}
+
+/**
+ * Builds the secrets payload for an SSO provider.
+ * Validates required fields per provider, applies defaults, and returns
+ * the API-ready secret key/value map.
+ *
+ * Throws with a list of missing field names (domain-level, not CLI flags)
+ * so the CLI layer can format them for the user.
+ */
+export function buildSSOSecrets(
+  provider: KnownSSOProvider,
+  options: SSOSecretOptions,
+): Record<string, string> {
+  const schema = SSO_PROVIDER_SCHEMAS[provider];
+
+  const secrets: Record<string, string> = {};
+  secrets[SSOSecretKey.Name] = options.ssoName ?? provider;
+  secrets[SSOSecretKey.ClientId] = options.clientId;
+  secrets[SSOSecretKey.ClientSecret] = options.clientSecret;
+
+  // Map option fields to secret keys
+  for (const [optionKey, secretKey] of Object.entries(OPTION_TO_SECRET_KEY)) {
+    const value = options[optionKey as keyof SSOSecretOptions];
+    if (typeof value === "string" && value.length > 0) {
+      secrets[secretKey] = value;
+    }
+  }
+
+  // Apply derived defaults (e.g., discovery URL from tenant ID)
+  if (schema.deriveDefaults) {
+    const derived = schema.deriveDefaults(secrets);
+    for (const [key, val] of Object.entries(derived)) {
+      if (!secrets[key]) {
+        secrets[key] = val;
+      }
+    }
+  }
+
+  // Apply static defaults
+  for (const [key, val] of Object.entries(schema.defaults)) {
+    if (!secrets[key]) {
+      secrets[key] = val;
+    }
+  }
+
+  // Validate required keys — report missing fields as domain names
+  const missing: string[] = [];
+  for (const key of schema.requiredKeys) {
+    if (!secrets[key]) {
+      missing.push(key);
+    }
+  }
+
+  if (provider === KNOWN_SSO_PROVIDERS.custom && !options.ssoName) {
+    missing.push(SSOSecretKey.Name);
+  }
+
+  if (missing.length > 0) {
+    throw new InvalidInputError(
+      `Missing required fields for ${provider}: ${missing.join(", ")}`,
+    );
+  }
+
+  // Remove empty values
+  return Object.fromEntries(
+    Object.entries(secrets).filter(([, v]) => v.length > 0),
+  );
+}
+
+/**
+ * Pushes SSO secrets to the backend via the secrets API.
+ */
+export async function pushSSOSecrets(
+  secrets: Record<string, string>,
+): Promise<void> {
+  await setSecrets(secrets);
+}
+
+/**
+ * Deletes all known SSO secret keys (best-effort).
+ */
+export async function deleteSSOSecrets(): Promise<void> {
+  await Promise.allSettled(ALL_SSO_SECRET_KEYS.map((key) => deleteSecret(key)));
+}

--- a/packages/cli/src/core/resources/auth-config/sso/operations.ts
+++ b/packages/cli/src/core/resources/auth-config/sso/operations.ts
@@ -52,11 +52,27 @@ export async function updateSSOConfig(
 }
 
 /**
+ * Thrown by `buildSSOSecrets` when required secret fields are missing.
+ * Exposes structured `missingKeys` so the CLI can map them to flag names
+ * without string-parsing the message.
+ */
+export class MissingSSOFieldsError extends InvalidInputError {
+  readonly missingKeys: SSOSecretKey[];
+  readonly provider: KnownSSOProvider;
+
+  constructor(provider: KnownSSOProvider, missingKeys: SSOSecretKey[]) {
+    super(`Missing required fields for ${provider}: ${missingKeys.join(", ")}`);
+    this.provider = provider;
+    this.missingKeys = missingKeys;
+  }
+}
+
+/**
  * Builds the secrets payload for an SSO provider.
  * Validates required fields per provider, applies defaults, and returns
  * the API-ready secret key/value map.
  *
- * Throws with a list of missing field names (domain-level, not CLI flags)
+ * Throws `MissingSSOFieldsError` with the structured list of missing keys
  * so the CLI layer can format them for the user.
  */
 export function buildSSOSecrets(
@@ -95,8 +111,8 @@ export function buildSSOSecrets(
     }
   }
 
-  // Validate required keys — report missing fields as domain names
-  const missing: string[] = [];
+  // Validate required keys — collect missing as typed enum values
+  const missing: SSOSecretKey[] = [];
   for (const key of schema.requiredKeys) {
     if (!secrets[key]) {
       missing.push(key);
@@ -108,9 +124,7 @@ export function buildSSOSecrets(
   }
 
   if (missing.length > 0) {
-    throw new InvalidInputError(
-      `Missing required fields for ${provider}: ${missing.join(", ")}`,
-    );
+    throw new MissingSSOFieldsError(provider, missing);
   }
 
   // Remove empty values

--- a/packages/cli/src/core/resources/auth-config/sso/providers/custom.ts
+++ b/packages/cli/src/core/resources/auth-config/sso/providers/custom.ts
@@ -1,0 +1,14 @@
+import { DEFAULT_OIDC_SCOPE, SSOSecretKey } from "../secret-keys.js";
+import type { SSOProviderSchema } from "../types.js";
+
+export const customProvider: SSOProviderSchema = {
+  requiredKeys: [
+    SSOSecretKey.AuthEndpoint,
+    SSOSecretKey.TokenEndpoint,
+    SSOSecretKey.UserinfoEndpoint,
+    SSOSecretKey.JwksUri,
+  ],
+  defaults: {
+    [SSOSecretKey.Scope]: DEFAULT_OIDC_SCOPE,
+  },
+};

--- a/packages/cli/src/core/resources/auth-config/sso/providers/github.ts
+++ b/packages/cli/src/core/resources/auth-config/sso/providers/github.ts
@@ -1,0 +1,12 @@
+import { DEFAULT_GITHUB_SCOPE, SSOSecretKey } from "../secret-keys.js";
+import type { SSOProviderSchema } from "../types.js";
+
+export const githubProvider: SSOProviderSchema = {
+  requiredKeys: [],
+  defaults: {
+    [SSOSecretKey.Scope]: DEFAULT_GITHUB_SCOPE,
+    [SSOSecretKey.AuthEndpoint]: "https://github.com/login/oauth/authorize",
+    [SSOSecretKey.TokenEndpoint]: "https://github.com/login/oauth/access_token",
+    [SSOSecretKey.UserinfoEndpoint]: "https://api.github.com/user",
+  },
+};

--- a/packages/cli/src/core/resources/auth-config/sso/providers/google.ts
+++ b/packages/cli/src/core/resources/auth-config/sso/providers/google.ts
@@ -1,0 +1,11 @@
+import { DEFAULT_OIDC_SCOPE, SSOSecretKey } from "../secret-keys.js";
+import type { SSOProviderSchema } from "../types.js";
+
+export const googleProvider: SSOProviderSchema = {
+  requiredKeys: [],
+  defaults: {
+    [SSOSecretKey.Scope]: DEFAULT_OIDC_SCOPE,
+    [SSOSecretKey.DiscoveryUrl]:
+      "https://accounts.google.com/.well-known/openid-configuration",
+  },
+};

--- a/packages/cli/src/core/resources/auth-config/sso/providers/index.ts
+++ b/packages/cli/src/core/resources/auth-config/sso/providers/index.ts
@@ -1,0 +1,15 @@
+import type { KnownSSOProvider, SSOProviderSchema } from "../types.js";
+import { customProvider } from "./custom.js";
+import { githubProvider } from "./github.js";
+import { googleProvider } from "./google.js";
+import { microsoftProvider } from "./microsoft.js";
+import { oktaProvider } from "./okta.js";
+
+export const SSO_PROVIDER_SCHEMAS: Record<KnownSSOProvider, SSOProviderSchema> =
+  {
+    google: googleProvider,
+    microsoft: microsoftProvider,
+    github: githubProvider,
+    okta: oktaProvider,
+    custom: customProvider,
+  };

--- a/packages/cli/src/core/resources/auth-config/sso/providers/microsoft.ts
+++ b/packages/cli/src/core/resources/auth-config/sso/providers/microsoft.ts
@@ -1,0 +1,18 @@
+import { DEFAULT_OIDC_SCOPE, SSOSecretKey } from "../secret-keys.js";
+import type { SSOProviderSchema } from "../types.js";
+
+export const microsoftProvider: SSOProviderSchema = {
+  requiredKeys: [SSOSecretKey.TenantId],
+  defaults: {
+    [SSOSecretKey.Scope]: DEFAULT_OIDC_SCOPE,
+  },
+  deriveDefaults: (secrets): Record<string, string> => {
+    const tenantId = secrets[SSOSecretKey.TenantId];
+    if (tenantId) {
+      return {
+        [SSOSecretKey.DiscoveryUrl]: `https://login.microsoftonline.com/${tenantId}/v2.0/.well-known/openid-configuration`,
+      };
+    }
+    return {};
+  },
+};

--- a/packages/cli/src/core/resources/auth-config/sso/providers/okta.ts
+++ b/packages/cli/src/core/resources/auth-config/sso/providers/okta.ts
@@ -1,0 +1,18 @@
+import { DEFAULT_OIDC_SCOPE, SSOSecretKey } from "../secret-keys.js";
+import type { SSOProviderSchema } from "../types.js";
+
+export const oktaProvider: SSOProviderSchema = {
+  requiredKeys: [SSOSecretKey.OktaDomain],
+  defaults: {
+    [SSOSecretKey.Scope]: DEFAULT_OIDC_SCOPE,
+  },
+  deriveDefaults: (secrets): Record<string, string> => {
+    const domain = secrets[SSOSecretKey.OktaDomain];
+    if (domain) {
+      return {
+        [SSOSecretKey.DiscoveryUrl]: `https://${domain}/.well-known/openid-configuration`,
+      };
+    }
+    return {};
+  },
+};

--- a/packages/cli/src/core/resources/auth-config/sso/secret-keys.ts
+++ b/packages/cli/src/core/resources/auth-config/sso/secret-keys.ts
@@ -1,0 +1,25 @@
+/**
+ * All SSO secret keys expected by the backend API.
+ * Used as the single source of truth for secret key names across
+ * provider schemas, secret building, and cleanup.
+ */
+export enum SSOSecretKey {
+  Name = "sso_name",
+  ClientId = "sso_client_id",
+  ClientSecret = "sso_client_secret",
+  Scope = "sso_scope",
+  DiscoveryUrl = "sso_discovery_url",
+  TenantId = "sso_tenant_id",
+  AuthEndpoint = "sso_auth_endpoint",
+  TokenEndpoint = "sso_token_endpoint",
+  UserinfoEndpoint = "sso_userinfo_endpoint",
+  OktaDomain = "sso_okta_domain",
+  JwksUri = "sso_jwks_uri",
+}
+
+/** All SSO secret key values, for bulk operations like cleanup. */
+export const ALL_SSO_SECRET_KEYS: string[] = Object.values(SSOSecretKey);
+
+/** Default OAuth scopes per provider category. */
+export const DEFAULT_OIDC_SCOPE = "openid email profile";
+export const DEFAULT_GITHUB_SCOPE = "user:email";

--- a/packages/cli/src/core/resources/auth-config/sso/types.ts
+++ b/packages/cli/src/core/resources/auth-config/sso/types.ts
@@ -1,0 +1,35 @@
+import type { SSOSecretKey } from "./secret-keys.js";
+
+export const KNOWN_SSO_PROVIDERS = {
+  google: "google",
+  microsoft: "microsoft",
+  github: "github",
+  okta: "okta",
+  custom: "custom",
+} as const;
+
+export type KnownSSOProvider =
+  (typeof KNOWN_SSO_PROVIDERS)[keyof typeof KNOWN_SSO_PROVIDERS];
+
+export interface SSOProviderSchema {
+  /** Secret keys required for this provider (beyond the base set) */
+  requiredKeys: SSOSecretKey[];
+  /** Default values for secrets (e.g., scope, discovery URL) */
+  defaults: Partial<Record<SSOSecretKey, string>>;
+  /** Function to derive default values from other options */
+  deriveDefaults?: (secrets: Record<string, string>) => Record<string, string>;
+}
+
+export interface SSOSecretOptions {
+  clientId: string;
+  clientSecret: string;
+  scope?: string;
+  discoveryUrl?: string;
+  tenantId?: string;
+  oktaDomain?: string;
+  authEndpoint?: string;
+  tokenEndpoint?: string;
+  userinfoEndpoint?: string;
+  jwksUri?: string;
+  ssoName?: string;
+}

--- a/packages/cli/tests/cli/auth_sso.spec.ts
+++ b/packages/cli/tests/cli/auth_sso.spec.ts
@@ -105,6 +105,37 @@ describe("auth sso command", () => {
     t.expectResult(result).toNotContain("sso_tenant_id");
   });
 
+  it("fails custom enable without --sso-name (uses CLI flag in error, not --name)", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockSecretsSet({ success: true });
+
+    const result = await t.run(
+      "auth",
+      "sso",
+      "enable",
+      "--provider",
+      "custom",
+      "--client-id",
+      "abc",
+      "--client-secret",
+      "xyz",
+      "--auth-endpoint",
+      "https://idp/authorize",
+      "--token-endpoint",
+      "https://idp/token",
+      "--userinfo-endpoint",
+      "https://idp/userinfo",
+      "--jwks-uri",
+      "https://idp/jwks",
+    );
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("--sso-name");
+    // Regression: regex-based conversion would yield --name, which is not a valid flag
+    t.expectResult(result).toNotContain("--name,");
+    t.expectResult(result).toNotContain("--name ");
+  });
+
   it("fails okta enable without --okta-domain (uses CLI flag in error)", async () => {
     await t.givenLoggedInWithProject(fixture("basic"));
     t.api.mockSecretsSet({ success: true });

--- a/packages/cli/tests/cli/auth_sso.spec.ts
+++ b/packages/cli/tests/cli/auth_sso.spec.ts
@@ -1,0 +1,166 @@
+import { describe, it } from "vitest";
+import { fixture, setupCLITests } from "./testkit/index.js";
+
+describe("auth sso command", () => {
+  const t = setupCLITests();
+
+  it("fails when no action argument is provided", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+
+    const result = await t.run("auth", "sso");
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("missing required argument");
+  });
+
+  it("fails with invalid action", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+
+    const result = await t.run("auth", "sso", "invalid");
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("enable");
+    t.expectResult(result).toContain("disable");
+  });
+
+  it("fails when not in a project directory", async () => {
+    await t.givenLoggedIn({ email: "test@example.com", name: "Test User" });
+
+    const result = await t.run(
+      "auth",
+      "sso",
+      "enable",
+      "--provider",
+      "google",
+      "--client-id",
+      "x",
+      "--client-secret",
+      "y",
+    );
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("No Base44 project found");
+  });
+
+  it("fails enable without --provider", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+
+    const result = await t.run(
+      "auth",
+      "sso",
+      "enable",
+      "--client-id",
+      "x",
+      "--client-secret",
+      "y",
+    );
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("Missing --provider");
+  });
+
+  it("fails enable without --client-id", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+
+    const result = await t.run(
+      "auth",
+      "sso",
+      "enable",
+      "--provider",
+      "google",
+      "--client-secret",
+      "y",
+    );
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("Missing --client-id");
+  });
+
+  it("fails microsoft enable without --tenant-id", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockSecretsSet({ success: true });
+
+    const result = await t.run(
+      "auth",
+      "sso",
+      "enable",
+      "--provider",
+      "microsoft",
+      "--client-id",
+      "abc",
+      "--client-secret",
+      "xyz",
+    );
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("sso_tenant_id");
+  });
+
+  it("fails okta enable without --okta-domain", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockSecretsSet({ success: true });
+
+    const result = await t.run(
+      "auth",
+      "sso",
+      "enable",
+      "--provider",
+      "okta",
+      "--client-id",
+      "abc",
+      "--client-secret",
+      "xyz",
+    );
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("sso_okta_domain");
+  });
+
+  it("shows help with --help flag", async () => {
+    const result = await t.run("auth", "sso", "--help");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("SSO identity provider");
+    t.expectResult(result).toContain("--provider");
+    t.expectResult(result).toContain("--client-id");
+    t.expectResult(result).toContain("--client-secret");
+    t.expectResult(result).toContain("--file");
+  });
+
+  it("shows sso in auth subcommands", async () => {
+    const result = await t.run("auth", "--help");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("sso");
+  });
+
+  it("enables google SSO with valid flags", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockSecretsSet({ success: true });
+
+    const result = await t.run(
+      "auth",
+      "sso",
+      "enable",
+      "--provider",
+      "google",
+      "--client-id",
+      "google-client-id",
+      "--client-secret",
+      "google-client-secret",
+    );
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("SSO configured with google");
+  });
+
+  it("disables SSO", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockSecretsDelete({ success: true });
+
+    const result = await t.run("auth", "sso", "disable");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("SSO disabled");
+  });
+});

--- a/packages/cli/tests/cli/auth_sso.spec.ts
+++ b/packages/cli/tests/cli/auth_sso.spec.ts
@@ -93,7 +93,7 @@ describe("auth sso command", () => {
     );
 
     t.expectResult(result).toFail();
-    t.expectResult(result).toContain("sso_tenant_id");
+    t.expectResult(result).toContain("--tenant-id");
   });
 
   it("fails okta enable without --okta-domain", async () => {
@@ -113,7 +113,7 @@ describe("auth sso command", () => {
     );
 
     t.expectResult(result).toFail();
-    t.expectResult(result).toContain("sso_okta_domain");
+    t.expectResult(result).toContain("--okta-domain");
   });
 
   it("shows help with --help flag", async () => {

--- a/packages/cli/tests/cli/auth_sso.spec.ts
+++ b/packages/cli/tests/cli/auth_sso.spec.ts
@@ -322,6 +322,37 @@ describe("auth sso command", () => {
     t.expectResult(result).toFail();
   });
 
+  it("fails when both --file and --env-file are provided", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+
+    const filePath = join(t.getTempDir(), "sso.json");
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        provider: "google",
+        clientId: "google-id",
+        clientSecret: "google-secret",
+      }),
+    );
+    const envPath = join(t.getTempDir(), ".env.sso");
+    await writeFile(envPath, "sso_client_secret=other-secret\n");
+
+    const result = await t.run(
+      "auth",
+      "sso",
+      "enable",
+      "--file",
+      filePath,
+      "--env-file",
+      envPath,
+    );
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain(
+      "--file and --env-file cannot be used together",
+    );
+  });
+
   it("fails on schema-invalid --file content", async () => {
     await t.givenLoggedInWithProject(fixture("basic"));
 

--- a/packages/cli/tests/cli/auth_sso.spec.ts
+++ b/packages/cli/tests/cli/auth_sso.spec.ts
@@ -1,8 +1,13 @@
-import { describe, it } from "vitest";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import JSON5 from "json5";
+import { describe, expect, it } from "vitest";
 import { fixture, setupCLITests } from "./testkit/index.js";
 
 describe("auth sso command", () => {
   const t = setupCLITests();
+
+  // ─── ARGUMENT VALIDATION ────────────────────────────────────────
 
   it("fails when no action argument is provided", async () => {
     await t.givenLoggedInWithProject(fixture("basic"));
@@ -42,6 +47,8 @@ describe("auth sso command", () => {
     t.expectResult(result).toContain("No Base44 project found");
   });
 
+  // ─── REQUIRED-FIELD VALIDATION ──────────────────────────────────
+
   it("fails enable without --provider", async () => {
     await t.givenLoggedInWithProject(fixture("basic"));
 
@@ -76,7 +83,7 @@ describe("auth sso command", () => {
     t.expectResult(result).toContain("Missing --client-id");
   });
 
-  it("fails microsoft enable without --tenant-id", async () => {
+  it("fails microsoft enable without --tenant-id (uses CLI flag in error)", async () => {
     await t.givenLoggedInWithProject(fixture("basic"));
     t.api.mockSecretsSet({ success: true });
 
@@ -93,10 +100,12 @@ describe("auth sso command", () => {
     );
 
     t.expectResult(result).toFail();
+    // The whole point of buildSSOSecrets's catch — flag names, not API keys
     t.expectResult(result).toContain("--tenant-id");
+    t.expectResult(result).toNotContain("sso_tenant_id");
   });
 
-  it("fails okta enable without --okta-domain", async () => {
+  it("fails okta enable without --okta-domain (uses CLI flag in error)", async () => {
     await t.givenLoggedInWithProject(fixture("basic"));
     t.api.mockSecretsSet({ success: true });
 
@@ -114,7 +123,10 @@ describe("auth sso command", () => {
 
     t.expectResult(result).toFail();
     t.expectResult(result).toContain("--okta-domain");
+    t.expectResult(result).toNotContain("sso_okta_domain");
   });
+
+  // ─── HELP / DISCOVERY ───────────────────────────────────────────
 
   it("shows help with --help flag", async () => {
     const result = await t.run("auth", "sso", "--help");
@@ -125,6 +137,10 @@ describe("auth sso command", () => {
     t.expectResult(result).toContain("--client-id");
     t.expectResult(result).toContain("--client-secret");
     t.expectResult(result).toContain("--file");
+    t.expectResult(result).toContain("--env-file");
+    t.expectResult(result).toContain("--client-secret-stdin");
+    // Mutual-exclusivity is documented in the description
+    t.expectResult(result).toContain("mutually exclusive");
   });
 
   it("shows sso in auth subcommands", async () => {
@@ -134,7 +150,9 @@ describe("auth sso command", () => {
     t.expectResult(result).toContain("sso");
   });
 
-  it("enables google SSO with valid flags", async () => {
+  // ─── HAPPY-PATH TESTS ───────────────────────────────────────────
+
+  it("enables google SSO and writes auth config + pushes secrets", async () => {
     await t.givenLoggedInWithProject(fixture("basic"));
     t.api.mockSecretsSet({ success: true });
 
@@ -152,6 +170,15 @@ describe("auth sso command", () => {
 
     t.expectResult(result).toSucceed();
     t.expectResult(result).toContain("SSO configured with google");
+
+    // Local config was written
+    const raw = await t.readProjectFile("base44/auth/config.jsonc");
+    expect(raw).not.toBeNull();
+    const config = JSON5.parse(raw!);
+    expect(config.enableSSOLogin).toBe(true);
+    expect(config.ssoProviderName).toBe("google");
+    // Mutual exclusivity
+    expect(config.enableGoogleLogin).toBe(false);
   });
 
   it("disables SSO", async () => {
@@ -162,5 +189,177 @@ describe("auth sso command", () => {
 
     t.expectResult(result).toSucceed();
     t.expectResult(result).toContain("SSO disabled");
+
+    const raw = await t.readProjectFile("base44/auth/config.jsonc");
+    expect(raw).not.toBeNull();
+    const config = JSON5.parse(raw!);
+    expect(config.enableSSOLogin).toBe(false);
+    expect(config.ssoProviderName).toBeNull();
+  });
+
+  it("rejects enable-only flags when used with disable", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+
+    const result = await t.run(
+      "auth",
+      "sso",
+      "disable",
+      "--provider",
+      "google",
+      "--client-id",
+      "x",
+    );
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("cannot be used with disable");
+  });
+
+  // ─── SECRET INPUT METHODS ───────────────────────────────────────
+
+  it("enables SSO with --client-secret-stdin", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockSecretsSet({ success: true });
+    t.givenStdin("stdin-secret-value");
+
+    const result = await t.run(
+      "auth",
+      "sso",
+      "enable",
+      "--provider",
+      "google",
+      "--client-id",
+      "google-id",
+      "--client-secret-stdin",
+    );
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("SSO configured with google");
+  });
+
+  it("enables SSO with --env-file resolving sso_client_secret", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockSecretsSet({ success: true });
+
+    const envPath = join(t.getTempDir(), ".env.sso");
+    await writeFile(envPath, "sso_client_secret=env-file-secret-value\n");
+
+    const result = await t.run(
+      "auth",
+      "sso",
+      "enable",
+      "--provider",
+      "google",
+      "--client-id",
+      "google-id",
+      "--env-file",
+      envPath,
+    );
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("SSO configured with google");
+  });
+
+  it("fails when --env-file does not contain sso_client_secret", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+
+    const envPath = join(t.getTempDir(), ".env.sso");
+    await writeFile(envPath, "SOMETHING_ELSE=value\n");
+
+    const result = await t.run(
+      "auth",
+      "sso",
+      "enable",
+      "--provider",
+      "google",
+      "--client-id",
+      "google-id",
+      "--env-file",
+      envPath,
+    );
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("sso_client_secret");
+    t.expectResult(result).toContain("not found");
+  });
+
+  // ─── --file INPUT ───────────────────────────────────────────────
+
+  it("enables SSO from a JSON --file", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockSecretsSet({ success: true });
+
+    const filePath = join(t.getTempDir(), "sso.json");
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        provider: "okta",
+        clientId: "okta-id",
+        clientSecret: "okta-secret",
+        oktaDomain: "myorg.okta.com",
+      }),
+    );
+
+    const result = await t.run("auth", "sso", "enable", "--file", filePath);
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("SSO configured with okta");
+
+    const raw = await t.readProjectFile("base44/auth/config.jsonc");
+    expect(raw).not.toBeNull();
+    const config = JSON5.parse(raw!);
+    expect(config.enableSSOLogin).toBe(true);
+    expect(config.ssoProviderName).toBe("okta");
+  });
+
+  it("fails on invalid JSON in --file", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+
+    const filePath = join(t.getTempDir(), "sso.json");
+    await writeFile(filePath, "{not valid json");
+
+    const result = await t.run("auth", "sso", "enable", "--file", filePath);
+
+    t.expectResult(result).toFail();
+  });
+
+  it("fails on schema-invalid --file content", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+
+    const filePath = join(t.getTempDir(), "sso.json");
+    await writeFile(
+      filePath,
+      JSON.stringify({ provider: "unknown-provider", clientId: "x" }),
+    );
+
+    const result = await t.run("auth", "sso", "enable", "--file", filePath);
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("Invalid SSO config file");
+  });
+
+  // ─── DEFAULTS / OVERRIDES ───────────────────────────────────────
+
+  it("allows --scope and --discovery-url to override provider defaults", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockSecretsSet({ success: true });
+
+    const result = await t.run(
+      "auth",
+      "sso",
+      "enable",
+      "--provider",
+      "google",
+      "--client-id",
+      "google-id",
+      "--client-secret",
+      "google-secret",
+      "--scope",
+      "openid email",
+      "--discovery-url",
+      "https://custom.example.com/.well-known/openid-configuration",
+    );
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("SSO configured with google");
   });
 });

--- a/packages/cli/tests/core/auth-sso.spec.ts
+++ b/packages/cli/tests/core/auth-sso.spec.ts
@@ -1,0 +1,243 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock secrets API
+const mockSetSecrets = vi.fn();
+const mockDeleteSecret = vi.fn();
+vi.mock("../../src/core/resources/secret/index.js", () => ({
+  setSecrets: (...args: unknown[]) => mockSetSecrets(...args),
+  deleteSecret: (...args: unknown[]) => mockDeleteSecret(...args),
+}));
+
+import {
+  readAuthConfig,
+  writeAuthConfig,
+} from "../../src/core/resources/auth-config/config.js";
+import type { AuthConfig } from "../../src/core/resources/auth-config/schema.js";
+import {
+  buildSSOSecrets,
+  deleteSSOSecrets,
+  KNOWN_SSO_PROVIDERS,
+  updateSSOConfig,
+} from "../../src/core/resources/auth-config/sso/index.js";
+
+const ALL_DISABLED: AuthConfig = {
+  enableUsernamePassword: false,
+  enableGoogleLogin: false,
+  enableMicrosoftLogin: false,
+  enableFacebookLogin: false,
+  enableAppleLogin: false,
+  ssoProviderName: null,
+  enableSSOLogin: false,
+  googleOAuthMode: "default",
+  googleOAuthClientId: null,
+  useWorkspaceSSO: false,
+};
+
+describe("updateSSOConfig", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "auth-sso-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("enables SSO with provider name", async () => {
+    await writeAuthConfig(tempDir, ALL_DISABLED);
+
+    const result = await updateSSOConfig(tempDir, "google", true);
+
+    expect(result.enableSSOLogin).toBe(true);
+    expect(result.ssoProviderName).toBe("google");
+
+    const saved = await readAuthConfig(tempDir);
+    expect(saved?.enableSSOLogin).toBe(true);
+    expect(saved?.ssoProviderName).toBe("google");
+  });
+
+  it("disables SSO and clears provider name", async () => {
+    await writeAuthConfig(tempDir, {
+      ...ALL_DISABLED,
+      enableSSOLogin: true,
+      ssoProviderName: "okta",
+    });
+
+    const result = await updateSSOConfig(tempDir, null, false);
+
+    expect(result.enableSSOLogin).toBe(false);
+    expect(result.ssoProviderName).toBeNull();
+
+    const saved = await readAuthConfig(tempDir);
+    expect(saved?.enableSSOLogin).toBe(false);
+    expect(saved?.ssoProviderName).toBeNull();
+  });
+
+  it("creates config file when none exists", async () => {
+    const result = await updateSSOConfig(tempDir, "microsoft", true);
+
+    expect(result.enableSSOLogin).toBe(true);
+    expect(result.ssoProviderName).toBe("microsoft");
+
+    const saved = await readAuthConfig(tempDir);
+    expect(saved).not.toBeNull();
+  });
+
+  it("preserves non-social fields and disables social login when enabling SSO", async () => {
+    await writeAuthConfig(tempDir, {
+      ...ALL_DISABLED,
+      enableUsernamePassword: true,
+      enableGoogleLogin: true,
+    });
+
+    const result = await updateSSOConfig(tempDir, "okta", true);
+
+    expect(result.enableUsernamePassword).toBe(true);
+    expect(result.enableSSOLogin).toBe(true);
+    // SSO and social login are mutually exclusive
+    expect(result.enableGoogleLogin).toBe(false);
+  });
+});
+
+describe("buildSSOSecrets", () => {
+  const baseOptions = {
+    clientId: "test-client-id",
+    clientSecret: "test-client-secret",
+  };
+
+  it("builds google secrets with defaults", () => {
+    const secrets = buildSSOSecrets("google", baseOptions);
+
+    expect(secrets.sso_name).toBe("google");
+    expect(secrets.sso_client_id).toBe("test-client-id");
+    expect(secrets.sso_client_secret).toBe("test-client-secret");
+    expect(secrets.sso_scope).toBe("openid email profile");
+    expect(secrets.sso_discovery_url).toBe(
+      "https://accounts.google.com/.well-known/openid-configuration",
+    );
+  });
+
+  it("builds microsoft secrets with tenant-derived discovery URL", () => {
+    const secrets = buildSSOSecrets("microsoft", {
+      ...baseOptions,
+      tenantId: "my-tenant",
+    });
+
+    expect(secrets.sso_tenant_id).toBe("my-tenant");
+    expect(secrets.sso_discovery_url).toBe(
+      "https://login.microsoftonline.com/my-tenant/v2.0/.well-known/openid-configuration",
+    );
+  });
+
+  it("throws when microsoft is missing tenant-id", () => {
+    expect(() => buildSSOSecrets("microsoft", baseOptions)).toThrow(
+      "sso_tenant_id",
+    );
+  });
+
+  it("builds github secrets with endpoint defaults", () => {
+    const secrets = buildSSOSecrets("github", baseOptions);
+
+    expect(secrets.sso_scope).toBe("user:email");
+    expect(secrets.sso_auth_endpoint).toBe(
+      "https://github.com/login/oauth/authorize",
+    );
+    expect(secrets.sso_token_endpoint).toBe(
+      "https://github.com/login/oauth/access_token",
+    );
+    expect(secrets.sso_userinfo_endpoint).toBe("https://api.github.com/user");
+  });
+
+  it("builds okta secrets with domain-derived discovery URL", () => {
+    const secrets = buildSSOSecrets("okta", {
+      ...baseOptions,
+      oktaDomain: "myorg.okta.com",
+    });
+
+    expect(secrets.sso_okta_domain).toBe("myorg.okta.com");
+    expect(secrets.sso_discovery_url).toBe(
+      "https://myorg.okta.com/.well-known/openid-configuration",
+    );
+  });
+
+  it("throws when okta is missing okta-domain", () => {
+    expect(() => buildSSOSecrets("okta", baseOptions)).toThrow(
+      "sso_okta_domain",
+    );
+  });
+
+  it("throws when custom is missing required endpoints", () => {
+    expect(() =>
+      buildSSOSecrets("custom", { ...baseOptions, ssoName: "my-idp" }),
+    ).toThrow("sso_auth_endpoint");
+  });
+
+  it("throws when custom is missing sso-name", () => {
+    expect(() =>
+      buildSSOSecrets("custom", {
+        ...baseOptions,
+        authEndpoint: "https://a",
+        tokenEndpoint: "https://b",
+        userinfoEndpoint: "https://c",
+        jwksUri: "https://d",
+      }),
+    ).toThrow("sso_name");
+  });
+
+  it("allows overriding defaults", () => {
+    const secrets = buildSSOSecrets("google", {
+      ...baseOptions,
+      scope: "openid",
+      discoveryUrl:
+        "https://custom.example.com/.well-known/openid-configuration",
+    });
+
+    expect(secrets.sso_scope).toBe("openid");
+    expect(secrets.sso_discovery_url).toBe(
+      "https://custom.example.com/.well-known/openid-configuration",
+    );
+  });
+
+  it("exports all known providers", () => {
+    expect(Object.keys(KNOWN_SSO_PROVIDERS)).toEqual([
+      "google",
+      "microsoft",
+      "github",
+      "okta",
+      "custom",
+    ]);
+  });
+});
+
+describe("deleteSSOSecrets", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockDeleteSecret.mockResolvedValue(undefined);
+  });
+
+  it("attempts to delete all known SSO secret keys", async () => {
+    await deleteSSOSecrets();
+
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_name");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_client_id");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_client_secret");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_scope");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_discovery_url");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_tenant_id");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_auth_endpoint");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_token_endpoint");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_userinfo_endpoint");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_okta_domain");
+    expect(mockDeleteSecret).toHaveBeenCalledWith("sso_jwks_uri");
+  });
+
+  it("does not throw when individual deletes fail", async () => {
+    mockDeleteSecret.mockRejectedValue(new Error("not found"));
+
+    await expect(deleteSSOSecrets()).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> This PR adds the `base44 auth sso` command, enabling users to configure SSO (Single Sign-On) authentication for their Base44 apps from the CLI. It supports five providers — Google, Microsoft, GitHub, Okta, and custom OIDC — and handles secret management by pushing credentials securely to the backend. The implementation includes both the CLI presentation layer (`auth/sso.ts`) and the core SDK layer with provider-specific schemas, secret key definitions, and operations.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added `base44 auth sso enable` and `base44 auth sso disable` subcommands under the existing `auth` command group
> - Implemented `core/resources/auth-config/sso/` module with provider schemas for Google, Microsoft, GitHub, Okta, and custom OIDC providers
> - Added `buildSSOSecrets`, `pushSSOSecrets`, `deleteSSOSecrets`, and `updateSSOConfig` operations to manage secrets and local auth config
> - Supports multiple secret input methods: `--client-secret`, `--client-secret-stdin`, `--env-file`, and environment variable (`SSO_CLIENT_SECRET`)
> - Supports loading full SSO config from a JSON/JSONC file via `--file`, with CLI flags taking precedence
> - Validates that `--file` and `--env-file` cannot be used together
> - Enables SSO and automatically disables mutually exclusive social login providers in `auth.jsonc`
> - Structured `MissingSSOFieldsError` maps missing API secret keys to user-facing flag names for clear error messages
> - Added comprehensive CLI integration tests (`tests/cli/auth_sso.spec.ts`) and core unit tests (`tests/core/auth-sso.spec.ts`) covering validation, all providers, and all secret input methods
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [x] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> SSO and social login (Google, Microsoft, Facebook, Apple) are mutually exclusive in the auth config. Enabling SSO via this command automatically disables any enabled social login providers in the local `auth.jsonc`. The `sso_name` secret key intentionally maps to `--sso-name` (not `--name`) to avoid future flag collisions.
>
> ---
> <sub>🤖 Generated by Claude | 2026-04-30 00:00 UTC | 9abd5e2</sub>