### PR TITLE
refactor(cli): extract shared scaffold logic into scaffold-shared (1/3)

### DIFF
--- a/packages/cli/src/cli/commands/project/create.ts
+++ b/packages/cli/src/cli/commands/project/create.ts
@@ -1,27 +1,24 @@
-import { basename, join, resolve } from "node:path";
+import { basename, resolve } from "node:path";
 import type { Option } from "@clack/prompts";
-import { confirm, group, isCancel, select, text } from "@clack/prompts";
+import { group, select, text } from "@clack/prompts";
 import { Argument, type Command } from "commander";
-import { execa } from "execa";
 import kebabCase from "lodash/kebabCase";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";
-import {
-  Base44Command,
-  getDashboardUrl,
-  onPromptCancel,
-  theme,
-} from "@/cli/utils/index.js";
+import { Base44Command, onPromptCancel, theme } from "@/cli/utils/index.js";
 import { InvalidInputError } from "@/core/errors.js";
-import { deploySite, isDirEmpty, pushEntities } from "@/core/index.js";
+import { isDirEmpty } from "@/core/index.js";
 import type { Template } from "@/core/project/index.js";
 import {
   createProjectFiles,
   listTemplates,
-  readProjectConfig,
   setAppConfig,
 } from "@/core/project/index.js";
-
-const DEFAULT_TEMPLATE_ID = "backend-only";
+import {
+  completeProjectSetup,
+  DEFAULT_TEMPLATE_ID,
+  getTemplateById,
+  printProjectSummary,
+} from "./scaffold-shared.js";
 
 interface CreateOptions {
   name?: string;
@@ -29,18 +26,6 @@ interface CreateOptions {
   template?: string;
   deploy?: boolean;
   skills?: boolean;
-}
-
-async function getTemplateById(templateId: string): Promise<Template> {
-  const templates = await listTemplates();
-  const template = templates.find((t) => t.id === templateId);
-  if (!template) {
-    const validIds = templates.map((t) => t.id).join(", ");
-    throw new InvalidInputError(`Template "${templateId}" not found.`, {
-      hints: [{ message: `Use one of: ${validIds}` }],
-    });
-  }
-  return template;
 }
 
 function validateNonInteractiveFlags(command: Command): void {
@@ -55,7 +40,7 @@ function validateNonInteractiveFlags(command: Command): void {
 
 async function createInteractive(
   options: CreateOptions,
-  ctx: Pick<CLIContext, "log" | "runTask">,
+  ctx: CLIContext,
 ): Promise<RunCommandResult> {
   const templates = await listTemplates();
   const templateOptions: Option<Template>[] = templates.map((t) => ({
@@ -116,7 +101,7 @@ async function createInteractive(
 
 async function createNonInteractive(
   options: CreateOptions,
-  ctx: Pick<CLIContext, "log" | "runTask">,
+  ctx: CLIContext,
 ): Promise<RunCommandResult> {
   ctx.log.info(`Creating a new project at ${resolve(options.path!)}`);
 
@@ -155,8 +140,9 @@ async function executeCreate(
     skills?: boolean;
     isInteractive: boolean;
   },
-  { log, runTask }: Pick<CLIContext, "log" | "runTask">,
+  ctx: CLIContext,
 ): Promise<RunCommandResult> {
+  const { log, runTask } = ctx;
   const name = rawName.trim();
   const resolvedPath = resolve(projectPath);
 
@@ -176,124 +162,19 @@ async function executeCreate(
     },
   );
 
-  // Set app config in cache for sync access to getDashboardUrl and getAppClient
   setAppConfig({ id: projectId, projectRoot: resolvedPath });
 
-  const { project, entities } = await readProjectConfig(resolvedPath);
-  let finalAppUrl: string | undefined;
-
-  if (entities.length > 0) {
-    let shouldPushEntities: boolean;
-
-    if (isInteractive) {
-      const result = await confirm({
-        message:
-          "Set up the backend data now? (This pushes the data models used by the template to Base44)",
-      });
-      shouldPushEntities = !isCancel(result) && result;
-    } else {
-      shouldPushEntities = !!deploy;
-    }
-
-    if (shouldPushEntities) {
-      await runTask(
-        `Pushing ${entities.length} data models to Base44...`,
-        async () => {
-          await pushEntities(entities);
-        },
-        {
-          successMessage: theme.colors.base44Orange(
-            "Data models pushed successfully",
-          ),
-          errorMessage: "Failed to push data models",
-        },
-      );
-    }
-  }
-
-  if (project.site) {
-    const { installCommand, buildCommand, outputDirectory } = project.site;
-
-    let shouldDeploy: boolean;
-
-    if (isInteractive) {
-      const result = await confirm({
-        message: "Would you like to deploy the site now? (Hosted on Base44)",
-      });
-      shouldDeploy = !isCancel(result) && result;
-    } else {
-      shouldDeploy = !!deploy;
-    }
-
-    if (shouldDeploy && installCommand && buildCommand && outputDirectory) {
-      const { appUrl } = await runTask(
-        "Installing dependencies...",
-        async (updateMessage) => {
-          await execa({ cwd: resolvedPath, shell: true })`${installCommand}`;
-
-          updateMessage("Building project...");
-          await execa({ cwd: resolvedPath, shell: true })`${buildCommand}`;
-
-          updateMessage("Deploying site...");
-          return await deploySite(join(resolvedPath, outputDirectory));
-        },
-        {
-          successMessage: theme.colors.base44Orange(
-            "Site deployed successfully",
-          ),
-          errorMessage: "Failed to deploy site",
-        },
-      );
-
-      finalAppUrl = appUrl;
-    }
-  }
-
-  // Add AI agent skills (--no-skills flag sets skills to false, otherwise defaults to true)
-  const shouldAddSkills = skills;
-
-  if (shouldAddSkills) {
-    try {
-      await runTask(
-        "Installing AI agent skills...",
-        async () => {
-          await execa("npx", ["-y", "skills", "add", "base44/skills", "-y"], {
-            cwd: resolvedPath,
-            shell: true,
-          });
-        },
-        {
-          successMessage: theme.colors.base44Orange(
-            "AI agent skills added successfully",
-          ),
-          errorMessage:
-            "Failed to add AI agent skills - you can add them later with: npx skills add base44/skills",
-        },
-      );
-    } catch {
-      // Skills installation is non-critical (e.g., user may not have git installed)
-      // The error message is already shown by runTask, so we just continue
-    }
-  }
-
-  log.message(
-    `${theme.styles.header("Project")}: ${theme.colors.base44Orange(name)}`,
+  const summary = await completeProjectSetup(
+    { projectId, name, resolvedPath, deploy, skills, isInteractive },
+    ctx,
   );
-  log.message(
-    `${theme.styles.header("Dashboard")}: ${theme.colors.links(getDashboardUrl(projectId))}`,
-  );
-
-  if (finalAppUrl) {
-    log.message(
-      `${theme.styles.header("Site")}: ${theme.colors.links(finalAppUrl)}`,
-    );
-  }
+  printProjectSummary(summary, log);
 
   return { outroMessage: "Your project is set up and ready to use" };
 }
 
 async function createAction(
-  { log, runTask, isNonInteractive }: CLIContext,
+  ctx: CLIContext,
   name: string | undefined,
   options: CreateOptions,
 ): Promise<RunCommandResult> {
@@ -303,7 +184,7 @@ async function createAction(
 
   const skipPrompts = !!(options.name ?? name) && !!options.path;
 
-  if (!skipPrompts && isNonInteractive) {
+  if (!skipPrompts && ctx.isNonInteractive) {
     throw new InvalidInputError(
       "Project name and --path are required in non-interactive mode",
       {
@@ -315,8 +196,6 @@ async function createAction(
       },
     );
   }
-
-  const ctx = { log, runTask };
 
   if (skipPrompts) {
     return await createNonInteractive(

--- a/packages/cli/src/cli/commands/project/scaffold-shared.ts
+++ b/packages/cli/src/cli/commands/project/scaffold-shared.ts
@@ -1,0 +1,169 @@
+import { join } from "node:path";
+import { confirm, isCancel } from "@clack/prompts";
+import { execa } from "execa";
+import type { CLIContext } from "@/cli/types.js";
+import { getDashboardUrl, theme } from "@/cli/utils/index.js";
+import { InvalidInputError } from "@/core/errors.js";
+import { deploySite, pushEntities } from "@/core/index.js";
+import type { Template } from "@/core/project/index.js";
+import { listTemplates, readProjectConfig } from "@/core/project/index.js";
+
+export const DEFAULT_TEMPLATE_ID = "backend-only";
+
+export async function getTemplateById(templateId: string): Promise<Template> {
+  const templates = await listTemplates();
+  const template = templates.find((t) => t.id === templateId);
+  if (!template) {
+    const validIds = templates.map((t) => t.id).join(", ");
+    throw new InvalidInputError(`Template "${templateId}" not found.`, {
+      hints: [{ message: `Use one of: ${validIds}` }],
+    });
+  }
+  return template;
+}
+
+interface CompleteProjectSetupOptions {
+  projectId: string;
+  name: string;
+  resolvedPath: string;
+  deploy?: boolean;
+  skills?: boolean;
+  isInteractive: boolean;
+}
+
+interface ProjectSetupResult {
+  name: string;
+  dashboardUrl: string;
+  appUrl?: string;
+}
+
+// Requires `setAppConfig()` to have run first so `getAppClient()` /
+// `getDashboardUrl()` resolve.
+export async function completeProjectSetup(
+  {
+    projectId,
+    name,
+    resolvedPath,
+    deploy,
+    skills,
+    isInteractive,
+  }: CompleteProjectSetupOptions,
+  { runTask }: CLIContext,
+): Promise<ProjectSetupResult> {
+  const { project, entities } = await readProjectConfig(resolvedPath);
+  let finalAppUrl: string | undefined;
+
+  if (entities.length > 0) {
+    let shouldPushEntities: boolean;
+
+    if (isInteractive) {
+      const result = await confirm({
+        message:
+          "Set up the backend data now? (This pushes the data models used by the template to Base44)",
+      });
+      shouldPushEntities = !isCancel(result) && result;
+    } else {
+      shouldPushEntities = !!deploy;
+    }
+
+    if (shouldPushEntities) {
+      await runTask(
+        `Pushing ${entities.length} data models to Base44...`,
+        async () => {
+          await pushEntities(entities);
+        },
+        {
+          successMessage: theme.colors.base44Orange(
+            "Data models pushed successfully",
+          ),
+          errorMessage: "Failed to push data models",
+        },
+      );
+    }
+  }
+
+  if (project.site) {
+    const { installCommand, buildCommand, outputDirectory } = project.site;
+
+    let shouldDeploy: boolean;
+
+    if (isInteractive) {
+      const result = await confirm({
+        message: "Would you like to deploy the site now? (Hosted on Base44)",
+      });
+      shouldDeploy = !isCancel(result) && result;
+    } else {
+      shouldDeploy = !!deploy;
+    }
+
+    if (shouldDeploy && installCommand && buildCommand && outputDirectory) {
+      const { appUrl } = await runTask(
+        "Installing dependencies...",
+        async (updateMessage) => {
+          await execa({ cwd: resolvedPath, shell: true })`${installCommand}`;
+
+          updateMessage("Building project...");
+          await execa({ cwd: resolvedPath, shell: true })`${buildCommand}`;
+
+          updateMessage("Deploying site...");
+          return await deploySite(join(resolvedPath, outputDirectory));
+        },
+        {
+          successMessage: theme.colors.base44Orange(
+            "Site deployed successfully",
+          ),
+          errorMessage: "Failed to deploy site",
+        },
+      );
+
+      finalAppUrl = appUrl;
+    }
+  }
+
+  if (skills) {
+    try {
+      await runTask(
+        "Installing AI agent skills...",
+        async () => {
+          await execa("npx", ["-y", "skills", "add", "base44/skills", "-y"], {
+            cwd: resolvedPath,
+            shell: true,
+          });
+        },
+        {
+          successMessage: theme.colors.base44Orange(
+            "AI agent skills added successfully",
+          ),
+          errorMessage:
+            "Failed to add AI agent skills - you can add them later with: npx skills add base44/skills",
+        },
+      );
+    } catch {
+      // Non-critical; runTask already showed the error, so continue.
+    }
+  }
+
+  return {
+    name,
+    dashboardUrl: getDashboardUrl(projectId),
+    appUrl: finalAppUrl,
+  };
+}
+
+export function printProjectSummary(
+  { name, dashboardUrl, appUrl }: ProjectSetupResult,
+  log: CLIContext["log"],
+): void {
+  log.message(
+    `${theme.styles.header("Project")}: ${theme.colors.base44Orange(name)}`,
+  );
+  log.message(
+    `${theme.styles.header("Dashboard")}: ${theme.colors.links(dashboardUrl)}`,
+  );
+
+  if (appUrl) {
+    log.message(
+      `${theme.styles.header("Site")}: ${theme.colors.links(appUrl)}`,
+    );
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Extracts the shared post-scaffold setup logic (entity push, site deploy, AI agent skills install, and project summary printing) out of the `create` command into a new `scaffold-shared.ts` module. This decouples the reusable setup flow from the `create.ts` command wiring so it can be shared by other scaffolding commands, with no change to user-facing behavior.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [x] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added `packages/cli/src/cli/commands/project/scaffold-shared.ts` exposing `DEFAULT_TEMPLATE_ID`, `getTemplateById()`, `completeProjectSetup()`, and `printProjectSummary()`.
> - Moved entity push, site deploy, and AI agent skills installation logic from `create.ts` into `completeProjectSetup()`.
> - Moved the project/dashboard/site summary output into `printProjectSummary()`.
> - Slimmed down `create.ts` to import these shared helpers; removed now-unused imports (`execa`, `confirm`, `isCancel`, `getDashboardUrl`, `deploySite`, `pushEntities`, `readProjectConfig`, `join`).
> - Changed the `ctx` parameter in `createInteractive`/`createNonInteractive`/`executeCreate` from a narrowed `Pick<CLIContext, ...>` to the full `CLIContext` so it can be passed through to the shared helpers.
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (\`npm test\`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [x] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated \`docs/\` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> Pure refactoring: the logic and prompts are moved verbatim with no behavioral change. `completeProjectSetup()` documents that it requires `setAppConfig()` to have run first so `getDashboardUrl()`/`getAppClient()` resolve.
>
> ---
> <sub>🤖 Generated by Claude | 2026-06-10 13:07 UTC | 1c139b6</sub>