### PR TITLE
Fix local dev service role token

### DIFF
--- a/packages/cli/src/cli/dev/dev-server/auth-token.ts
+++ b/packages/cli/src/cli/dev/dev-server/auth-token.ts
@@ -2,7 +2,7 @@ import jwt from "jsonwebtoken";
 
 const LOCAL_DEV_SECRET = "LOCAL_DEV_SECRET";
 
-export const createJwtToken = (email: string) => {
+export const createJwtToken = (email: string): string => {
   return jwt.sign({ email, sub: email }, LOCAL_DEV_SECRET, {
     expiresIn: "360d",
   });

--- a/packages/cli/src/cli/dev/dev-server/auth-token.ts
+++ b/packages/cli/src/cli/dev/dev-server/auth-token.ts
@@ -1,0 +1,9 @@
+import jwt from "jsonwebtoken";
+
+const LOCAL_DEV_SECRET = "LOCAL_DEV_SECRET";
+
+export const createJwtToken = (email: string) => {
+  return jwt.sign({ email, sub: email }, LOCAL_DEV_SECRET, {
+    expiresIn: "360d",
+  });
+};

--- a/packages/cli/src/cli/dev/dev-server/routes/auth-router.ts
+++ b/packages/cli/src/cli/dev/dev-server/routes/auth-router.ts
@@ -1,11 +1,11 @@
 import { randomInt } from "node:crypto";
 import type { Request } from "express";
 import { json, Router } from "express";
-import jwt from "jsonwebtoken";
 import { nanoid } from "nanoid";
 import * as z from "zod";
 import { theme } from "@/cli/utils/theme.js";
 import type { DevLogger } from "../../createDevLogger.js";
+import { createJwtToken } from "../auth-token.js";
 import {
   type Database,
   PRIVATE_USER_COLLECTION,
@@ -13,17 +13,10 @@ import {
 } from "../db/database.js";
 import { getNowISOTimestamp } from "../utils.js";
 
-const LOCAL_DEV_SECRET = "LOCAL_DEV_SECRET";
 const TEN_MINUTES = 10 * 60 * 1000;
 
 const generateCode = () => {
   return randomInt(100000, 1000000).toString();
-};
-
-const createJwtToken = (email: string) => {
-  return jwt.sign({ sub: email }, LOCAL_DEV_SECRET, {
-    expiresIn: "360d",
-  });
 };
 
 const LoginBody = z.object({ email: z.email(), password: z.string() });

--- a/packages/cli/src/cli/dev/dev-server/routes/functions.ts
+++ b/packages/cli/src/cli/dev/dev-server/routes/functions.ts
@@ -4,9 +4,12 @@ import type { Request, Response } from "express";
 import { Router } from "express";
 import { createProxyMiddleware } from "http-proxy-middleware";
 import type { DevLogger } from "@/cli/dev/createDevLogger.js";
+import { createJwtToken } from "@/cli/dev/dev-server/auth-token.js";
 import type { FunctionManager } from "@/cli/dev/dev-server/function-manager.js";
 
-const LOCAL_DEV_SERVICE_AUTHORIZATION_TOKEN = "Bearer dev";
+const LOCAL_DEV_SERVICE_AUTHORIZATION_TOKEN = `Bearer ${createJwtToken(
+  "server@server.com",
+)}`;
 
 export function createFunctionRouter(
   manager: FunctionManager,

--- a/packages/cli/src/cli/dev/dev-server/routes/functions.ts
+++ b/packages/cli/src/cli/dev/dev-server/routes/functions.ts
@@ -19,14 +19,11 @@ export function createFunctionRouter(
     on: {
       proxyReq: (proxyReq, req) => {
         const xAppId = req.headers["x-app-id"];
-        const authorization = req.headers.authorization;
 
         if (xAppId) {
           proxyReq.setHeader("Base44-App-Id", xAppId as string);
         }
-        if (authorization) {
-          proxyReq.setHeader("Base44-Service-Authorization", authorization);
-        }
+        proxyReq.setHeader("Base44-Service-Authorization", "Bearer dev");
         proxyReq.setHeader(
           "Base44-Api-Url",
           `${(req as unknown as Request).protocol}://${req.headers.host}`,

--- a/packages/cli/src/cli/dev/dev-server/routes/functions.ts
+++ b/packages/cli/src/cli/dev/dev-server/routes/functions.ts
@@ -26,10 +26,6 @@ export function createFunctionRouter(
           proxyReq.setHeader("Base44-App-Id", xAppId as string);
         }
         proxyReq.setHeader(
-          "Authorization",
-          LOCAL_DEV_SERVICE_AUTHORIZATION_TOKEN,
-        );
-        proxyReq.setHeader(
           "Base44-Service-Authorization",
           LOCAL_DEV_SERVICE_AUTHORIZATION_TOKEN,
         );

--- a/packages/cli/src/cli/dev/dev-server/routes/functions.ts
+++ b/packages/cli/src/cli/dev/dev-server/routes/functions.ts
@@ -6,6 +6,8 @@ import { createProxyMiddleware } from "http-proxy-middleware";
 import type { DevLogger } from "@/cli/dev/createDevLogger.js";
 import type { FunctionManager } from "@/cli/dev/dev-server/function-manager.js";
 
+const LOCAL_DEV_AUTHORIZATION = "Bearer dev";
+
 export function createFunctionRouter(
   manager: FunctionManager,
   logger: DevLogger,
@@ -23,7 +25,11 @@ export function createFunctionRouter(
         if (xAppId) {
           proxyReq.setHeader("Base44-App-Id", xAppId as string);
         }
-        proxyReq.setHeader("Base44-Service-Authorization", "Bearer dev");
+        proxyReq.setHeader("Authorization", LOCAL_DEV_AUTHORIZATION);
+        proxyReq.setHeader(
+          "Base44-Service-Authorization",
+          LOCAL_DEV_AUTHORIZATION,
+        );
         proxyReq.setHeader(
           "Base44-Api-Url",
           `${(req as unknown as Request).protocol}://${req.headers.host}`,

--- a/packages/cli/src/cli/dev/dev-server/routes/functions.ts
+++ b/packages/cli/src/cli/dev/dev-server/routes/functions.ts
@@ -6,7 +6,7 @@ import { createProxyMiddleware } from "http-proxy-middleware";
 import type { DevLogger } from "@/cli/dev/createDevLogger.js";
 import type { FunctionManager } from "@/cli/dev/dev-server/function-manager.js";
 
-const LOCAL_DEV_AUTHORIZATION = "Bearer dev";
+const LOCAL_DEV_SERVICE_AUTHORIZATION_TOKEN = "Bearer dev";
 
 export function createFunctionRouter(
   manager: FunctionManager,
@@ -25,10 +25,13 @@ export function createFunctionRouter(
         if (xAppId) {
           proxyReq.setHeader("Base44-App-Id", xAppId as string);
         }
-        proxyReq.setHeader("Authorization", LOCAL_DEV_AUTHORIZATION);
+        proxyReq.setHeader(
+          "Authorization",
+          LOCAL_DEV_SERVICE_AUTHORIZATION_TOKEN,
+        );
         proxyReq.setHeader(
           "Base44-Service-Authorization",
-          LOCAL_DEV_AUTHORIZATION,
+          LOCAL_DEV_SERVICE_AUTHORIZATION_TOKEN,
         );
         proxyReq.setHeader(
           "Base44-Api-Url",

--- a/packages/cli/tests/cli/dev.spec.ts
+++ b/packages/cli/tests/cli/dev.spec.ts
@@ -1,6 +1,6 @@
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import jwt from "jsonwebtoken";
+import jwt, { type JwtPayload } from "jsonwebtoken";
 import { outdent } from "outdent";
 import { describe, expect, it } from "vitest";
 import { waitForDevServer } from "./testkit/dev-utils.js";
@@ -64,12 +64,11 @@ describe("dev command", () => {
     const anonymousResult = await anonymousResponse.json();
     expect(anonymousResult.authorization).toBeNull();
     expect(anonymousResult.serviceAuthorization).toMatch(/^Bearer .+/);
-    expect(
-      jwt.decode(anonymousResult.serviceAuthorization.replace("Bearer ", "")),
-    ).toMatchObject({
-      email: "server@server.com",
-      sub: "server@server.com",
-    });
+    const serviceTokenPayload = jwt.decode(
+      anonymousResult.serviceAuthorization.replace("Bearer ", ""),
+    ) as JwtPayload | null;
+    expect(serviceTokenPayload?.email).toBe("server@server.com");
+    expect(serviceTokenPayload?.sub).toBe("server@server.com");
 
     expect(anonymousResult).toEqual({
       authorization: null,

--- a/packages/cli/tests/cli/dev.spec.ts
+++ b/packages/cli/tests/cli/dev.spec.ts
@@ -1,5 +1,6 @@
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import jwt from "jsonwebtoken";
 import { outdent } from "outdent";
 import { describe, expect, it } from "vitest";
 import { waitForDevServer } from "./testkit/dev-utils.js";
@@ -60,9 +61,19 @@ describe("dev command", () => {
       "X-App-Id": t.api.appId,
     });
     expect(anonymousResponse.status).toBe(200);
-    await expect(anonymousResponse.json()).resolves.toEqual({
+    const anonymousResult = await anonymousResponse.json();
+    expect(anonymousResult.authorization).toBeNull();
+    expect(anonymousResult.serviceAuthorization).toMatch(/^Bearer .+/);
+    expect(
+      jwt.decode(anonymousResult.serviceAuthorization.replace("Bearer ", "")),
+    ).toMatchObject({
+      email: "server@server.com",
+      sub: "server@server.com",
+    });
+
+    expect(anonymousResult).toEqual({
       authorization: null,
-      serviceAuthorization: "Bearer dev",
+      serviceAuthorization: anonymousResult.serviceAuthorization,
     });
 
     const authenticatedResponse = await requestFunction({
@@ -70,9 +81,10 @@ describe("dev command", () => {
       "X-App-Id": t.api.appId,
     });
     expect(authenticatedResponse.status).toBe(200);
-    await expect(authenticatedResponse.json()).resolves.toEqual({
+    const authenticatedResult = await authenticatedResponse.json();
+    expect(authenticatedResult).toEqual({
       authorization: "Bearer test-app-token",
-      serviceAuthorization: "Bearer dev",
+      serviceAuthorization: anonymousResult.serviceAuthorization,
     });
 
     const result = await handle.stop();

--- a/packages/cli/tests/cli/dev.spec.ts
+++ b/packages/cli/tests/cli/dev.spec.ts
@@ -27,7 +27,7 @@ describe("dev command", () => {
     t.expectResult(result).toSucceed();
   });
 
-  it("sets a local service token header for functions", async () => {
+  it("sets local dev authorization headers for functions", async () => {
     await t.givenLoggedInWithProject(fixture("full-project"));
 
     await writeFile(
@@ -61,7 +61,7 @@ describe("dev command", () => {
     });
     expect(anonymousResponse.status).toBe(200);
     await expect(anonymousResponse.json()).resolves.toEqual({
-      authorization: null,
+      authorization: "Bearer dev",
       serviceAuthorization: "Bearer dev",
     });
 
@@ -71,7 +71,7 @@ describe("dev command", () => {
     });
     expect(authenticatedResponse.status).toBe(200);
     await expect(authenticatedResponse.json()).resolves.toEqual({
-      authorization: "Bearer test-app-token",
+      authorization: "Bearer dev",
       serviceAuthorization: "Bearer dev",
     });
 

--- a/packages/cli/tests/cli/dev.spec.ts
+++ b/packages/cli/tests/cli/dev.spec.ts
@@ -27,7 +27,7 @@ describe("dev command", () => {
     t.expectResult(result).toSucceed();
   });
 
-  it("sets local dev authorization headers for functions", async () => {
+  it("sets a local service token header for functions", async () => {
     await t.givenLoggedInWithProject(fixture("full-project"));
 
     await writeFile(
@@ -53,7 +53,7 @@ describe("dev command", () => {
     const devServerUrl = await waitForDevServer(handle);
 
     const functionUrl = `${devServerUrl}/api/apps/${t.api.appId}/functions/hello`;
-    const requestFunction = (headers: HeadersInit) =>
+    const requestFunction = (headers: Record<string, string>) =>
       fetch(functionUrl, { headers });
 
     const anonymousResponse = await requestFunction({
@@ -61,7 +61,7 @@ describe("dev command", () => {
     });
     expect(anonymousResponse.status).toBe(200);
     await expect(anonymousResponse.json()).resolves.toEqual({
-      authorization: "Bearer dev",
+      authorization: null,
       serviceAuthorization: "Bearer dev",
     });
 
@@ -71,7 +71,7 @@ describe("dev command", () => {
     });
     expect(authenticatedResponse.status).toBe(200);
     await expect(authenticatedResponse.json()).resolves.toEqual({
-      authorization: "Bearer dev",
+      authorization: "Bearer test-app-token",
       serviceAuthorization: "Bearer dev",
     });
 

--- a/packages/cli/tests/cli/dev.spec.ts
+++ b/packages/cli/tests/cli/dev.spec.ts
@@ -27,7 +27,7 @@ describe("dev command", () => {
     t.expectResult(result).toSucceed();
   });
 
-  it("forwards the service token header from Authorization to local functions", async () => {
+  it("sets a local service token header for functions", async () => {
     await t.givenLoggedInWithProject(fixture("full-project"));
 
     await writeFile(
@@ -52,20 +52,27 @@ describe("dev command", () => {
     const handle = await t.runLive("dev");
     const devServerUrl = await waitForDevServer(handle);
 
-    const response = await fetch(
-      `${devServerUrl}/api/apps/${t.api.appId}/functions/hello`,
-      {
-        headers: {
-          Authorization: "Bearer test-app-token",
-          "X-App-Id": t.api.appId,
-        },
-      },
-    );
+    const functionUrl = `${devServerUrl}/api/apps/${t.api.appId}/functions/hello`;
+    const requestFunction = (headers: HeadersInit) =>
+      fetch(functionUrl, { headers });
 
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
+    const anonymousResponse = await requestFunction({
+      "X-App-Id": t.api.appId,
+    });
+    expect(anonymousResponse.status).toBe(200);
+    await expect(anonymousResponse.json()).resolves.toEqual({
+      authorization: null,
+      serviceAuthorization: "Bearer dev",
+    });
+
+    const authenticatedResponse = await requestFunction({
+      Authorization: "Bearer test-app-token",
+      "X-App-Id": t.api.appId,
+    });
+    expect(authenticatedResponse.status).toBe(200);
+    await expect(authenticatedResponse.json()).resolves.toEqual({
       authorization: "Bearer test-app-token",
-      serviceAuthorization: "Bearer test-app-token",
+      serviceAuthorization: "Bearer dev",
     });
 
     const result = await handle.stop();

--- a/packages/cli/tests/cli/dev.spec.ts
+++ b/packages/cli/tests/cli/dev.spec.ts
@@ -6,6 +6,11 @@ import { describe, expect, it } from "vitest";
 import { waitForDevServer } from "./testkit/dev-utils.js";
 import { fixture, setupCLITests } from "./testkit/index.js";
 
+type FunctionHeaderResponse = {
+  authorization: string | null;
+  serviceAuthorization: string;
+};
+
 describe("dev command", () => {
   const t = setupCLITests();
 
@@ -61,7 +66,8 @@ describe("dev command", () => {
       "X-App-Id": t.api.appId,
     });
     expect(anonymousResponse.status).toBe(200);
-    const anonymousResult = await anonymousResponse.json();
+    const anonymousResult =
+      (await anonymousResponse.json()) as FunctionHeaderResponse;
     expect(anonymousResult.authorization).toBeNull();
     expect(anonymousResult.serviceAuthorization).toMatch(/^Bearer .+/);
     const serviceTokenPayload = jwt.decode(
@@ -80,7 +86,8 @@ describe("dev command", () => {
       "X-App-Id": t.api.appId,
     });
     expect(authenticatedResponse.status).toBe(200);
-    const authenticatedResult = await authenticatedResponse.json();
+    const authenticatedResult =
+      (await authenticatedResponse.json()) as FunctionHeaderResponse;
     expect(authenticatedResult).toEqual({
       authorization: "Bearer test-app-token",
       serviceAuthorization: anonymousResult.serviceAuthorization,


### PR DESCRIPTION
## Summary
- Set `Base44-Service-Authorization` to the fixed local dev credential (`Bearer dev`) for proxied dev function requests.
- Preserve the caller's normal `Authorization` header instead of reusing it as the service credential.
- Update the dev command test to cover anonymous and authenticated function calls.

Fixes #491