### PR TITLE
fix(dev): Deno 2.8 compat for local function runner (Deno.serve getter)

### DIFF
--- a/packages/cli/deno-runtime/main.ts
+++ b/packages/cli/deno-runtime/main.ts
@@ -25,9 +25,8 @@ if (!functionPath) {
 // Store the original Deno.serve
 const originalServe = Deno.serve.bind(Deno);
 
-// Patch Deno.serve to inject our port and add onListen callback
-// @ts-expect-error - We're intentionally overriding Deno.serve
-Deno.serve = (
+// Patch Deno.serve to inject our port and add onListen callback.
+const patchedServe = (
   optionsOrHandler:
     | Deno.ServeOptions
     | Deno.ServeHandler
@@ -59,6 +58,15 @@ Deno.serve = (
   };
   return originalServe({ ...options, port, onListen });
 };
+
+// Deno 2.8 exposes `Deno.serve` as a getter-only property, so a plain
+// `Deno.serve = ...` assignment throws. Use defineProperty to override it
+// (works on both the old writable property and the new accessor).
+Object.defineProperty(Deno, "serve", {
+  value: patchedServe,
+  writable: true,
+  configurable: true,
+});
 
 console.log(`[${functionName}] Starting function from ${functionPath}`);
 


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Fixes `base44 dev` failing under Deno 2.8, which redefined `Deno.serve` as a getter-only property. The previous direct assignment (`Deno.serve = ...`) now throws at runtime. This PR uses `Object.defineProperty` to override `Deno.serve` so the runtime works on both pre-2.8 (writable property) and 2.8+ (accessor) versions of Deno.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Extracted the `Deno.serve` patch logic into a `patchedServe` constant in `packages/cli/deno-runtime/main.ts`.
> - Replaced the direct `Deno.serve = ...` assignment (which fails on Deno 2.8) with `Object.defineProperty(Deno, "serve", { value: patchedServe, writable: true, configurable: true })`.
> - Removed the `@ts-expect-error` previously needed for the direct assignment.
> - Added a comment explaining the Deno 2.8 getter-only behavior and the compatibility rationale.
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [x] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [x] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated \`docs/\` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> Behavior on older Deno versions is preserved: `defineProperty` works on both the previous writable property and the new accessor. No public CLI surface changes.
>
> ---
> <sub>🤖 Generated by Claude | 2026-06-02 11:43 UTC | ff4dead</sub>