### PR TITLE
feat(cli): add `init` command for Stripe Projects handoff

### DIFF
--- a/docs/api-patterns.md
+++ b/docs/api-patterns.md
@@ -43,6 +43,33 @@ The `base44Client` automatically handles token refresh:
 2. If expired, refreshes token and saves new tokens
 3. On 401 response, attempts refresh and retries once
 
+## Environment-Supplied Credentials (Stripe Projects Handoff)
+
+When `BASE44_ACCESS_TOKEN` is set in the environment, `base44Client` uses it
+verbatim as the bearer token, taking precedence over `~/.base44/auth/auth.json`
+and **bypassing the OAuth refresh logic** (these tokens are provider-issued, not
+Base44 OAuth tokens, so they cannot be refreshed via `/oauth/token`; on a 401 the
+error simply propagates). `isLoggedIn()` also returns `true` when this var is set,
+so `requireAuth` commands run without an interactive login. See
+`getEnvAccessToken()` in `core/auth/config.js`.
+
+This supports the Stripe Projects CLI handoff: it provisions a Base44 app and
+writes the credentials to `.env` via `stripe projects env --pull`. The CLI loads
+`.env`/`.env.local` from the working directory at startup (`loadProjectEnvFiles()`
+in `core/utils/env.js`, wired through `cli/bootstrap-env.js` as the first import so
+it runs before the HTTP clients capture `getBase44ApiUrl()`). Precedence: ambient
+`process.env` > `.env.local` > `.env`; pre-set values are never overridden.
+
+**Var name normalization.** `stripe projects env --pull` namespaces each var by
+resource name, so the credentials arrive as e.g. `BASE44_PROJECTS_BASE44_APP_ID`
+rather than bare `BASE44_APP_ID`. After loading, `loadProjectEnvFiles()` normalizes
+the four credential keys (`BASE44_APP_ID`, `BASE44_ACCESS_TOKEN`,
+`BASE44_REFRESH_TOKEN`, `BASE44_API_URL`): for each, if the bare name is unset and
+exactly one `<PREFIX>_<KEY>` variable exists, its value is copied to the bare name.
+This is prefix-agnostic (survives any resource name) and leaves the bare key unset
+when ambiguous. The `base44 init` command then consumes `BASE44_APP_ID` to scaffold
+a local project for that existing app.
+
 ## API Response Transformation (snake_case to camelCase)
 
 The Base44 API returns snake_case keys, but the CLI uses camelCase. Use Zod's `.transform()` to convert:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -143,7 +143,9 @@ export function getMyCommand(): Command {
 }
 ```
 
-Commands that only use `logger.*` (display-only, no input) don't need this guard. See `project/create.ts`, `project/link.ts`, and `project/eject.ts` for real examples.
+Commands that only use `logger.*` (display-only, no input) don't need this guard. See `project/create.ts`, `project/init.ts`, `project/link.ts`, and `project/eject.ts` for real examples.
+
+`project/create.ts` and `project/init.ts` share their post-scaffold logic (push entities, deploy site, install skills, print summary) via `project/scaffold-shared.ts` — `create` mints a new app, `init` reuses an existing app id (from `--app-id` or `BASE44_APP_ID`).
 
 ## runTask (Async Operations with Spinners)
 

--- a/packages/cli/src/cli/bootstrap-env.ts
+++ b/packages/cli/src/cli/bootstrap-env.ts
@@ -1,0 +1,9 @@
+import { loadProjectEnvFiles } from "@/core/utils/env.js";
+
+// Side-effect module: loads project-local .env / .env.local into process.env at
+// the very start of the CLI process. This MUST run before any module that reads
+// env-derived config at import time — notably the HTTP clients, which capture
+// the API base URL (getBase44ApiUrl) when ky.create() runs at module load.
+//
+// Imported first in cli/index.ts so it initializes ahead of the program graph.
+loadProjectEnvFiles();

--- a/packages/cli/src/cli/commands/project/create.ts
+++ b/packages/cli/src/cli/commands/project/create.ts
@@ -1,27 +1,23 @@
-import { basename, join, resolve } from "node:path";
+import { basename, resolve } from "node:path";
 import type { Option } from "@clack/prompts";
-import { confirm, group, isCancel, select, text } from "@clack/prompts";
+import { group, select, text } from "@clack/prompts";
 import { Argument, type Command } from "commander";
-import { execa } from "execa";
 import kebabCase from "lodash/kebabCase";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";
-import {
-  Base44Command,
-  getDashboardUrl,
-  onPromptCancel,
-  theme,
-} from "@/cli/utils/index.js";
+import { Base44Command, onPromptCancel, theme } from "@/cli/utils/index.js";
 import { InvalidInputError } from "@/core/errors.js";
-import { deploySite, isDirEmpty, pushEntities } from "@/core/index.js";
+import { isDirEmpty } from "@/core/index.js";
 import type { Template } from "@/core/project/index.js";
 import {
   createProjectFiles,
   listTemplates,
-  readProjectConfig,
   setAppConfig,
 } from "@/core/project/index.js";
-
-const DEFAULT_TEMPLATE_ID = "backend-only";
+import {
+  completeProjectSetup,
+  DEFAULT_TEMPLATE_ID,
+  getTemplateById,
+} from "./scaffold-shared.js";
 
 interface CreateOptions {
   name?: string;
@@ -29,18 +25,6 @@ interface CreateOptions {
   template?: string;
   deploy?: boolean;
   skills?: boolean;
-}
-
-async function getTemplateById(templateId: string): Promise<Template> {
-  const templates = await listTemplates();
-  const template = templates.find((t) => t.id === templateId);
-  if (!template) {
-    const validIds = templates.map((t) => t.id).join(", ");
-    throw new InvalidInputError(`Template "${templateId}" not found.`, {
-      hints: [{ message: `Use one of: ${validIds}` }],
-    });
-  }
-  return template;
 }
 
 function validateNonInteractiveFlags(command: Command): void {
@@ -179,117 +163,10 @@ async function executeCreate(
   // Set app config in cache for sync access to getDashboardUrl and getAppClient
   setAppConfig({ id: projectId, projectRoot: resolvedPath });
 
-  const { project, entities } = await readProjectConfig(resolvedPath);
-  let finalAppUrl: string | undefined;
-
-  if (entities.length > 0) {
-    let shouldPushEntities: boolean;
-
-    if (isInteractive) {
-      const result = await confirm({
-        message:
-          "Set up the backend data now? (This pushes the data models used by the template to Base44)",
-      });
-      shouldPushEntities = !isCancel(result) && result;
-    } else {
-      shouldPushEntities = !!deploy;
-    }
-
-    if (shouldPushEntities) {
-      await runTask(
-        `Pushing ${entities.length} data models to Base44...`,
-        async () => {
-          await pushEntities(entities);
-        },
-        {
-          successMessage: theme.colors.base44Orange(
-            "Data models pushed successfully",
-          ),
-          errorMessage: "Failed to push data models",
-        },
-      );
-    }
-  }
-
-  if (project.site) {
-    const { installCommand, buildCommand, outputDirectory } = project.site;
-
-    let shouldDeploy: boolean;
-
-    if (isInteractive) {
-      const result = await confirm({
-        message: "Would you like to deploy the site now? (Hosted on Base44)",
-      });
-      shouldDeploy = !isCancel(result) && result;
-    } else {
-      shouldDeploy = !!deploy;
-    }
-
-    if (shouldDeploy && installCommand && buildCommand && outputDirectory) {
-      const { appUrl } = await runTask(
-        "Installing dependencies...",
-        async (updateMessage) => {
-          await execa({ cwd: resolvedPath, shell: true })`${installCommand}`;
-
-          updateMessage("Building project...");
-          await execa({ cwd: resolvedPath, shell: true })`${buildCommand}`;
-
-          updateMessage("Deploying site...");
-          return await deploySite(join(resolvedPath, outputDirectory));
-        },
-        {
-          successMessage: theme.colors.base44Orange(
-            "Site deployed successfully",
-          ),
-          errorMessage: "Failed to deploy site",
-        },
-      );
-
-      finalAppUrl = appUrl;
-    }
-  }
-
-  // Add AI agent skills (--no-skills flag sets skills to false, otherwise defaults to true)
-  const shouldAddSkills = skills;
-
-  if (shouldAddSkills) {
-    try {
-      await runTask(
-        "Installing AI agent skills...",
-        async () => {
-          await execa("npx", ["-y", "skills", "add", "base44/skills", "-y"], {
-            cwd: resolvedPath,
-            shell: true,
-          });
-        },
-        {
-          successMessage: theme.colors.base44Orange(
-            "AI agent skills added successfully",
-          ),
-          errorMessage:
-            "Failed to add AI agent skills - you can add them later with: npx skills add base44/skills",
-        },
-      );
-    } catch {
-      // Skills installation is non-critical (e.g., user may not have git installed)
-      // The error message is already shown by runTask, so we just continue
-    }
-  }
-
-  log.message(
-    `${theme.styles.header("Project")}: ${theme.colors.base44Orange(name)}`,
+  return await completeProjectSetup(
+    { projectId, name, resolvedPath, deploy, skills, isInteractive },
+    { log, runTask },
   );
-  log.message(
-    `${theme.styles.header("Dashboard")}: ${theme.colors.links(getDashboardUrl(projectId))}`,
-  );
-
-  if (finalAppUrl) {
-    log.message(
-      `${theme.styles.header("Site")}: ${theme.colors.links(finalAppUrl)}`,
-    );
-  }
-
-  return { outroMessage: "Your project is set up and ready to use" };
 }
 
 async function createAction(

--- a/packages/cli/src/cli/commands/project/init.ts
+++ b/packages/cli/src/cli/commands/project/init.ts
@@ -1,0 +1,244 @@
+import { basename, resolve } from "node:path";
+import type { Option } from "@clack/prompts";
+import { group, select, text } from "@clack/prompts";
+import { Argument, type Command } from "commander";
+import type { CLIContext, RunCommandResult } from "@/cli/types.js";
+import { Base44Command, onPromptCancel, theme } from "@/cli/utils/index.js";
+import { InvalidInputError } from "@/core/errors.js";
+import type { Template } from "@/core/project/index.js";
+import {
+  initProjectFiles,
+  listTemplates,
+  setAppConfig,
+} from "@/core/project/index.js";
+import {
+  completeProjectSetup,
+  DEFAULT_TEMPLATE_ID,
+  getTemplateById,
+} from "./scaffold-shared.js";
+
+interface InitOptions {
+  name?: string;
+  path?: string;
+  template?: string;
+  appId?: string;
+  deploy?: boolean;
+  skills?: boolean;
+}
+
+/**
+ * Resolves the existing app ID from --app-id or the BASE44_APP_ID environment
+ * variable (written by the Stripe Projects CLI via `stripe projects env --pull`).
+ */
+function resolveAppId(options: InitOptions): string {
+  const appId = options.appId ?? process.env.BASE44_APP_ID;
+  if (!appId) {
+    throw new InvalidInputError(
+      "No app ID found. `base44 init` scaffolds a local project for an existing Base44 app.",
+      {
+        hints: [
+          { message: "Pass it explicitly with --app-id <id>" },
+          {
+            message:
+              "Or set BASE44_APP_ID (the Stripe Projects CLI writes it to .env via `stripe projects env --pull`)",
+          },
+        ],
+      },
+    );
+  }
+  return appId;
+}
+
+async function executeInit(
+  {
+    template,
+    name: rawName,
+    description,
+    appId,
+    projectPath,
+    deploy,
+    skills,
+    isInteractive,
+  }: {
+    template: Template;
+    name: string;
+    description?: string;
+    appId: string;
+    projectPath: string;
+    deploy?: boolean;
+    skills?: boolean;
+    isInteractive: boolean;
+  },
+  { log, runTask }: Pick<CLIContext, "log" | "runTask">,
+): Promise<RunCommandResult> {
+  const name = rawName.trim();
+  const resolvedPath = resolve(projectPath);
+
+  const { projectId, skippedFiles } = await runTask(
+    "Setting up your project...",
+    async () => {
+      return await initProjectFiles({
+        name,
+        description: description?.trim(),
+        path: resolvedPath,
+        template,
+        appId,
+      });
+    },
+    {
+      successMessage: theme.colors.base44Orange("Project created successfully"),
+      errorMessage: "Failed to create project",
+    },
+  );
+
+  if (skippedFiles.length > 0) {
+    log.info(
+      `Kept existing file${skippedFiles.length > 1 ? "s" : ""}: ${skippedFiles.join(", ")}`,
+    );
+  }
+
+  // Set app config in cache for sync access to getDashboardUrl and getAppClient
+  setAppConfig({ id: projectId, projectRoot: resolvedPath });
+
+  return await completeProjectSetup(
+    { projectId, name, resolvedPath, deploy, skills, isInteractive },
+    { log, runTask },
+  );
+}
+
+async function initInteractive(
+  appId: string,
+  options: InitOptions,
+  ctx: Pick<CLIContext, "log" | "runTask">,
+): Promise<RunCommandResult> {
+  const templates = await listTemplates();
+  const templateOptions: Option<Template>[] = templates.map((t) => ({
+    value: t,
+    label: t.name,
+    hint: t.description,
+  }));
+
+  const result = await group(
+    {
+      template: () =>
+        select({
+          message: "Pick an option",
+          options: templateOptions,
+        }),
+      name: () => {
+        return options.name
+          ? Promise.resolve(options.name)
+          : text({
+              message: "What is the name of your project?",
+              placeholder: basename(process.cwd()),
+              initialValue: basename(process.cwd()),
+              validate: (value) => {
+                if (!value || value.trim().length === 0) {
+                  return "Every project deserves a name";
+                }
+              },
+            });
+      },
+      // init scaffolds into the existing project directory by default.
+      projectPath: () =>
+        text({
+          message: "Where should we set up your project?",
+          placeholder: "./",
+          initialValue: options.path ?? "./",
+        }),
+    },
+    {
+      onCancel: onPromptCancel,
+    },
+  );
+
+  return await executeInit(
+    {
+      template: result.template,
+      name: result.name,
+      appId,
+      projectPath: result.projectPath as string,
+      deploy: options.deploy,
+      skills: options.skills,
+      isInteractive: true,
+    },
+    ctx,
+  );
+}
+
+async function initNonInteractive(
+  appId: string,
+  options: InitOptions,
+  ctx: Pick<CLIContext, "log" | "runTask">,
+): Promise<RunCommandResult> {
+  const projectPath = options.path ?? "./";
+  const name = options.name ?? basename(resolve(projectPath));
+
+  ctx.log.info(`Initializing project at ${resolve(projectPath)}`);
+
+  const template = await getTemplateById(
+    options.template ?? DEFAULT_TEMPLATE_ID,
+  );
+
+  return await executeInit(
+    {
+      template,
+      name,
+      appId,
+      projectPath,
+      deploy: options.deploy,
+      skills: options.skills,
+      isInteractive: false,
+    },
+    ctx,
+  );
+}
+
+async function initAction(
+  { log, runTask, isNonInteractive }: CLIContext,
+  name: string | undefined,
+  options: InitOptions,
+): Promise<RunCommandResult> {
+  const appId = resolveAppId(options);
+  const opts: InitOptions = { ...options, name: options.name ?? name };
+  const ctx = { log, runTask };
+
+  if (isNonInteractive) {
+    return await initNonInteractive(appId, opts, ctx);
+  }
+  return await initInteractive(appId, opts, ctx);
+}
+
+export function getInitCommand(): Command {
+  return new Base44Command("init", {
+    requireAppConfig: false,
+    fullBanner: true,
+  })
+    .description(
+      "Scaffold a local project for an existing Base44 app (e.g. one provisioned by the Stripe Projects CLI)",
+    )
+    .addArgument(new Argument("name", "Project name").argOptional())
+    .option(
+      "--app-id <id>",
+      "Existing Base44 app ID (defaults to the BASE44_APP_ID environment variable)",
+    )
+    .option(
+      "-p, --path <path>",
+      "Path where to set up the project (defaults to the current directory)",
+    )
+    .option(
+      "-t, --template <id>",
+      "Template ID (e.g., backend-only, backend-and-client)",
+    )
+    .option("--deploy", "Build and deploy the site")
+    .option("--no-skills", "Skip AI agent skills installation")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ base44 init                                  Scaffolds in the current dir using $BASE44_APP_ID
+  $ base44 init --app-id app_123                 Scaffolds in the current dir for the given app
+  $ base44 init my-app --app-id app_123          Scaffolds in the current dir named "my-app"`,
+    )
+    .action(initAction);
+}

--- a/packages/cli/src/cli/commands/project/scaffold-shared.ts
+++ b/packages/cli/src/cli/commands/project/scaffold-shared.ts
@@ -1,0 +1,167 @@
+import { join } from "node:path";
+import { confirm, isCancel } from "@clack/prompts";
+import { execa } from "execa";
+import type { CLIContext, RunCommandResult } from "@/cli/types.js";
+import { getDashboardUrl, theme } from "@/cli/utils/index.js";
+import { InvalidInputError } from "@/core/errors.js";
+import { deploySite, pushEntities } from "@/core/index.js";
+import type { Template } from "@/core/project/index.js";
+import { listTemplates, readProjectConfig } from "@/core/project/index.js";
+
+/** Default template used by `create`/`init` when none is specified. */
+export const DEFAULT_TEMPLATE_ID = "backend-only";
+
+/**
+ * Looks up a template by id, throwing a helpful error listing valid ids.
+ * Shared by the `create` and `init` commands.
+ */
+export async function getTemplateById(templateId: string): Promise<Template> {
+  const templates = await listTemplates();
+  const template = templates.find((t) => t.id === templateId);
+  if (!template) {
+    const validIds = templates.map((t) => t.id).join(", ");
+    throw new InvalidInputError(`Template "${templateId}" not found.`, {
+      hints: [{ message: `Use one of: ${validIds}` }],
+    });
+  }
+  return template;
+}
+
+interface CompleteProjectSetupOptions {
+  projectId: string;
+  name: string;
+  resolvedPath: string;
+  deploy?: boolean;
+  skills?: boolean;
+  isInteractive: boolean;
+}
+
+/**
+ * Post-scaffold steps shared by `create` and `init`: optionally push the
+ * template's data models, optionally build & deploy the site, install AI agent
+ * skills, then print the project/dashboard/site summary.
+ *
+ * Assumes the project files already exist and app config has been set
+ * (via `setAppConfig`) so `getAppClient()` and `getDashboardUrl()` work.
+ */
+export async function completeProjectSetup(
+  {
+    projectId,
+    name,
+    resolvedPath,
+    deploy,
+    skills,
+    isInteractive,
+  }: CompleteProjectSetupOptions,
+  { log, runTask }: Pick<CLIContext, "log" | "runTask">,
+): Promise<RunCommandResult> {
+  const { project, entities } = await readProjectConfig(resolvedPath);
+  let finalAppUrl: string | undefined;
+
+  if (entities.length > 0) {
+    let shouldPushEntities: boolean;
+
+    if (isInteractive) {
+      const result = await confirm({
+        message:
+          "Set up the backend data now? (This pushes the data models used by the template to Base44)",
+      });
+      shouldPushEntities = !isCancel(result) && result;
+    } else {
+      shouldPushEntities = !!deploy;
+    }
+
+    if (shouldPushEntities) {
+      await runTask(
+        `Pushing ${entities.length} data models to Base44...`,
+        async () => {
+          await pushEntities(entities);
+        },
+        {
+          successMessage: theme.colors.base44Orange(
+            "Data models pushed successfully",
+          ),
+          errorMessage: "Failed to push data models",
+        },
+      );
+    }
+  }
+
+  if (project.site) {
+    const { installCommand, buildCommand, outputDirectory } = project.site;
+
+    let shouldDeploy: boolean;
+
+    if (isInteractive) {
+      const result = await confirm({
+        message: "Would you like to deploy the site now? (Hosted on Base44)",
+      });
+      shouldDeploy = !isCancel(result) && result;
+    } else {
+      shouldDeploy = !!deploy;
+    }
+
+    if (shouldDeploy && installCommand && buildCommand && outputDirectory) {
+      const { appUrl } = await runTask(
+        "Installing dependencies...",
+        async (updateMessage) => {
+          await execa({ cwd: resolvedPath, shell: true })`${installCommand}`;
+
+          updateMessage("Building project...");
+          await execa({ cwd: resolvedPath, shell: true })`${buildCommand}`;
+
+          updateMessage("Deploying site...");
+          return await deploySite(join(resolvedPath, outputDirectory));
+        },
+        {
+          successMessage: theme.colors.base44Orange(
+            "Site deployed successfully",
+          ),
+          errorMessage: "Failed to deploy site",
+        },
+      );
+
+      finalAppUrl = appUrl;
+    }
+  }
+
+  // Add AI agent skills (--no-skills flag sets skills to false, otherwise defaults to true)
+  if (skills) {
+    try {
+      await runTask(
+        "Installing AI agent skills...",
+        async () => {
+          await execa("npx", ["-y", "skills", "add", "base44/skills", "-y"], {
+            cwd: resolvedPath,
+            shell: true,
+          });
+        },
+        {
+          successMessage: theme.colors.base44Orange(
+            "AI agent skills added successfully",
+          ),
+          errorMessage:
+            "Failed to add AI agent skills - you can add them later with: npx skills add base44/skills",
+        },
+      );
+    } catch {
+      // Skills installation is non-critical (e.g., user may not have git installed)
+      // The error message is already shown by runTask, so we just continue
+    }
+  }
+
+  log.message(
+    `${theme.styles.header("Project")}: ${theme.colors.base44Orange(name)}`,
+  );
+  log.message(
+    `${theme.styles.header("Dashboard")}: ${theme.colors.links(getDashboardUrl(projectId))}`,
+  );
+
+  if (finalAppUrl) {
+    log.message(
+      `${theme.styles.header("Site")}: ${theme.colors.links(finalAppUrl)}`,
+    );
+  }
+
+  return { outroMessage: "Your project is set up and ready to use" };
+}

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -1,3 +1,7 @@
+// Must be the first import: loads .env/.env.local into process.env before any
+// module captures env-derived config (e.g. the API base URL read when the HTTP
+// clients are constructed at module load).
+import "@/cli/bootstrap-env.js";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { ClackLogger, SimpleLogger } from "@base44-cli/logger";

--- a/packages/cli/src/cli/program.ts
+++ b/packages/cli/src/cli/program.ts
@@ -10,6 +10,7 @@ import { getEntitiesPushCommand } from "@/cli/commands/entities/push.js";
 import { getFunctionsCommand } from "@/cli/commands/functions/index.js";
 import { getCreateCommand } from "@/cli/commands/project/create.js";
 import { getDeployCommand } from "@/cli/commands/project/deploy.js";
+import { getInitCommand } from "@/cli/commands/project/init.js";
 import { getLinkCommand } from "@/cli/commands/project/link.js";
 import { getLogsCommand } from "@/cli/commands/project/logs.js";
 import { getSecretsCommand } from "@/cli/commands/secrets/index.js";
@@ -50,6 +51,7 @@ export function createProgram(context: CLIContext): Command {
 
   // Register project commands
   program.addCommand(getCreateCommand());
+  program.addCommand(getInitCommand());
   program.addCommand(getDashboardCommand());
   program.addCommand(getDeployCommand());
   program.addCommand(getLinkCommand());

--- a/packages/cli/src/core/auth/config.ts
+++ b/packages/cli/src/core/auth/config.ts
@@ -12,6 +12,20 @@ const TOKEN_REFRESH_BUFFER_MS = 60 * 1000;
 let refreshPromise: Promise<string | null> | null = null;
 
 /**
+ * Returns an access token supplied via the environment, if present.
+ *
+ * Used for non-interactive handoff flows (e.g. the Stripe Projects CLI), where
+ * the Base44 app's bearer token is injected as `BASE44_ACCESS_TOKEN` instead of
+ * coming from the interactive OAuth login stored in `~/.base44/auth/auth.json`.
+ *
+ * When set, this token takes precedence over the stored auth and is used as-is:
+ * it is never persisted and is not refreshable via the Base44 OAuth flow.
+ */
+export function getEnvAccessToken(): string | undefined {
+  return process.env.BASE44_ACCESS_TOKEN || undefined;
+}
+
+/**
  * Reads and validates the stored authentication data.
  *
  * @returns The parsed authentication data (tokens, user info).
@@ -132,6 +146,12 @@ export async function refreshAndSaveTokens(): Promise<string | null> {
  * }
  */
 export async function isLoggedIn(): Promise<boolean> {
+  // An env-supplied access token (e.g. Stripe Projects handoff) counts as
+  // authenticated without an interactive login.
+  if (getEnvAccessToken()) {
+    return true;
+  }
+
   try {
     await readAuth();
     return true;

--- a/packages/cli/src/core/clients/base44-client.ts
+++ b/packages/cli/src/core/clients/base44-client.ts
@@ -7,6 +7,7 @@ import { randomUUID } from "node:crypto";
 import type { KyRequest, KyResponse, NormalizedOptions } from "ky";
 import ky from "ky";
 import {
+  getEnvAccessToken,
   isTokenExpired,
   readAuth,
   refreshAndSaveTokens,
@@ -56,6 +57,13 @@ async function handleUnauthorized(
     return;
   }
 
+  // An env-supplied token (e.g. Stripe Projects handoff) is used as-is and
+  // cannot be refreshed via the Base44 OAuth flow. Let the 401 propagate
+  // rather than wiping the stored auth on a refresh failure.
+  if (getEnvAccessToken()) {
+    return;
+  }
+
   const newAccessToken = await refreshAndSaveTokens();
 
   if (!newAccessToken) {
@@ -98,6 +106,15 @@ export const base44Client = ky.create({
       captureRequestBody,
       async (request) => {
         try {
+          // An env-supplied token (e.g. Stripe Projects handoff) takes
+          // precedence and is used as-is, bypassing the stored auth and its
+          // OAuth refresh logic.
+          const envToken = getEnvAccessToken();
+          if (envToken) {
+            request.headers.set("Authorization", `Bearer ${envToken}`);
+            return;
+          }
+
           const auth = await readAuth();
 
           // Proactively refresh if token is expired or about to expire

--- a/packages/cli/src/core/project/create.ts
+++ b/packages/cli/src/core/project/create.ts
@@ -53,6 +53,45 @@ export async function createProjectFiles(
   };
 }
 
+/**
+ * Scaffolds a new local project for an **existing** Base44 app.
+ *
+ * Mirrors {@link createProjectFiles} but skips the `createProject()` API call:
+ * the app already exists (e.g. provisioned by the Stripe Projects CLI), so the
+ * caller passes its `appId` and the template is rendered against it.
+ */
+export async function initProjectFiles(options: {
+  name: string;
+  description?: string;
+  path: string;
+  template: Template;
+  appId: string;
+}): Promise<CreateProjectResult & { skippedFiles: string[] }> {
+  const { name, description, path: basePath, template, appId } = options;
+
+  await assertProjectNotExists(basePath);
+
+  // Render the template using the existing app ID (no API call to create one).
+  // Skip files that already exist so scaffolding into a non-empty directory
+  // (e.g. a Stripe Projects dir) never clobbers files like .gitignore.
+  const skippedFiles = await renderTemplate(
+    template,
+    basePath,
+    {
+      name,
+      description,
+      projectId: appId,
+    },
+    { skipExisting: true },
+  );
+
+  return {
+    projectId: appId,
+    projectDir: basePath,
+    skippedFiles,
+  };
+}
+
 export async function createProjectFilesForExistingProject(options: {
   projectId: string;
   projectPath: string;

--- a/packages/cli/src/core/project/template.ts
+++ b/packages/cli/src/core/project/template.ts
@@ -6,7 +6,12 @@ import { getTemplatesDir, getTemplatesIndexPath } from "@/core/assets.js";
 import { SchemaValidationError } from "@/core/errors.js";
 import type { Template } from "@/core/project/schema.js";
 import { TemplatesConfigSchema } from "@/core/project/schema.js";
-import { copyFile, readJsonFile, writeFile } from "@/core/utils/fs.js";
+import {
+  copyFile,
+  pathExists,
+  readJsonFile,
+  writeFile,
+} from "@/core/utils/fs.js";
 
 interface TemplateData {
   name: string;
@@ -34,17 +39,31 @@ export async function listTemplates(): Promise<Template[]> {
   return result.data.templates;
 }
 
+interface RenderTemplateOptions {
+  /**
+   * When true, existing destination files are left untouched instead of being
+   * overwritten. Used by `init`, which scaffolds into an existing directory
+   * (e.g. a Stripe Projects dir) and must not clobber files like `.gitignore`.
+   */
+  skipExisting?: boolean;
+}
+
 /**
  * Render a template directory to a destination path.
  * - Files ending in .ejs are rendered with EJS and written without the .ejs extension
  * - EJS files can have frontmatter with custom attributes
  * - All other files are copied directly
+ *
+ * @returns The destination-relative paths of files that were skipped because
+ *   they already existed (only populated when `skipExisting` is set).
  */
 export async function renderTemplate(
   template: Template,
   destPath: string,
   data: TemplateData,
-): Promise<void> {
+  options: RenderTemplateOptions = {},
+): Promise<string[]> {
+  const { skipExisting = false } = options;
   const templateDir = join(getTemplatesDir(), template.path);
 
   // Get all files in the template directory
@@ -53,6 +72,8 @@ export async function renderTemplate(
     dot: true,
     onlyFiles: true,
   });
+
+  const skipped: string[] = [];
 
   for (const file of files) {
     const srcPath = join(templateDir, file);
@@ -67,10 +88,19 @@ export async function renderTemplate(
           : file.replace(/\.ejs$/, "");
         const destFilePath = join(destPath, destFile);
 
+        if (skipExisting && (await pathExists(destFilePath))) {
+          skipped.push(destFile);
+          continue;
+        }
         await writeFile(destFilePath, body);
       } else {
         // Copy file directly
         const destFilePath = join(destPath, file);
+
+        if (skipExisting && (await pathExists(destFilePath))) {
+          skipped.push(file);
+          continue;
+        }
         await copyFile(srcPath, destFilePath);
       }
     } catch (error) {
@@ -78,4 +108,6 @@ export async function renderTemplate(
       throw new Error(`Failed to process template file "${file}": ${message}`);
     }
   }
+
+  return skipped;
 }

--- a/packages/cli/src/core/utils/env.ts
+++ b/packages/cli/src/core/utils/env.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { parse } from "dotenv";
 import { readTextFile } from "./fs.js";
 
@@ -9,4 +11,79 @@ export async function parseEnvFile(
 ): Promise<Record<string, string>> {
   const content = await readTextFile(filePath);
   return parse(content);
+}
+
+// Project-local env files loaded at CLI startup, in increasing precedence order
+// (a later file overrides an earlier one for the same key).
+const PROJECT_ENV_FILES = [".env", ".env.local"];
+
+// The credentials the CLI consumes from the environment. The Stripe Projects
+// CLI namespaces these by resource (e.g. BASE44_PROJECTS_BASE44_APP_ID), so we
+// also accept any `<PREFIX>_BASE44_*` form and normalize it to the bare name.
+const BASE44_ENV_KEYS = [
+  "BASE44_APP_ID",
+  "BASE44_ACCESS_TOKEN",
+  "BASE44_REFRESH_TOKEN",
+  "BASE44_API_URL",
+];
+
+/**
+ * Loads project-local `.env` / `.env.local` files into `process.env`.
+ *
+ * Enables non-interactive handoff flows such as the Stripe Projects CLI, which
+ * writes the Base44 credentials to `.env` via `stripe projects env --pull`.
+ * Loading them here lets `base44` commands pick up those credentials with no
+ * wrapper.
+ *
+ * Precedence: ambient/explicit `process.env` > `.env.local` > `.env`. Values
+ * already present in the environment are never overridden. Missing files are
+ * ignored. Synchronous so it can run during program bootstrap before parsing.
+ */
+export function loadProjectEnvFiles(cwd: string = process.cwd()): void {
+  const merged: Record<string, string> = {};
+
+  for (const fileName of PROJECT_ENV_FILES) {
+    try {
+      const content = readFileSync(join(cwd, fileName), "utf-8");
+      Object.assign(merged, parse(content));
+    } catch {
+      // File missing or unreadable — skip it.
+    }
+  }
+
+  for (const [key, value] of Object.entries(merged)) {
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+
+  normalizeBase44Env();
+}
+
+/**
+ * Bridges the Stripe Projects CLI's namespaced credential vars to the bare
+ * `BASE44_*` names the rest of the CLI reads.
+ *
+ * `stripe projects env --pull` prefixes each provider var with the resource
+ * name, so the access token arrives as e.g. `BASE44_PROJECTS_BASE44_ACCESS_TOKEN`
+ * rather than `BASE44_ACCESS_TOKEN`. For each expected key, if the bare name is
+ * unset and exactly one `<PREFIX>_<KEY>` variable exists, copy its value to the
+ * bare name. Ambiguous (multiple matches) or missing keys are left untouched so
+ * resolution fails with a clear error instead of picking the wrong credential.
+ */
+function normalizeBase44Env(): void {
+  for (const bareKey of BASE44_ENV_KEYS) {
+    if (process.env[bareKey] !== undefined) {
+      continue;
+    }
+
+    const suffix = `_${bareKey}`;
+    const matches = Object.keys(process.env).filter(
+      (key) => key !== bareKey && key.endsWith(suffix),
+    );
+
+    if (matches.length === 1) {
+      process.env[bareKey] = process.env[matches[0]];
+    }
+  }
 }

--- a/packages/cli/tests/cli/env-token-auth.spec.ts
+++ b/packages/cli/tests/cli/env-token-auth.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { fixture, setupCLITests } from "./testkit/index.js";
+
+const APP_ID = "test-app-id";
+
+describe("env access token authentication", () => {
+  const t = setupCLITests();
+
+  it("uses BASE44_ACCESS_TOKEN as the bearer token for API calls", async () => {
+    // No givenLoggedIn(): the only credential is the env access token. This
+    // verifies the token is sent verbatim, with no stored auth and no refresh.
+    await t.givenProject(fixture("with-entities"));
+    t.givenEnv({ BASE44_ACCESS_TOKEN: "env-access-token-xyz" });
+
+    let authHeader: string | undefined;
+    t.api.mockRoute("PUT", `/api/apps/${APP_ID}/entity-schemas`, (req, res) => {
+      authHeader = req.headers.authorization;
+      res.status(200).json({ created: ["customer"], updated: [], deleted: [] });
+    });
+
+    const result = await t.run("entities", "push");
+
+    t.expectResult(result).toSucceed();
+    expect(authHeader).toBe("Bearer env-access-token-xyz");
+  });
+
+  it("does not attempt an OAuth refresh on 401 when using an env token", async () => {
+    await t.givenProject(fixture("with-entities"));
+    t.givenEnv({ BASE44_ACCESS_TOKEN: "env-access-token-xyz" });
+
+    // If the client tried to refresh, it would call POST /oauth/token. We make
+    // that fail loudly so an unexpected refresh attempt is observable.
+    let refreshAttempted = false;
+    t.api.mockRoute("POST", "/oauth/token", (_req, res) => {
+      refreshAttempted = true;
+      res.status(500).json({ error: "should-not-be-called" });
+    });
+    t.api.mockRoute(
+      "PUT",
+      `/api/apps/${APP_ID}/entity-schemas`,
+      (_req, res) => {
+        res.status(401).json({ error: "Unauthorized" });
+      },
+    );
+
+    const result = await t.run("entities", "push");
+
+    // The 401 should propagate as a failure, without a refresh round-trip.
+    t.expectResult(result).toFail();
+    expect(refreshAttempted).toBe(false);
+  });
+});

--- a/packages/cli/tests/cli/init.spec.ts
+++ b/packages/cli/tests/cli/init.spec.ts
@@ -1,0 +1,121 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { setupCLITests } from "./testkit/index.js";
+
+const USER = { email: "test@example.com", name: "Test User" };
+
+/** Read a file scaffolded into the temp (working) directory. */
+async function readTempFile(
+  dir: string,
+  relativePath: string,
+): Promise<string | null> {
+  try {
+    return await readFile(join(dir, relativePath), "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+describe("init command", () => {
+  const t = setupCLITests();
+
+  it("scaffolds for an existing app id without creating a new app", async () => {
+    await t.givenLoggedIn(USER);
+    // Note: mockCreateApp is intentionally NOT registered. If init tried to
+    // create an app, the unmocked POST /api/apps would 404 and fail the run.
+
+    const result = await t.run(
+      "init",
+      "--app-id",
+      "app-existing-123",
+      "--no-skills",
+    );
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("Project created successfully");
+    t.expectResult(result).toContain("app-existing-123");
+
+    const appConfig = await readTempFile(t.getTempDir(), "base44/.app.jsonc");
+    expect(appConfig).toContain("app-existing-123");
+  });
+
+  it("reads the app id from BASE44_APP_ID when --app-id is omitted", async () => {
+    await t.givenLoggedIn(USER);
+    t.givenEnv({ BASE44_APP_ID: "app-from-env" });
+
+    const result = await t.run("init", "--no-skills");
+
+    t.expectResult(result).toSucceed();
+    const appConfig = await readTempFile(t.getTempDir(), "base44/.app.jsonc");
+    expect(appConfig).toContain("app-from-env");
+  });
+
+  it("prefers --app-id over the BASE44_APP_ID env var", async () => {
+    await t.givenLoggedIn(USER);
+    t.givenEnv({ BASE44_APP_ID: "app-from-env" });
+
+    const result = await t.run(
+      "init",
+      "--app-id",
+      "app-from-flag",
+      "--no-skills",
+    );
+
+    t.expectResult(result).toSucceed();
+    const appConfig = await readTempFile(t.getTempDir(), "base44/.app.jsonc");
+    expect(appConfig).toContain("app-from-flag");
+    expect(appConfig).not.toContain("app-from-env");
+  });
+
+  it("fails with a helpful message when no app id is available", async () => {
+    await t.givenLoggedIn(USER);
+
+    const result = await t.run("init", "--no-skills");
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("No app ID found");
+    t.expectResult(result).toContain("--app-id");
+    t.expectResult(result).toContain("BASE44_APP_ID");
+  });
+
+  it("authenticates via BASE44_ACCESS_TOKEN without a stored login", async () => {
+    // No givenLoggedIn(): there is no ~/.base44/auth/auth.json. The env access
+    // token must satisfy the auth requirement on its own.
+    t.givenEnv({ BASE44_ACCESS_TOKEN: "env-access-token" });
+
+    const result = await t.run(
+      "init",
+      "--app-id",
+      "app-env-auth",
+      "--no-skills",
+    );
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("Project created successfully");
+  });
+
+  it("does not overwrite existing files when scaffolding", async () => {
+    await t.givenLoggedIn(USER);
+
+    // Pre-create base44/.gitignore (which the template would otherwise write).
+    // This does not match the project-config pattern (base44/config.*), so init
+    // still proceeds, but the existing file must be preserved.
+    const base44Dir = join(t.getTempDir(), "base44");
+    await mkdir(base44Dir, { recursive: true });
+    await writeFile(join(base44Dir, ".gitignore"), "# pre-existing\nkeep-me\n");
+
+    const result = await t.run(
+      "init",
+      "--app-id",
+      "app-skip-existing",
+      "--no-skills",
+    );
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("Kept existing file");
+
+    const gitignore = await readTempFile(t.getTempDir(), "base44/.gitignore");
+    expect(gitignore).toContain("keep-me");
+  });
+});

--- a/packages/cli/tests/cli/testkit/CLITestkit.ts
+++ b/packages/cli/tests/cli/testkit/CLITestkit.ts
@@ -136,6 +136,11 @@ export class CLITestkit {
     this.stdinContent = content;
   }
 
+  /** Set additional environment variables for subsequent run()/runLive() calls */
+  givenEnv(vars: Record<string, string>): void {
+    this.env = { ...this.env, ...vars };
+  }
+
   // ─── WHEN METHODS ─────────────────────────────────────────────
 
   /** Spawn the CLI as a child process and execute the command */

--- a/packages/cli/tests/cli/testkit/index.ts
+++ b/packages/cli/tests/cli/testkit/index.ts
@@ -38,6 +38,9 @@ export interface TestContext {
   /** Simulate piped stdin for the next run() call */
   givenStdin: (content: string) => void;
 
+  /** Set additional environment variables for subsequent run() calls */
+  givenEnv: (vars: Record<string, string>) => void;
+
   // ─── WHEN METHODS ──────────────────────────────────────────
 
   /** Execute CLI command */
@@ -124,6 +127,7 @@ export function setupCLITests(): TestContext {
     },
     givenLatestVersion: (version) => getKit().givenLatestVersion(version),
     givenStdin: (content) => getKit().givenStdin(content),
+    givenEnv: (vars) => getKit().givenEnv(vars),
 
     // When methods
     run: (...args) => getKit().run(...args),

--- a/packages/cli/tests/core/env.spec.ts
+++ b/packages/cli/tests/core/env.spec.ts
@@ -1,0 +1,100 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadProjectEnvFiles } from "@/core/utils/env.js";
+
+// Keys this suite manipulates; saved and restored around each test so we never
+// leak into the real process environment.
+const KEYS = [
+  "LPE_FOO",
+  "LPE_BAR",
+  "LPE_PRESET",
+  "BASE44_APP_ID",
+  "ACME_BASE44_APP_ID",
+  "OTHER_BASE44_APP_ID",
+];
+
+describe("loadProjectEnvFiles", () => {
+  let dir: string;
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "b44-env-"));
+    saved = {};
+    for (const key of KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(async () => {
+    for (const key of KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("loads values from .env", async () => {
+    await writeFile(join(dir, ".env"), "LPE_FOO=from_env\n");
+
+    loadProjectEnvFiles(dir);
+
+    expect(process.env.LPE_FOO).toBe("from_env");
+  });
+
+  it("lets .env.local override .env", async () => {
+    await writeFile(join(dir, ".env"), "LPE_BAR=from_env\n");
+    await writeFile(join(dir, ".env.local"), "LPE_BAR=from_local\n");
+
+    loadProjectEnvFiles(dir);
+
+    expect(process.env.LPE_BAR).toBe("from_local");
+  });
+
+  it("never overrides a value already present in process.env", async () => {
+    process.env.LPE_PRESET = "ambient";
+    await writeFile(join(dir, ".env"), "LPE_PRESET=from_env\n");
+
+    loadProjectEnvFiles(dir);
+
+    expect(process.env.LPE_PRESET).toBe("ambient");
+  });
+
+  it("ignores missing files", () => {
+    expect(() => loadProjectEnvFiles(dir)).not.toThrow();
+  });
+
+  it("normalizes a Stripe-prefixed BASE44_APP_ID to the bare name", async () => {
+    // Mirrors `stripe projects env --pull`, which writes BASE44_PROJECTS_BASE44_APP_ID.
+    await writeFile(join(dir, ".env"), "ACME_BASE44_APP_ID=app_prefixed\n");
+
+    loadProjectEnvFiles(dir);
+
+    expect(process.env.BASE44_APP_ID).toBe("app_prefixed");
+  });
+
+  it("does not override a bare BASE44_APP_ID with a prefixed one", async () => {
+    process.env.BASE44_APP_ID = "app_bare";
+    await writeFile(join(dir, ".env"), "ACME_BASE44_APP_ID=app_prefixed\n");
+
+    loadProjectEnvFiles(dir);
+
+    expect(process.env.BASE44_APP_ID).toBe("app_bare");
+  });
+
+  it("leaves the bare key unset when prefixed vars are ambiguous", async () => {
+    await writeFile(
+      join(dir, ".env"),
+      "ACME_BASE44_APP_ID=app_one\nOTHER_BASE44_APP_ID=app_two\n",
+    );
+
+    loadProjectEnvFiles(dir);
+
+    expect(process.env.BASE44_APP_ID).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What & why

Adds **`base44 init`** — scaffolds a local project for an **already-existing** Base44 app (e.g. one provisioned by the **Stripe Projects CLI**), using the app id and access token supplied via the environment, without creating a new app or requiring an interactive login. This is the local-dev handoff after `stripe projects add base44_projects`.

## Changes

- **`init` command** (`cli/commands/project/init.ts`, registered in `program.ts`): resolves the app id from `--app-id` or `BASE44_APP_ID`, scaffolds the template against the existing id (no `createProject()` call), defaults path to the current dir.
- **Env-token auth** (`core/auth/config.ts`, `core/clients/base44-client.ts`): `BASE44_ACCESS_TOKEN` is used verbatim as the bearer token, taking precedence over `~/.base44/auth.json` and bypassing OAuth refresh (provider-issued tokens can't refresh via `/oauth/token`). `isLoggedIn()` honors it so `requireAuth` commands run without login.
- **`.env` auto-load + normalization** (`core/utils/env.ts` + `cli/bootstrap-env.ts` as the first import): loads `.env`/`.env.local` before the HTTP clients capture the API URL, and normalizes the Stripe CLI's resource-prefixed vars (e.g. `BASE44_PROJECTS_BASE44_APP_ID`) to the bare `BASE44_*` names (prefix-agnostic; ambiguous matches left unset).
- **Non-destructive scaffolding** (`core/project/template.ts`): `renderTemplate` gains a `skipExisting` mode so `init` never clobbers existing files (e.g. a Stripe-managed `.gitignore`).
- **Shared internals** (`cli/commands/project/scaffold-shared.ts`): `create`'s post-scaffold logic (push/deploy/skills/output + `getTemplateById`) is extracted and reused by both `create` and `init` (`create.ts` shrank ~138 lines).

## Verification

- `typecheck` ✓, `lint` ✓, **520 tests** ✓ (new specs: `init`, `env-token-auth`, core `env`; adds a `givenEnv` testkit helper).
- **Real Stripe e2e** against a live provisioned app: `stripe projects env --pull` → `base44 init` (scaffolded the real appId via prefix-normalization) → `entities push` → `deploy --yes`, all authenticated by the Stripe env token; test artifacts cleaned up afterward. (This e2e is what surfaced the prefix-normalization requirement.)

## ⚠️ Known limitation / follow-up

`entities push` (and `deploy`) is a **full reconcile** — the remote is made to match `base44/entities/` exactly, so entities present remotely but absent locally are **deleted**. `init` currently scaffolds a fresh template and does **not** pull the existing app's resources, so running `push`/`deploy` after `init` against an app that already has data models can delete them (including the default `User` entity). There is also no `entities pull` command today.

Recommended follow-up before this is used for non-empty apps: have `init` mirror the existing app's resources (pull entities — `GET /entity-schemas` already exists — plus functions/agents/connectors) so the first push is non-destructive. Tracking this separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
