### PR TITLE
fix(dev): write VITE_BASE44_APP_BASE_URL instead of VITE_BASE44_BACKEND_URL in .env.local

### DIFF
--- a/packages/cli/src/cli/commands/dev.ts
+++ b/packages/cli/src/cli/commands/dev.ts
@@ -37,7 +37,7 @@ async function writeEnvLocalIfMissing(
   const { id: appId } = await initAppConfig();
   await writeFile(
     envLocalPath,
-    `VITE_BASE44_APP_ID=${appId}\nVITE_BASE44_BACKEND_URL=${localServerUrl(port)}\n`,
+    `VITE_BASE44_APP_ID=${appId}\nVITE_BASE44_APP_BASE_URL=${localServerUrl(port)}\n`,
   );
   log.info("Created .env.local with app ID and dev server URL");
 }

--- a/packages/cli/tests/cli/dev.spec.ts
+++ b/packages/cli/tests/cli/dev.spec.ts
@@ -47,14 +47,14 @@ describe("dev command", () => {
 
     const content = await t.readProjectFile(".env.local");
     expect(content).toContain(`VITE_BASE44_APP_ID=${t.api.appId}`);
-    expect(content).toContain("VITE_BASE44_BACKEND_URL=http://localhost:");
+    expect(content).toContain("VITE_BASE44_APP_BASE_URL=http://localhost:");
   });
 
   it("does not overwrite .env.local when it already exists", async () => {
     await t.givenLoggedInWithProject(fixture("full-project"));
 
     const existing =
-      "VITE_BASE44_APP_ID=existing-id\nVITE_BASE44_BACKEND_URL=http://localhost:9999\n";
+      "VITE_BASE44_APP_ID=existing-id\nVITE_BASE44_APP_BASE_URL=http://localhost:9999\n";
     await writeFile(join(t.getTempDir(), "project", ".env.local"), existing);
 
     const handle = await t.runLive("dev");


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> The `base44 dev` command scaffolds a `.env.local` file pointing the frontend at the local dev server. This PR corrects the environment variable name written to that file from `VITE_BASE44_BACKEND_URL` to `VITE_BASE44_APP_BASE_URL`, the variable the Base44 frontend SDK actually reads. Without this fix, the generated `.env.local` would not redirect the app to the local dev server.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Write `VITE_BASE44_APP_BASE_URL` instead of `VITE_BASE44_BACKEND_URL` when generating `.env.local` in `packages/cli/src/cli/commands/dev.ts`
> - Update `dev` command tests in `packages/cli/tests/cli/dev.spec.ts` to assert on the corrected variable name (both the creation and the do-not-overwrite cases)
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [x] All tests pass (\`npm test\`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated \`docs/\` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> None
>
> ---
> <sub>🤖 Generated by Claude | 2026-06-07 12:48 UTC | 4cbec83</sub>