### PR TITLE
feat(dev): write .env.local on first run

### DIFF
--- a/packages/cli/src/cli/commands/dev.ts
+++ b/packages/cli/src/cli/commands/dev.ts
@@ -1,10 +1,13 @@
 import process from "node:process";
+import { join } from "node:path";
 import type { Command } from "commander";
 import { createDevServer } from "@/cli/dev/dev-server/main.js";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";
 import { Base44Command, theme } from "@/cli/utils/index.js";
 import { getDenoWrapperPath } from "@/core/assets.js";
+import { initAppConfig } from "@/core/project/app-config.js";
 import { readProjectConfig } from "@/core/project/config.js";
+import { pathExists, writeFile } from "@/core/utils/fs.js";
 
 interface DevOptions {
   port?: string;
@@ -15,6 +18,8 @@ async function devAction(
   options: DevOptions,
 ): Promise<RunCommandResult> {
   const port = options.port ? Number(options.port) : undefined;
+  let projectRoot: string | undefined;
+
   const { port: resolvedPort } = await createDevServer({
     log,
     port,
@@ -22,9 +27,22 @@ async function devAction(
     denoWrapperPath: getDenoWrapperPath(),
     loadResources: async () => {
       const { functions, entities, project } = await readProjectConfig();
+      projectRoot = project.root;
       return { functions, entities, project };
     },
   });
+
+  if (projectRoot) {
+    const envLocalPath = join(projectRoot, ".env.local");
+    if (!(await pathExists(envLocalPath))) {
+      const { id: appId } = await initAppConfig();
+      await writeFile(
+        envLocalPath,
+        `VITE_BASE44_APP_ID=${appId}\nVITE_BASE44_APP_BASE_URL=http://localhost:${resolvedPort}\n`,
+      );
+      log.info("Created .env.local with app ID and dev server URL");
+    }
+  }
 
   return {
     outroMessage: `Dev server is available at ${theme.colors.links(`http://localhost:${resolvedPort}`)}`,

--- a/packages/cli/src/cli/commands/dev.ts
+++ b/packages/cli/src/cli/commands/dev.ts
@@ -1,5 +1,5 @@
-import process from "node:process";
 import { join } from "node:path";
+import process from "node:process";
 import type { Command } from "commander";
 import { createDevServer } from "@/cli/dev/dev-server/main.js";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";

--- a/packages/cli/src/cli/commands/dev.ts
+++ b/packages/cli/src/cli/commands/dev.ts
@@ -1,3 +1,4 @@
+import type { Logger } from "@base44-cli/logger";
 import { join } from "node:path";
 import process from "node:process";
 import type { Command } from "commander";
@@ -11,6 +12,34 @@ import { pathExists, writeFile } from "@/core/utils/fs.js";
 
 interface DevOptions {
   port?: string;
+}
+
+function localServerUrl(port: number): string {
+  return `http://localhost:${port}`;
+}
+
+/**
+ * On first run there is no `.env.local`, so the `@base44/vite-plugin` in the
+ * frontend has no app ID and falls back to the production backend instead of
+ * this dev server. Write the file (matching the plugin's expected variable
+ * names) unless the user already maintains one.
+ */
+async function writeEnvLocalIfMissing(
+  projectRoot: string,
+  port: number,
+  log: Logger,
+): Promise<void> {
+  const envLocalPath = join(projectRoot, ".env.local");
+  if (await pathExists(envLocalPath)) {
+    return;
+  }
+
+  const { id: appId } = await initAppConfig();
+  await writeFile(
+    envLocalPath,
+    `VITE_BASE44_APP_ID=${appId}\nVITE_BASE44_BACKEND_URL=${localServerUrl(port)}\n`,
+  );
+  log.info("Created .env.local with app ID and dev server URL");
 }
 
 async function devAction(
@@ -33,19 +62,11 @@ async function devAction(
   });
 
   if (projectRoot) {
-    const envLocalPath = join(projectRoot, ".env.local");
-    if (!(await pathExists(envLocalPath))) {
-      const { id: appId } = await initAppConfig();
-      await writeFile(
-        envLocalPath,
-        `VITE_BASE44_APP_ID=${appId}\nVITE_BASE44_APP_BASE_URL=http://localhost:${resolvedPort}\n`,
-      );
-      log.info("Created .env.local with app ID and dev server URL");
-    }
+    await writeEnvLocalIfMissing(projectRoot, resolvedPort, log);
   }
 
   return {
-    outroMessage: `Dev server is available at ${theme.colors.links(`http://localhost:${resolvedPort}`)}`,
+    outroMessage: `Dev server is available at ${theme.colors.links(localServerUrl(resolvedPort))}`,
   };
 }
 

--- a/packages/cli/src/cli/commands/dev.ts
+++ b/packages/cli/src/cli/commands/dev.ts
@@ -1,6 +1,6 @@
-import type { Logger } from "@base44-cli/logger";
 import { join } from "node:path";
 import process from "node:process";
+import type { Logger } from "@base44-cli/logger";
 import type { Command } from "commander";
 import { createDevServer } from "@/cli/dev/dev-server/main.js";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";

--- a/packages/cli/tests/cli/dev.spec.ts
+++ b/packages/cli/tests/cli/dev.spec.ts
@@ -47,14 +47,14 @@ describe("dev command", () => {
 
     const content = await t.readProjectFile(".env.local");
     expect(content).toContain(`VITE_BASE44_APP_ID=${t.api.appId}`);
-    expect(content).toContain("VITE_BASE44_APP_BASE_URL=http://localhost:");
+    expect(content).toContain("VITE_BASE44_BACKEND_URL=http://localhost:");
   });
 
   it("does not overwrite .env.local when it already exists", async () => {
     await t.givenLoggedInWithProject(fixture("full-project"));
 
     const existing =
-      "VITE_BASE44_APP_ID=existing-id\nVITE_BASE44_APP_BASE_URL=http://localhost:9999\n";
+      "VITE_BASE44_APP_ID=existing-id\nVITE_BASE44_BACKEND_URL=http://localhost:9999\n";
     await writeFile(join(t.getTempDir(), "project", ".env.local"), existing);
 
     const handle = await t.runLive("dev");

--- a/packages/cli/tests/cli/dev.spec.ts
+++ b/packages/cli/tests/cli/dev.spec.ts
@@ -38,6 +38,33 @@ describe("dev command", () => {
     t.expectResult(result).toSucceed();
   });
 
+  it("creates .env.local with app ID and dev server URL when it does not exist", async () => {
+    await t.givenLoggedInWithProject(fixture("full-project"));
+
+    const handle = await t.runLive("dev");
+    await waitForDevServer(handle);
+    await handle.stop();
+
+    const content = await t.readProjectFile(".env.local");
+    expect(content).toContain(`VITE_BASE44_APP_ID=${t.api.appId}`);
+    expect(content).toContain("VITE_BASE44_APP_BASE_URL=http://localhost:");
+  });
+
+  it("does not overwrite .env.local when it already exists", async () => {
+    await t.givenLoggedInWithProject(fixture("full-project"));
+
+    const existing =
+      "VITE_BASE44_APP_ID=existing-id\nVITE_BASE44_APP_BASE_URL=http://localhost:9999\n";
+    await writeFile(join(t.getTempDir(), "project", ".env.local"), existing);
+
+    const handle = await t.runLive("dev");
+    await waitForDevServer(handle);
+    await handle.stop();
+
+    const content = await t.readProjectFile(".env.local");
+    expect(content).toBe(existing);
+  });
+
   it("forwards caller Authorization and injects a service JWT to local functions", async () => {
     await t.givenLoggedInWithProject(fixture("full-project"));
 


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> The `base44 dev` command now writes a `.env.local` file on first run when one does not already exist. Without it, the frontend's `@base44/vite-plugin` has no app ID and falls back to the production backend instead of the local dev server. The file is populated with the app ID and the local dev server URL using the variable names the plugin expects, and existing `.env.local` files are left untouched.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Add `writeEnvLocalIfMissing()` to `dev.ts`, which writes `.env.local` with `VITE_BASE44_APP_ID` and `VITE_BASE44_BACKEND_URL` when the file is absent, and logs that it was created.
> - Resolve the app ID via `initAppConfig()` and point `VITE_BASE44_BACKEND_URL` at the resolved local dev server URL.
> - Skip writing when a `.env.local` already exists so user-maintained files are never overwritten.
> - Capture the project root from `loadResources` and call the new helper after the dev server starts.
> - Extract a `localServerUrl()` helper and reuse it for the outro message.
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [x] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [x] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> Two new integration tests cover both paths: creating `.env.local` when it is missing, and leaving an existing file untouched.
>
> ---
> <sub>🤖 Generated by Claude | 2026-06-04 10:21 UTC | e294dda</sub>