### PR TITLE
feat(login): browser-based loopback OAuth flow with device-code fallback

### DIFF
--- a/packages/cli/src/cli/commands/auth/login-flow.ts
+++ b/packages/cli/src/cli/commands/auth/login-flow.ts
@@ -15,6 +15,7 @@ import {
   writeAuth,
 } from "@/core/auth/index.js";
 import { AuthExpiredError, InternalError } from "@/core/errors.js";
+import { isHeadlessEnv, loginViaLoopback } from "./loopback-flow.js";
 
 async function generateAndDisplayDeviceCode(
   log: Logger,
@@ -85,6 +86,19 @@ async function waitForAuthentication(
   return tokenResponse;
 }
 
+async function loginViaDeviceCode(
+  log: Logger,
+  runTask: RunTaskFn,
+): Promise<TokenResponse> {
+  const deviceCodeResponse = await generateAndDisplayDeviceCode(log, runTask);
+  return waitForAuthentication(
+    deviceCodeResponse.deviceCode,
+    deviceCodeResponse.expiresIn,
+    deviceCodeResponse.interval,
+    runTask,
+  );
+}
+
 async function saveAuthData(
   response: TokenResponse,
   userInfo: UserInfoResponse,
@@ -100,22 +114,41 @@ async function saveAuthData(
   });
 }
 
-/**
- * Execute the login flow (device code authentication).
- * This function is separate from the command to avoid circular dependencies.
- */
-export async function login({
-  log,
-  runTask,
-}: CLIContext): Promise<RunCommandResult> {
-  const deviceCodeResponse = await generateAndDisplayDeviceCode(log, runTask);
+interface LoginOptions {
+  /** Force device-code flow, skipping the loopback browser flow. */
+  deviceCode?: boolean;
+}
 
-  const token = await waitForAuthentication(
-    deviceCodeResponse.deviceCode,
-    deviceCodeResponse.expiresIn,
-    deviceCodeResponse.interval,
-    runTask,
-  );
+/**
+ * Execute the login flow.
+ *
+ * Default path: loopback (RFC 8252) with PKCE — opens browser, awaits localhost
+ * callback. Falls back to device code on headless environments (SSH, CI, no
+ * DISPLAY) or if the loopback flow fails for any reason.
+ */
+export async function login(
+  { log, runTask }: CLIContext,
+  options: LoginOptions = {},
+): Promise<RunCommandResult> {
+  let token: TokenResponse | undefined;
+
+  const useDeviceCode = options.deviceCode || isHeadlessEnv();
+
+  if (!useDeviceCode) {
+    try {
+      token = await loginViaLoopback(log, runTask);
+    } catch (error) {
+      log.warn(
+        `Browser sign-in unavailable (${
+          error instanceof Error ? error.message : String(error)
+        }). Falling back to device code.`,
+      );
+    }
+  }
+
+  if (!token) {
+    token = await loginViaDeviceCode(log, runTask);
+  }
 
   const userInfo = await getUserInfo(token.accessToken);
 

--- a/packages/cli/src/cli/commands/auth/login.ts
+++ b/packages/cli/src/cli/commands/auth/login.ts
@@ -8,5 +8,10 @@ export function getLoginCommand(): Command {
     requireAppConfig: false,
   })
     .description("Authenticate with Base44")
+    .option(
+      "--device-code",
+      "Use device code flow instead of opening a browser",
+      false,
+    )
     .action(login);
 }

--- a/packages/cli/src/cli/commands/auth/loopback-flow.ts
+++ b/packages/cli/src/cli/commands/auth/loopback-flow.ts
@@ -1,0 +1,89 @@
+import type { Logger } from "@base44-cli/logger";
+import open from "open";
+import type { RunTaskFn } from "@/cli/utils/runTask.js";
+import { theme } from "@/cli/utils/theme.js";
+import {
+  buildAuthorizeUrl,
+  exchangeCodeForToken,
+  type TokenResponse,
+} from "@/core/auth/index.js";
+import { startLoopbackServer } from "@/core/auth/loopback-server.js";
+import { generatePkcePair, generateState } from "@/core/auth/pkce.js";
+
+const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Returns true if the current environment can't reach a localhost callback
+ * (SSH, no DISPLAY on Linux, common CI signals). In these cases we skip the
+ * loopback flow and use device code instead.
+ */
+export function isHeadlessEnv(): boolean {
+  const env = process.env;
+  if (env.SSH_CONNECTION || env.SSH_CLIENT || env.SSH_TTY) return true;
+  if (env.CI || env.CONTINUOUS_INTEGRATION) return true;
+  if (process.platform === "linux" && !env.DISPLAY && !env.WAYLAND_DISPLAY) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Loopback (RFC 8252) authorization-code-with-PKCE login.
+ *
+ * Caller is responsible for falling back to device code if this throws.
+ */
+export async function loginViaLoopback(
+  log: Logger,
+  runTask: RunTaskFn,
+): Promise<TokenResponse> {
+  const server = await startLoopbackServer();
+  const pkce = generatePkcePair();
+  const state = generateState();
+
+  try {
+    const authorizeUrl = buildAuthorizeUrl({
+      redirectUri: server.redirectUri,
+      state,
+      codeChallenge: pkce.codeChallenge,
+    });
+
+    log.info(
+      `Opening your browser to sign in.\nIf it doesn't open, visit: ${theme.styles.dim(
+        authorizeUrl,
+      )}`,
+    );
+
+    try {
+      await open(authorizeUrl);
+    } catch {
+      // Browser open failed — the user can still paste the URL manually.
+    }
+
+    const { code } = await runTask(
+      "Waiting for browser sign-in...",
+      async () => server.waitForCallback(state, CALLBACK_TIMEOUT_MS),
+      {
+        successMessage: "Browser sign-in completed",
+        errorMessage: "Browser sign-in failed",
+      },
+    );
+
+    const token = await runTask(
+      "Exchanging authorization code...",
+      async () =>
+        exchangeCodeForToken({
+          code,
+          redirectUri: server.redirectUri,
+          codeVerifier: pkce.codeVerifier,
+        }),
+      {
+        successMessage: "Authentication completed!",
+        errorMessage: "Token exchange failed",
+      },
+    );
+
+    return token;
+  } finally {
+    server.close();
+  }
+}

--- a/packages/cli/src/core/auth/api.ts
+++ b/packages/cli/src/core/auth/api.ts
@@ -10,14 +10,17 @@ import {
   UserInfoSchema,
 } from "@/core/auth/schema.js";
 import { oauthClient } from "@/core/clients/index.js";
+import { getBase44ApiUrl } from "@/core/config.js";
 import { AUTH_CLIENT_ID } from "@/core/consts.js";
 import { ApiError, SchemaValidationError } from "@/core/errors.js";
+
+const OAUTH_SCOPE = "apps:read apps:write offline";
 
 export async function generateDeviceCode(): Promise<DeviceCodeResponse> {
   const response = await oauthClient.post("oauth/device/code", {
     json: {
       client_id: AUTH_CLIENT_ID,
-      scope: "apps:read apps:write",
+      scope: OAUTH_SCOPE,
     },
     throwHttpErrors: false,
   });
@@ -124,6 +127,70 @@ export async function renewAccessToken(
       });
     }
 
+    const { error, error_description } = errorResult.data;
+    throw new ApiError(error_description ?? `OAuth error: ${error}`, {
+      statusCode: response.status,
+    });
+  }
+
+  const result = TokenResponseSchema.safeParse(json);
+
+  if (!result.success) {
+    throw new SchemaValidationError(
+      "Invalid token response from server",
+      result.error,
+    );
+  }
+
+  return result.data;
+}
+
+export function buildAuthorizeUrl(params: {
+  redirectUri: string;
+  state: string;
+  codeChallenge: string;
+}): string {
+  const search = new URLSearchParams({
+    response_type: "code",
+    client_id: AUTH_CLIENT_ID,
+    redirect_uri: params.redirectUri,
+    scope: OAUTH_SCOPE,
+    state: params.state,
+    code_challenge: params.codeChallenge,
+    code_challenge_method: "S256",
+  });
+  return `${getBase44ApiUrl().replace(/\/$/, "")}/oauth/authorize?${search.toString()}`;
+}
+
+export async function exchangeCodeForToken(params: {
+  code: string;
+  redirectUri: string;
+  codeVerifier: string;
+}): Promise<TokenResponse> {
+  const searchParams = new URLSearchParams();
+  searchParams.set("grant_type", "authorization_code");
+  searchParams.set("code", params.code);
+  searchParams.set("redirect_uri", params.redirectUri);
+  searchParams.set("client_id", AUTH_CLIENT_ID);
+  searchParams.set("code_verifier", params.codeVerifier);
+
+  const response = await oauthClient.post("oauth/token", {
+    body: searchParams.toString(),
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    throwHttpErrors: false,
+  });
+
+  const json = await response.json();
+
+  if (!response.ok) {
+    const errorResult = OAuthErrorSchema.safeParse(json);
+    if (!errorResult.success) {
+      throw new ApiError(`Token exchange failed: ${response.statusText}`, {
+        statusCode: response.status,
+      });
+    }
     const { error, error_description } = errorResult.data;
     throw new ApiError(error_description ?? `OAuth error: ${error}`, {
       statusCode: response.status,

--- a/packages/cli/src/core/auth/loopback-server.ts
+++ b/packages/cli/src/core/auth/loopback-server.ts
@@ -1,0 +1,166 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import getPort from "get-port";
+import { ApiError, InternalError } from "@/core/errors.js";
+
+const LOOPBACK_HOST = "127.0.0.1";
+const CALLBACK_PATH = "/callback";
+
+const SUCCESS_HTML = `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Base44 CLI</title>
+<style>body{font-family:system-ui,sans-serif;text-align:center;padding:48px;color:#1f2937}
+h1{font-size:20px;margin:0 0 8px}p{color:#6b7280;margin:0}</style></head>
+<body><h1>You're signed in.</h1><p>You can close this tab and return to your terminal.</p></body></html>`;
+
+const ERROR_HTML = (msg: string) => `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>Base44 CLI</title>
+<style>body{font-family:system-ui,sans-serif;text-align:center;padding:48px;color:#991b1b}
+h1{font-size:20px;margin:0 0 8px}p{color:#6b7280;margin:0}</style></head>
+<body><h1>Sign-in failed</h1><p>${msg}</p></body></html>`;
+
+interface LoopbackCallbackResult {
+  code: string;
+}
+
+interface LoopbackServer {
+  port: number;
+  redirectUri: string;
+  /** Resolves when the OAuth provider redirects to /callback with a valid code. */
+  waitForCallback(
+    expectedState: string,
+    timeoutMs: number,
+  ): Promise<LoopbackCallbackResult>;
+  close(): void;
+}
+
+export async function startLoopbackServer(): Promise<LoopbackServer> {
+  const port = await getPort({ host: LOOPBACK_HOST });
+
+  let resolveCallback: ((result: LoopbackCallbackResult) => void) | null = null;
+  let rejectCallback: ((err: Error) => void) | null = null;
+
+  const server: Server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", `http://${LOOPBACK_HOST}:${port}`);
+
+    if (url.pathname !== CALLBACK_PATH) {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("Not Found");
+      return;
+    }
+
+    const code = url.searchParams.get("code");
+    const state = url.searchParams.get("state");
+    const error = url.searchParams.get("error");
+    const errorDescription = url.searchParams.get("error_description");
+
+    if (error) {
+      const message = errorDescription ?? error;
+      res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(ERROR_HTML(message));
+      rejectCallback?.(
+        new ApiError(`Authorization failed: ${message}`, { statusCode: 400 }),
+      );
+      return;
+    }
+
+    // We compare against the server's currently-expected state. waitForCallback
+    // captures it in a closure; until waitForCallback is called, every callback
+    // is rejected as unsolicited.
+    if (!code || !state) {
+      res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(ERROR_HTML("Missing code or state parameter."));
+      rejectCallback?.(
+        new ApiError("OAuth callback missing code or state", {
+          statusCode: 400,
+        }),
+      );
+      return;
+    }
+
+    res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    res.end(SUCCESS_HTML);
+
+    // Defer to waitForCallback to validate state and resolve.
+    pendingCallback = { code, state };
+    if (resolveCallback) {
+      tryDeliverCallback();
+    }
+  });
+
+  let pendingCallback: { code: string; state: string } | null = null;
+  let expectedState: string | null = null;
+
+  function tryDeliverCallback(): void {
+    if (!pendingCallback || !expectedState) return;
+    const { code, state } = pendingCallback;
+    pendingCallback = null;
+    if (state !== expectedState) {
+      rejectCallback?.(
+        new ApiError("OAuth state mismatch — possible CSRF", {
+          statusCode: 400,
+        }),
+      );
+      return;
+    }
+    resolveCallback?.({ code });
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, LOOPBACK_HOST, () => {
+      server.removeListener("error", reject);
+      // Don't keep the event loop alive on our account. Once the login flow's
+      // promises settle and the server is closed, the process should exit
+      // naturally. Without this, a browser keep-alive connection holds the
+      // listening socket open and Node hangs after "Successfully logged in".
+      server.unref();
+      resolve();
+    });
+  });
+
+  const actualPort = (server.address() as AddressInfo).port;
+  const redirectUri = `http://${LOOPBACK_HOST}:${actualPort}${CALLBACK_PATH}`;
+
+  return {
+    port: actualPort,
+    redirectUri,
+    waitForCallback(state, timeoutMs) {
+      expectedState = state;
+      return new Promise<LoopbackCallbackResult>((resolve, reject) => {
+        resolveCallback = resolve;
+        rejectCallback = reject;
+
+        const timer = setTimeout(() => {
+          reject(
+            new InternalError(
+              `Timed out waiting for browser authentication after ${Math.round(
+                timeoutMs / 1000,
+              )}s`,
+            ),
+          );
+        }, timeoutMs);
+
+        const wrappedResolve = (r: LoopbackCallbackResult) => {
+          clearTimeout(timer);
+          resolve(r);
+        };
+        const wrappedReject = (e: Error) => {
+          clearTimeout(timer);
+          reject(e);
+        };
+        resolveCallback = wrappedResolve;
+        rejectCallback = wrappedReject;
+
+        // A callback may have arrived before waitForCallback was called.
+        tryDeliverCallback();
+      });
+    },
+    close() {
+      server.close();
+      // server.close() only stops accepting new connections; existing
+      // keep-alive sockets persist until idle timeout. Force-close them so
+      // the process can exit promptly.
+      server.closeAllConnections?.();
+    },
+  };
+}

--- a/packages/cli/src/core/auth/pkce.ts
+++ b/packages/cli/src/core/auth/pkce.ts
@@ -1,0 +1,27 @@
+import { createHash, randomBytes } from "node:crypto";
+
+interface PkcePair {
+  codeVerifier: string;
+  codeChallenge: string;
+  codeChallengeMethod: "S256";
+}
+
+function base64UrlEncode(buffer: Buffer): string {
+  return buffer
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+export function generatePkcePair(): PkcePair {
+  const codeVerifier = base64UrlEncode(randomBytes(32));
+  const codeChallenge = base64UrlEncode(
+    createHash("sha256").update(codeVerifier).digest(),
+  );
+  return { codeVerifier, codeChallenge, codeChallengeMethod: "S256" };
+}
+
+export function generateState(): string {
+  return base64UrlEncode(randomBytes(16));
+}


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Adds a browser-based loopback OAuth flow (RFC 8252 + PKCE) as the default for `base44 login`, replacing device-code as the primary path. The existing device-code flow remains as an automatic fallback for headless environments (SSH, CI, Linux without DISPLAY) and is also opt-in via the new `--device-code` flag. This gives interactive users a one-click sign-in while preserving the headless-friendly path.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added `loopback-flow.ts` in `cli/commands/auth/` orchestrating the browser sign-in: opens the authorize URL, waits for the localhost callback, exchanges the code for a token, and reports progress via `runTask`.
> - Added `core/auth/loopback-server.ts`: ephemeral `127.0.0.1` HTTP server on a `get-port`-chosen port handling `/callback`, validating `state` (CSRF), rendering success/error HTML pages, and `unref`-ing the socket plus force-closing keep-alives so the process exits promptly after login.
> - Added `core/auth/pkce.ts` with `generatePkcePair()` (S256) and `generateState()` using `node:crypto`.
> - Extended `core/auth/api.ts` with `buildAuthorizeUrl()` and `exchangeCodeForToken()` (form-encoded `authorization_code` grant with PKCE verifier), and centralized the OAuth scope (now includes `offline`).
> - Reworked `login-flow.ts` to try loopback first and transparently fall back to device-code on failure or in headless environments (detected via `SSH_*`, `CI`, or missing `DISPLAY`/`WAYLAND_DISPLAY` on Linux).
> - Added `--device-code` flag to the `login` command to force the legacy flow.
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [x] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> Requires the Base44 OAuth server to support the `authorization_code` grant with PKCE (`code_challenge_method=S256`) at `/oauth/authorize` and `/oauth/token`, and to accept dynamic `http://127.0.0.1:<port>/callback` redirect URIs as required by RFC 8252. The added `offline` scope is needed so the browser flow returns a refresh token alongside the access token.
>
> ---
> <sub>🤖 Generated by Claude | 2026-05-24 18:10 UTC | 44a9028</sub>