### PR TITLE
feat(cli): seed auth.json from env-supplied credentials (2/3)

### DIFF
--- a/docs/api-patterns.md
+++ b/docs/api-patterns.md
@@ -43,6 +43,28 @@ The `base44Client` automatically handles token refresh:
 2. If expired, refreshes token and saves new tokens
 3. On 401 response, attempts refresh and retries once
 
+## Environment-Supplied Credentials
+
+For non-interactive flows (CI, agents, provisioning tools) that hand off an
+app's credentials via the environment, the `ensureAuth` middleware calls
+`seedAuthFromEnv()`: when `BASE44_ACCESS_TOKEN` is set, it decodes the JWT
+(`sub` → `email`, `exp` → `expiresAt`; no signature check — the server
+validates), pairs it with `BASE44_REFRESH_TOKEN`, and writes a standard
+`~/.base44/auth/auth.json`, so everything downstream uses one file-based path.
+
+This overwrites an existing login when env vars are present, and no-ops when
+they can't form a complete record. The seeded file looks like a normal login, so
+a 401 refresh applies to it too; if refresh fails it deletes the file, which
+self-heals on the next command (re-seeded from the still-present env vars). See
+`seedAuthFromEnv()` in `core/auth/config.js`.
+
+Credentials load from `.env`/`.env.local` at startup via `loadProjectEnvFiles()`
+(`core/utils/env.js`), wired through `cli/bootstrap-env.js` as the first import
+so it runs before the HTTP clients capture `getBase44ApiUrl()`. Precedence:
+ambient `process.env` > `.env.local` > `.env`. The Stripe Projects CLI namespaces
+its vars (`BASE44_PROJECTS_BASE44_*`), so the loader also copies those to the
+bare `BASE44_*` names when the bare name is unset.
+
 ## API Response Transformation (snake_case to camelCase)
 
 The Base44 API returns snake_case keys, but the CLI uses camelCase. Use Zod's `.transform()` to convert:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -143,7 +143,9 @@ export function getMyCommand(): Command {
 }
 ```
 
-Commands that only use `logger.*` (display-only, no input) don't need this guard. See `project/create.ts`, `project/link.ts`, and `project/eject.ts` for real examples.
+Commands that only use `logger.*` (display-only, no input) don't need this guard. See `project/create.ts`, `project/scaffold.ts`, `project/link.ts`, and `project/eject.ts` for real examples.
+
+`project/create.ts` and `project/scaffold.ts` share their post-scaffold logic (push entities, deploy site, install skills, print summary) via `project/scaffold-shared.ts` — `create` mints a new app, `scaffold` reuses an existing app id (from `--app-id` or `BASE44_APP_ID`).
 
 ## runTask (Async Operations with Spinners)
 

--- a/packages/cli/src/cli/bootstrap-env.ts
+++ b/packages/cli/src/cli/bootstrap-env.ts
@@ -1,0 +1,6 @@
+import { loadProjectEnvFiles } from "@/core/utils/env.js";
+
+// Must run before any module reads env-derived config at import time — notably
+// the HTTP clients, which capture getBase44ApiUrl() when ky.create() runs at
+// module load. Imported first in cli/index.ts so it initializes ahead of them.
+loadProjectEnvFiles();

--- a/packages/cli/src/cli/commands/project/create.ts
+++ b/packages/cli/src/cli/commands/project/create.ts
@@ -1,27 +1,24 @@
-import { basename, join, resolve } from "node:path";
+import { basename, resolve } from "node:path";
 import type { Option } from "@clack/prompts";
-import { confirm, group, isCancel, select, text } from "@clack/prompts";
+import { group, select, text } from "@clack/prompts";
 import { Argument, type Command } from "commander";
-import { execa } from "execa";
 import kebabCase from "lodash/kebabCase";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";
-import {
-  Base44Command,
-  getDashboardUrl,
-  onPromptCancel,
-  theme,
-} from "@/cli/utils/index.js";
+import { Base44Command, onPromptCancel, theme } from "@/cli/utils/index.js";
 import { InvalidInputError } from "@/core/errors.js";
-import { deploySite, isDirEmpty, pushEntities } from "@/core/index.js";
+import { isDirEmpty } from "@/core/index.js";
 import type { Template } from "@/core/project/index.js";
 import {
   createProjectFiles,
   listTemplates,
-  readProjectConfig,
   setAppConfig,
 } from "@/core/project/index.js";
-
-const DEFAULT_TEMPLATE_ID = "backend-only";
+import {
+  completeProjectSetup,
+  DEFAULT_TEMPLATE_ID,
+  getTemplateById,
+  printProjectSummary,
+} from "./scaffold-shared.js";
 
 interface CreateOptions {
   name?: string;
@@ -29,18 +26,6 @@ interface CreateOptions {
   template?: string;
   deploy?: boolean;
   skills?: boolean;
-}
-
-async function getTemplateById(templateId: string): Promise<Template> {
-  const templates = await listTemplates();
-  const template = templates.find((t) => t.id === templateId);
-  if (!template) {
-    const validIds = templates.map((t) => t.id).join(", ");
-    throw new InvalidInputError(`Template "${templateId}" not found.`, {
-      hints: [{ message: `Use one of: ${validIds}` }],
-    });
-  }
-  return template;
 }
 
 function validateNonInteractiveFlags(command: Command): void {
@@ -55,7 +40,7 @@ function validateNonInteractiveFlags(command: Command): void {
 
 async function createInteractive(
   options: CreateOptions,
-  ctx: Pick<CLIContext, "log" | "runTask">,
+  ctx: CLIContext,
 ): Promise<RunCommandResult> {
   const templates = await listTemplates();
   const templateOptions: Option<Template>[] = templates.map((t) => ({
@@ -116,7 +101,7 @@ async function createInteractive(
 
 async function createNonInteractive(
   options: CreateOptions,
-  ctx: Pick<CLIContext, "log" | "runTask">,
+  ctx: CLIContext,
 ): Promise<RunCommandResult> {
   ctx.log.info(`Creating a new project at ${resolve(options.path!)}`);
 
@@ -155,8 +140,9 @@ async function executeCreate(
     skills?: boolean;
     isInteractive: boolean;
   },
-  { log, runTask }: Pick<CLIContext, "log" | "runTask">,
+  ctx: CLIContext,
 ): Promise<RunCommandResult> {
+  const { log, runTask } = ctx;
   const name = rawName.trim();
   const resolvedPath = resolve(projectPath);
 
@@ -176,124 +162,19 @@ async function executeCreate(
     },
   );
 
-  // Set app config in cache for sync access to getDashboardUrl and getAppClient
   setAppConfig({ id: projectId, projectRoot: resolvedPath });
 
-  const { project, entities } = await readProjectConfig(resolvedPath);
-  let finalAppUrl: string | undefined;
-
-  if (entities.length > 0) {
-    let shouldPushEntities: boolean;
-
-    if (isInteractive) {
-      const result = await confirm({
-        message:
-          "Set up the backend data now? (This pushes the data models used by the template to Base44)",
-      });
-      shouldPushEntities = !isCancel(result) && result;
-    } else {
-      shouldPushEntities = !!deploy;
-    }
-
-    if (shouldPushEntities) {
-      await runTask(
-        `Pushing ${entities.length} data models to Base44...`,
-        async () => {
-          await pushEntities(entities);
-        },
-        {
-          successMessage: theme.colors.base44Orange(
-            "Data models pushed successfully",
-          ),
-          errorMessage: "Failed to push data models",
-        },
-      );
-    }
-  }
-
-  if (project.site) {
-    const { installCommand, buildCommand, outputDirectory } = project.site;
-
-    let shouldDeploy: boolean;
-
-    if (isInteractive) {
-      const result = await confirm({
-        message: "Would you like to deploy the site now? (Hosted on Base44)",
-      });
-      shouldDeploy = !isCancel(result) && result;
-    } else {
-      shouldDeploy = !!deploy;
-    }
-
-    if (shouldDeploy && installCommand && buildCommand && outputDirectory) {
-      const { appUrl } = await runTask(
-        "Installing dependencies...",
-        async (updateMessage) => {
-          await execa({ cwd: resolvedPath, shell: true })`${installCommand}`;
-
-          updateMessage("Building project...");
-          await execa({ cwd: resolvedPath, shell: true })`${buildCommand}`;
-
-          updateMessage("Deploying site...");
-          return await deploySite(join(resolvedPath, outputDirectory));
-        },
-        {
-          successMessage: theme.colors.base44Orange(
-            "Site deployed successfully",
-          ),
-          errorMessage: "Failed to deploy site",
-        },
-      );
-
-      finalAppUrl = appUrl;
-    }
-  }
-
-  // Add AI agent skills (--no-skills flag sets skills to false, otherwise defaults to true)
-  const shouldAddSkills = skills;
-
-  if (shouldAddSkills) {
-    try {
-      await runTask(
-        "Installing AI agent skills...",
-        async () => {
-          await execa("npx", ["-y", "skills", "add", "base44/skills", "-y"], {
-            cwd: resolvedPath,
-            shell: true,
-          });
-        },
-        {
-          successMessage: theme.colors.base44Orange(
-            "AI agent skills added successfully",
-          ),
-          errorMessage:
-            "Failed to add AI agent skills - you can add them later with: npx skills add base44/skills",
-        },
-      );
-    } catch {
-      // Skills installation is non-critical (e.g., user may not have git installed)
-      // The error message is already shown by runTask, so we just continue
-    }
-  }
-
-  log.message(
-    `${theme.styles.header("Project")}: ${theme.colors.base44Orange(name)}`,
+  const summary = await completeProjectSetup(
+    { projectId, name, resolvedPath, deploy, skills, isInteractive },
+    ctx,
   );
-  log.message(
-    `${theme.styles.header("Dashboard")}: ${theme.colors.links(getDashboardUrl(projectId))}`,
-  );
-
-  if (finalAppUrl) {
-    log.message(
-      `${theme.styles.header("Site")}: ${theme.colors.links(finalAppUrl)}`,
-    );
-  }
+  printProjectSummary(summary, log);
 
   return { outroMessage: "Your project is set up and ready to use" };
 }
 
 async function createAction(
-  { log, runTask, isNonInteractive }: CLIContext,
+  ctx: CLIContext,
   name: string | undefined,
   options: CreateOptions,
 ): Promise<RunCommandResult> {
@@ -303,7 +184,7 @@ async function createAction(
 
   const skipPrompts = !!(options.name ?? name) && !!options.path;
 
-  if (!skipPrompts && isNonInteractive) {
+  if (!skipPrompts && ctx.isNonInteractive) {
     throw new InvalidInputError(
       "Project name and --path are required in non-interactive mode",
       {
@@ -315,8 +196,6 @@ async function createAction(
       },
     );
   }
-
-  const ctx = { log, runTask };
 
   if (skipPrompts) {
     return await createNonInteractive(

--- a/packages/cli/src/cli/commands/project/link.ts
+++ b/packages/cli/src/cli/commands/project/link.ts
@@ -138,7 +138,7 @@ async function link(
     );
   }
 
-  const projectRoot = await findProjectRoot();
+  const projectRoot = findProjectRoot();
 
   if (!projectRoot) {
     throw new ConfigNotFoundError(

--- a/packages/cli/src/cli/commands/project/scaffold-shared.ts
+++ b/packages/cli/src/cli/commands/project/scaffold-shared.ts
@@ -1,0 +1,169 @@
+import { join } from "node:path";
+import { confirm, isCancel } from "@clack/prompts";
+import { execa } from "execa";
+import type { CLIContext } from "@/cli/types.js";
+import { getDashboardUrl, theme } from "@/cli/utils/index.js";
+import { InvalidInputError } from "@/core/errors.js";
+import { deploySite, pushEntities } from "@/core/index.js";
+import type { Template } from "@/core/project/index.js";
+import { listTemplates, readProjectConfig } from "@/core/project/index.js";
+
+export const DEFAULT_TEMPLATE_ID = "backend-only";
+
+export async function getTemplateById(templateId: string): Promise<Template> {
+  const templates = await listTemplates();
+  const template = templates.find((t) => t.id === templateId);
+  if (!template) {
+    const validIds = templates.map((t) => t.id).join(", ");
+    throw new InvalidInputError(`Template "${templateId}" not found.`, {
+      hints: [{ message: `Use one of: ${validIds}` }],
+    });
+  }
+  return template;
+}
+
+interface CompleteProjectSetupOptions {
+  projectId: string;
+  name: string;
+  resolvedPath: string;
+  deploy?: boolean;
+  skills?: boolean;
+  isInteractive: boolean;
+}
+
+interface ProjectSetupResult {
+  name: string;
+  dashboardUrl: string;
+  appUrl?: string;
+}
+
+// Requires `setAppConfig()` to have run first so `getAppClient()` /
+// `getDashboardUrl()` resolve.
+export async function completeProjectSetup(
+  {
+    projectId,
+    name,
+    resolvedPath,
+    deploy,
+    skills,
+    isInteractive,
+  }: CompleteProjectSetupOptions,
+  { runTask }: CLIContext,
+): Promise<ProjectSetupResult> {
+  const { project, entities } = await readProjectConfig(resolvedPath);
+  let finalAppUrl: string | undefined;
+
+  if (entities.length > 0) {
+    let shouldPushEntities: boolean;
+
+    if (isInteractive) {
+      const result = await confirm({
+        message:
+          "Set up the backend data now? (This pushes the data models used by the template to Base44)",
+      });
+      shouldPushEntities = !isCancel(result) && result;
+    } else {
+      shouldPushEntities = !!deploy;
+    }
+
+    if (shouldPushEntities) {
+      await runTask(
+        `Pushing ${entities.length} data models to Base44...`,
+        async () => {
+          await pushEntities(entities);
+        },
+        {
+          successMessage: theme.colors.base44Orange(
+            "Data models pushed successfully",
+          ),
+          errorMessage: "Failed to push data models",
+        },
+      );
+    }
+  }
+
+  if (project.site) {
+    const { installCommand, buildCommand, outputDirectory } = project.site;
+
+    let shouldDeploy: boolean;
+
+    if (isInteractive) {
+      const result = await confirm({
+        message: "Would you like to deploy the site now? (Hosted on Base44)",
+      });
+      shouldDeploy = !isCancel(result) && result;
+    } else {
+      shouldDeploy = !!deploy;
+    }
+
+    if (shouldDeploy && installCommand && buildCommand && outputDirectory) {
+      const { appUrl } = await runTask(
+        "Installing dependencies...",
+        async (updateMessage) => {
+          await execa({ cwd: resolvedPath, shell: true })`${installCommand}`;
+
+          updateMessage("Building project...");
+          await execa({ cwd: resolvedPath, shell: true })`${buildCommand}`;
+
+          updateMessage("Deploying site...");
+          return await deploySite(join(resolvedPath, outputDirectory));
+        },
+        {
+          successMessage: theme.colors.base44Orange(
+            "Site deployed successfully",
+          ),
+          errorMessage: "Failed to deploy site",
+        },
+      );
+
+      finalAppUrl = appUrl;
+    }
+  }
+
+  if (skills) {
+    try {
+      await runTask(
+        "Installing AI agent skills...",
+        async () => {
+          await execa("npx", ["-y", "skills", "add", "base44/skills", "-y"], {
+            cwd: resolvedPath,
+            shell: true,
+          });
+        },
+        {
+          successMessage: theme.colors.base44Orange(
+            "AI agent skills added successfully",
+          ),
+          errorMessage:
+            "Failed to add AI agent skills - you can add them later with: npx skills add base44/skills",
+        },
+      );
+    } catch {
+      // Non-critical; runTask already showed the error, so continue.
+    }
+  }
+
+  return {
+    name,
+    dashboardUrl: getDashboardUrl(projectId),
+    appUrl: finalAppUrl,
+  };
+}
+
+export function printProjectSummary(
+  { name, dashboardUrl, appUrl }: ProjectSetupResult,
+  log: CLIContext["log"],
+): void {
+  log.message(
+    `${theme.styles.header("Project")}: ${theme.colors.base44Orange(name)}`,
+  );
+  log.message(
+    `${theme.styles.header("Dashboard")}: ${theme.colors.links(dashboardUrl)}`,
+  );
+
+  if (appUrl) {
+    log.message(
+      `${theme.styles.header("Site")}: ${theme.colors.links(appUrl)}`,
+    );
+  }
+}

--- a/packages/cli/src/cli/commands/project/scaffold.ts
+++ b/packages/cli/src/cli/commands/project/scaffold.ts
@@ -1,0 +1,95 @@
+import { basename, resolve } from "node:path";
+import { Argument, type Command } from "commander";
+import type { CLIContext, RunCommandResult } from "@/cli/types.js";
+import { Base44Command, theme } from "@/cli/utils/index.js";
+import { InvalidInputError } from "@/core/errors.js";
+import { initProjectFiles, setAppConfig } from "@/core/project/index.js";
+import {
+  completeProjectSetup,
+  getTemplateById,
+  printProjectSummary,
+} from "./scaffold-shared.js";
+
+interface ScaffoldOptions {
+  appId?: string;
+  skills?: boolean;
+}
+
+function resolveAppId(options: ScaffoldOptions): string {
+  const appId = options.appId ?? process.env.BASE44_APP_ID;
+  if (!appId) {
+    throw new InvalidInputError(
+      "No app ID found. `base44 scaffold` sets up a local project for an existing Base44 app.",
+      {
+        hints: [{ message: "Pass it explicitly with --app-id <id>" }],
+      },
+    );
+  }
+  return appId;
+}
+
+async function scaffoldAction(
+  ctx: CLIContext,
+  name: string | undefined,
+  options: ScaffoldOptions,
+): Promise<RunCommandResult> {
+  const { log, runTask } = ctx;
+  const appId = resolveAppId(options);
+  const resolvedPath = resolve("./");
+  const projectName = (name ?? basename(resolvedPath)).trim();
+  const template = await getTemplateById("backend-only");
+
+  log.info(`Scaffolding project at ${resolvedPath}`);
+
+  const { projectId } = await runTask(
+    "Setting up your project...",
+    async () => {
+      return await initProjectFiles({
+        name: projectName,
+        path: resolvedPath,
+        template,
+        appId,
+      });
+    },
+    {
+      successMessage: theme.colors.base44Orange("Project created successfully"),
+      errorMessage: "Failed to create project",
+    },
+  );
+
+  setAppConfig({ id: projectId, projectRoot: resolvedPath });
+
+  const summary = await completeProjectSetup(
+    {
+      projectId,
+      name: projectName,
+      resolvedPath,
+      deploy: false,
+      skills: options.skills,
+      isInteractive: false,
+    },
+    ctx,
+  );
+  printProjectSummary(summary, log);
+
+  return { outroMessage: "Your project is set up and ready to use" };
+}
+
+export function getScaffoldCommand(): Command {
+  return new Base44Command("scaffold", {
+    requireAppConfig: false,
+    fullBanner: true,
+  })
+    .description("Scaffold a local project for an existing Base44 app")
+    .addArgument(new Argument("name", "Project name").argOptional())
+    .option("--app-id <id>", "Existing Base44 app ID")
+    .option("--no-skills", "Skip AI agent skills installation")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ base44 scaffold --app-id app_123         Scaffolds the current dir for the given app
+  $ base44 scaffold my-app --app-id app_123  Scaffolds the current dir, named "my-app"`,
+    )
+    .action(scaffoldAction);
+}

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -1,3 +1,5 @@
+// Must stay first — see bootstrap-env.js.
+import "@/cli/bootstrap-env.js";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { ClackLogger, SimpleLogger } from "@base44-cli/logger";

--- a/packages/cli/src/cli/program.ts
+++ b/packages/cli/src/cli/program.ts
@@ -12,6 +12,7 @@ import { getCreateCommand } from "@/cli/commands/project/create.js";
 import { getDeployCommand } from "@/cli/commands/project/deploy.js";
 import { getLinkCommand } from "@/cli/commands/project/link.js";
 import { getLogsCommand } from "@/cli/commands/project/logs.js";
+import { getScaffoldCommand } from "@/cli/commands/project/scaffold.js";
 import { getSecretsCommand } from "@/cli/commands/secrets/index.js";
 import { getSiteCommand } from "@/cli/commands/site/index.js";
 import { getTypesCommand } from "@/cli/commands/types/index.js";
@@ -50,6 +51,7 @@ export function createProgram(context: CLIContext): Command {
 
   // Register project commands
   program.addCommand(getCreateCommand());
+  program.addCommand(getScaffoldCommand());
   program.addCommand(getDashboardCommand());
   program.addCommand(getDeployCommand());
   program.addCommand(getLinkCommand());

--- a/packages/cli/src/cli/utils/command/middleware.ts
+++ b/packages/cli/src/cli/utils/command/middleware.ts
@@ -1,6 +1,6 @@
 import { login } from "@/cli/commands/auth/login-flow.js";
 import type { CLIContext } from "@/cli/types.js";
-import { isLoggedIn, readAuth } from "@/core/auth/index.js";
+import { isLoggedIn, readAuth, seedAuthFromEnv } from "@/core/auth/index.js";
 import { initAppConfig } from "@/core/project/index.js";
 
 /**
@@ -8,6 +8,10 @@ import { initAppConfig } from "@/core/project/index.js";
  * Sets user context on the error reporter after successful auth.
  */
 export async function ensureAuth(ctx: CLIContext): Promise<void> {
+  // Seed auth.json from env-supplied credentials (CI, agents, provisioning
+  // tools) before the login check, so env tokens satisfy auth without a login.
+  await seedAuthFromEnv();
+
   const loggedIn = await isLoggedIn();
 
   if (!loggedIn) {

--- a/packages/cli/src/core/auth/config.ts
+++ b/packages/cli/src/core/auth/config.ts
@@ -1,3 +1,4 @@
+import jwt, { type JwtPayload } from "jsonwebtoken";
 import { renewAccessToken } from "@/core/auth/api.js";
 import type { AuthData } from "@/core/auth/schema.js";
 import { AuthDataSchema } from "@/core/auth/schema.js";
@@ -10,6 +11,33 @@ const TOKEN_REFRESH_BUFFER_MS = 60 * 1000;
 
 // Lock to prevent concurrent token refreshes
 let refreshPromise: Promise<string | null> | null = null;
+
+export async function seedAuthFromEnv(): Promise<void> {
+  const accessToken = process.env.BASE44_ACCESS_TOKEN;
+  if (!accessToken) {
+    return;
+  }
+
+  const refreshToken = process.env.BASE44_REFRESH_TOKEN;
+  // Decode without verifying the signature — the server still validates it.
+  const claims = jwt.decode(accessToken);
+  const payload: JwtPayload | null =
+    claims !== null && typeof claims === "object" ? claims : null;
+  const sub = typeof payload?.sub === "string" ? payload.sub : undefined;
+  const exp = typeof payload?.exp === "number" ? payload.exp : undefined;
+
+  if (!refreshToken || !sub || !exp) {
+    return;
+  }
+
+  await writeAuth({
+    accessToken,
+    refreshToken,
+    expiresAt: exp * 1000, // exp is in seconds; expiresAt is milliseconds.
+    email: sub,
+    name: sub, // No name claim; use the identity.
+  });
+}
 
 /**
  * Reads and validates the stored authentication data.

--- a/packages/cli/src/core/project/app-config.ts
+++ b/packages/cli/src/core/project/app-config.ts
@@ -43,7 +43,7 @@ export async function initAppConfig(): Promise<CachedAppConfig> {
     return cache;
   }
 
-  const projectRoot = await findProjectRoot();
+  const projectRoot = findProjectRoot();
   if (!projectRoot) {
     throw new ConfigNotFoundError(
       "No Base44 project found. Run this command from a project directory with a config.jsonc file.",

--- a/packages/cli/src/core/project/app-config.ts
+++ b/packages/cli/src/core/project/app-config.ts
@@ -6,7 +6,7 @@ import {
   ConfigNotFoundError,
   SchemaValidationError,
 } from "@/core/errors.js";
-import { findProjectRoot } from "@/core/project/config.js";
+import { findProjectRoot } from "@/core/project/find-root.js";
 import type { AppConfig } from "@/core/project/schema.js";
 import { AppConfigSchema } from "@/core/project/schema.js";
 import { readJsonFile, writeFile } from "@/core/utils/fs.js";

--- a/packages/cli/src/core/project/config.ts
+++ b/packages/cli/src/core/project/config.ts
@@ -32,10 +32,6 @@ import { readJsonFile } from "@/core/utils/fs.js";
 
 type ProjectResources = Omit<ProjectData, "project">;
 
-// findProjectRoot / findConfigInDir live in ./find-root.js so bootstrap (env
-// loading) can reuse them without importing this module's HTTP-client deps.
-export { findProjectRoot };
-
 class ProjectConfigReader {
   private readonly pluginSourceByNamespace = new Map<string, string>();
 

--- a/packages/cli/src/core/project/config.ts
+++ b/packages/cli/src/core/project/config.ts
@@ -1,11 +1,11 @@
 import { dirname, join } from "node:path";
-import { globby } from "globby";
-import { PROJECT_CONFIG_PATTERNS, PROJECT_SUBDIR } from "@/core/consts.js";
+import { PROJECT_SUBDIR } from "@/core/consts.js";
 import {
   ConfigInvalidError,
   ConfigNotFoundError,
   SchemaValidationError,
 } from "@/core/errors.js";
+import { findConfigInDir, findProjectRoot } from "@/core/project/find-root.js";
 import {
   markPluginEntities,
   namespacePluginFunctions,
@@ -32,42 +32,9 @@ import { readJsonFile } from "@/core/utils/fs.js";
 
 type ProjectResources = Omit<ProjectData, "project">;
 
-async function findConfigInDir(dir: string): Promise<string | null> {
-  const files = await globby(PROJECT_CONFIG_PATTERNS, {
-    cwd: dir,
-    absolute: true,
-  });
-  return files[0] ?? null;
-}
-
-/**
- * Searches for a Base44 project root by looking for config files.
- * Walks up the directory tree from the starting path until it finds a config file.
- *
- * @param startPath - Directory to start searching from. Defaults to cwd.
- * @returns Project root info if found, null otherwise.
- *
- * @example
- * const found = await findProjectRoot();
- * if (found) {
- *   console.log(`Project found at: ${found.root}`);
- * }
- */
-export async function findProjectRoot(
-  startPath?: string,
-): Promise<ProjectRoot | null> {
-  let current = startPath || process.cwd();
-
-  while (current !== dirname(current)) {
-    const configPath = await findConfigInDir(current);
-    if (configPath) {
-      return { root: current, configPath };
-    }
-    current = dirname(current);
-  }
-
-  return null;
-}
+// findProjectRoot / findConfigInDir live in ./find-root.js so bootstrap (env
+// loading) can reuse them without importing this module's HTTP-client deps.
+export { findProjectRoot };
 
 class ProjectConfigReader {
   private readonly pluginSourceByNamespace = new Map<string, string>();
@@ -107,10 +74,10 @@ class ProjectConfigReader {
     let found: ProjectRoot | null;
 
     if (projectRoot) {
-      const configPath = await findConfigInDir(projectRoot);
+      const configPath = findConfigInDir(projectRoot);
       found = configPath ? { root: projectRoot, configPath } : null;
     } else {
-      found = await findProjectRoot();
+      found = findProjectRoot();
     }
 
     if (!found) {

--- a/packages/cli/src/core/project/create.ts
+++ b/packages/cli/src/core/project/create.ts
@@ -53,6 +53,41 @@ export async function createProjectFiles(
   };
 }
 
+/**
+ * Like {@link createProjectFiles} but skips the `createProject()` API call — the
+ * app already exists, so the caller supplies its `appId`.
+ */
+export async function initProjectFiles(options: {
+  name: string;
+  description?: string;
+  path: string;
+  template: Template;
+  appId: string;
+}): Promise<CreateProjectResult & { skippedFiles: string[] }> {
+  const { name, description, path: basePath, template, appId } = options;
+
+  await assertProjectNotExists(basePath);
+
+  // Skip files that already exist so scaffolding into a non-empty directory
+  // never clobbers existing files like .gitignore.
+  const skippedFiles = await renderTemplate(
+    template,
+    basePath,
+    {
+      name,
+      description,
+      projectId: appId,
+    },
+    { skipExisting: true },
+  );
+
+  return {
+    projectId: appId,
+    projectDir: basePath,
+    skippedFiles,
+  };
+}
+
 export async function createProjectFilesForExistingProject(options: {
   projectId: string;
   projectPath: string;

--- a/packages/cli/src/core/project/find-root.ts
+++ b/packages/cli/src/core/project/find-root.ts
@@ -1,0 +1,29 @@
+import { dirname } from "node:path";
+import { globbySync } from "globby";
+import { PROJECT_CONFIG_PATTERNS } from "@/core/consts.js";
+import type { ProjectRoot } from "@/core/project/types.js";
+
+export function findConfigInDir(dir: string): string | null {
+  const files = globbySync(PROJECT_CONFIG_PATTERNS, {
+    cwd: dir,
+    absolute: true,
+  });
+  return files[0] ?? null;
+}
+
+// Synchronous and dependency-light (no resource/client imports) so it can run at
+// bootstrap before the HTTP clients capture the API URL. Walks up from
+// `startPath` to the nearest directory holding a project config file.
+export function findProjectRoot(
+  startPath: string = process.cwd(),
+): ProjectRoot | null {
+  let current = startPath;
+  while (current !== dirname(current)) {
+    const configPath = findConfigInDir(current);
+    if (configPath) {
+      return { root: current, configPath };
+    }
+    current = dirname(current);
+  }
+  return null;
+}

--- a/packages/cli/src/core/project/index.ts
+++ b/packages/cli/src/core/project/index.ts
@@ -3,5 +3,6 @@ export * from "./app-config.js";
 export * from "./config.js";
 export * from "./create.js";
 export * from "./deploy.js";
+export * from "./find-root.js";
 export * from "./schema.js";
 export * from "./template.js";

--- a/packages/cli/src/core/project/template.ts
+++ b/packages/cli/src/core/project/template.ts
@@ -6,7 +6,12 @@ import { getTemplatesDir, getTemplatesIndexPath } from "@/core/assets.js";
 import { SchemaValidationError } from "@/core/errors.js";
 import type { Template } from "@/core/project/schema.js";
 import { TemplatesConfigSchema } from "@/core/project/schema.js";
-import { copyFile, readJsonFile, writeFile } from "@/core/utils/fs.js";
+import {
+  copyFile,
+  pathExists,
+  readJsonFile,
+  writeFile,
+} from "@/core/utils/fs.js";
 
 interface TemplateData {
   name: string;
@@ -34,6 +39,14 @@ export async function listTemplates(): Promise<Template[]> {
   return result.data.templates;
 }
 
+interface RenderTemplateOptions {
+  /**
+   * Leave existing destination files untouched instead of overwriting — used
+   * when scaffolding into a non-empty dir (must not clobber `.gitignore`).
+   */
+  skipExisting?: boolean;
+}
+
 /**
  * Render a template directory to a destination path.
  * - Files ending in .ejs are rendered with EJS and written without the .ejs extension
@@ -44,7 +57,9 @@ export async function renderTemplate(
   template: Template,
   destPath: string,
   data: TemplateData,
-): Promise<void> {
+  options: RenderTemplateOptions = {},
+): Promise<string[]> {
+  const { skipExisting = false } = options;
   const templateDir = join(getTemplatesDir(), template.path);
 
   // Get all files in the template directory
@@ -53,6 +68,8 @@ export async function renderTemplate(
     dot: true,
     onlyFiles: true,
   });
+
+  const skipped: string[] = [];
 
   for (const file of files) {
     const srcPath = join(templateDir, file);
@@ -67,10 +84,19 @@ export async function renderTemplate(
           : file.replace(/\.ejs$/, "");
         const destFilePath = join(destPath, destFile);
 
+        if (skipExisting && (await pathExists(destFilePath))) {
+          skipped.push(destFile);
+          continue;
+        }
         await writeFile(destFilePath, body);
       } else {
         // Copy file directly
         const destFilePath = join(destPath, file);
+
+        if (skipExisting && (await pathExists(destFilePath))) {
+          skipped.push(file);
+          continue;
+        }
         await copyFile(srcPath, destFilePath);
       }
     } catch (error) {
@@ -78,4 +104,6 @@ export async function renderTemplate(
       throw new Error(`Failed to process template file "${file}": ${message}`);
     }
   }
+
+  return skipped;
 }

--- a/packages/cli/src/core/utils/env.ts
+++ b/packages/cli/src/core/utils/env.ts
@@ -1,12 +1,69 @@
-import { parse } from "dotenv";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { config, parse } from "dotenv";
+import { PROJECT_SUBDIR } from "@/core/consts.js";
 import { readTextFile } from "./fs.js";
 
-/**
- * Parse a .env file into a Record of key-value pairs.
- */
 export async function parseEnvFile(
   filePath: string,
 ): Promise<Record<string, string>> {
   const content = await readTextFile(filePath);
   return parse(content);
+}
+
+// The Stripe Projects CLI namespaces Base44 credentials under this prefix (e.g.
+// `BASE44_PROJECTS_BASE44_APP_ID`); the normalizer copies them to the bare name.
+const STRIPE_ENV_PREFIX = "BASE44_PROJECTS_";
+
+const BASE44_ENV_KEYS = [
+  "BASE44_APP_ID",
+  "BASE44_ACCESS_TOKEN",
+  "BASE44_REFRESH_TOKEN",
+  "BASE44_API_URL",
+];
+
+// Project-root markers (mirror PROJECT_CONFIG_PATTERNS). The `.env` lives at the
+// root, so we anchor on these to allow running from any subdirectory.
+const PROJECT_CONFIG_FILES = ["jsonc", "json"].map((ext) =>
+  join(PROJECT_SUBDIR, `config.${ext}`),
+);
+
+function findProjectRootSync(startDir: string): string | null {
+  let current = startDir;
+  while (current !== dirname(current)) {
+    if (PROJECT_CONFIG_FILES.some((rel) => existsSync(join(current, rel)))) {
+      return current;
+    }
+    current = dirname(current);
+  }
+  return null;
+}
+
+/**
+ * Synchronous so bootstrap can run it before the HTTP clients capture
+ * `getBase44ApiUrl()` at module load.
+ */
+export function loadProjectEnvFiles(cwd: string = process.cwd()): void {
+  const root = findProjectRootSync(cwd) ?? cwd;
+  // `.env.local` first so it wins (dotenv keeps the first value set per key);
+  // ambient `process.env` is never overridden (override defaults to false).
+  config({
+    path: [join(root, ".env.local"), join(root, ".env")],
+    quiet: true,
+  });
+
+  normalizeBase44Env();
+}
+
+function normalizeBase44Env(): void {
+  for (const bareKey of BASE44_ENV_KEYS) {
+    if (process.env[bareKey] !== undefined) {
+      continue;
+    }
+
+    const prefixed = process.env[`${STRIPE_ENV_PREFIX}${bareKey}`];
+    if (prefixed !== undefined) {
+      process.env[bareKey] = prefixed;
+    }
+  }
 }

--- a/packages/cli/src/core/utils/env.ts
+++ b/packages/cli/src/core/utils/env.ts
@@ -1,7 +1,7 @@
-import { existsSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { config, parse } from "dotenv";
 import { PROJECT_SUBDIR } from "@/core/consts.js";
+import { findProjectRoot } from "@/core/project/find-root.js";
 import { readTextFile } from "./fs.js";
 
 export async function parseEnvFile(
@@ -22,29 +22,23 @@ const BASE44_ENV_KEYS = [
   "BASE44_API_URL",
 ];
 
-// Project-root markers (mirror PROJECT_CONFIG_PATTERNS). The `.env` lives at the
-// root, so we anchor on these to allow running from any subdirectory.
-const PROJECT_CONFIG_FILES = ["jsonc", "json"].map((ext) =>
-  join(PROJECT_SUBDIR, `config.${ext}`),
-);
-
-function findProjectRootSync(startDir: string): string | null {
-  let current = startDir;
-  while (current !== dirname(current)) {
-    if (PROJECT_CONFIG_FILES.some((rel) => existsSync(join(current, rel)))) {
-      return current;
-    }
-    current = dirname(current);
+// The project root is where `.env` and the `base44/` config dir live; derive it
+// from the located config (its parent, or one level up when it sits in base44/)
+// so commands work from the root or any subdirectory. findProjectRoot is
+// sync/light, so this is safe to call at bootstrap.
+function findEnvDir(cwd: string): string {
+  const found = findProjectRoot(cwd);
+  if (!found) {
+    return cwd;
   }
-  return null;
+  const configDir = dirname(found.configPath);
+  return basename(configDir) === PROJECT_SUBDIR
+    ? dirname(configDir)
+    : configDir;
 }
 
-/**
- * Synchronous so bootstrap can run it before the HTTP clients capture
- * `getBase44ApiUrl()` at module load.
- */
 export function loadProjectEnvFiles(cwd: string = process.cwd()): void {
-  const root = findProjectRootSync(cwd) ?? cwd;
+  const root = findEnvDir(cwd);
   // `.env.local` first so it wins (dotenv keeps the first value set per key);
   // ambient `process.env` is never overridden (override defaults to false).
   config({

--- a/packages/cli/tests/cli/env-token-auth.spec.ts
+++ b/packages/cli/tests/cli/env-token-auth.spec.ts
@@ -1,0 +1,94 @@
+import { sign } from "jsonwebtoken";
+import { describe, expect, it } from "vitest";
+import { fixture, setupCLITests } from "./testkit/index.js";
+
+const APP_ID = "test-app-id";
+
+/** Build a signed JWT with the given claims (seeding decodes, never verifies). */
+function makeJwt(claims: Record<string, unknown>): string {
+  return sign(claims, "test-secret");
+}
+
+describe("env credential seeding", () => {
+  const t = setupCLITests();
+
+  const futureExp = () => Math.floor(Date.now() / 1000) + 3600;
+
+  it("seeds a standard auth.json from env credentials", async () => {
+    // No givenLoggedIn(): the only credentials are env vars. The ensureAuth
+    // middleware should decode them and write a standard auth file.
+    const exp = futureExp();
+    const jwt = makeJwt({ sub: "alice@example.com", exp });
+    t.givenEnv({
+      BASE44_ACCESS_TOKEN: jwt,
+      BASE44_REFRESH_TOKEN: "refresh-xyz",
+    });
+
+    const result = await t.run("whoami");
+
+    t.expectResult(result).toSucceed();
+
+    const auth = await t.readAuthFile();
+    expect(auth).toMatchObject({
+      accessToken: jwt,
+      refreshToken: "refresh-xyz",
+      email: "alice@example.com",
+      name: "alice@example.com",
+      expiresAt: exp * 1000,
+    });
+  });
+
+  it("shows the seeded identity in whoami", async () => {
+    t.givenEnv({
+      BASE44_ACCESS_TOKEN: makeJwt({
+        sub: "alice@example.com",
+        exp: futureExp(),
+      }),
+      BASE44_REFRESH_TOKEN: "refresh-xyz",
+    });
+
+    const result = await t.run("whoami");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("alice@example.com");
+  });
+
+  it("uses the seeded token as the bearer for API calls", async () => {
+    await t.givenProject(fixture("with-entities"));
+    const jwt = makeJwt({ sub: "alice@example.com", exp: futureExp() });
+    t.givenEnv({
+      BASE44_ACCESS_TOKEN: jwt,
+      BASE44_REFRESH_TOKEN: "refresh-xyz",
+    });
+
+    let authHeader: string | undefined;
+    t.api.mockRoute("PUT", `/api/apps/${APP_ID}/entity-schemas`, (req, res) => {
+      authHeader = req.headers.authorization;
+      res.status(200).json({ created: ["customer"], updated: [], deleted: [] });
+    });
+
+    const result = await t.run("entities", "push");
+
+    t.expectResult(result).toSucceed();
+    expect(authHeader).toBe(`Bearer ${jwt}`);
+  });
+
+  it("does not overwrite a stored login when env credentials are incomplete", async () => {
+    await t.givenLoggedIn({ email: "real@example.com", name: "Real User" });
+    // Access token present but no refresh token → can't form a standard record,
+    // so seeding is skipped and the existing login is left untouched.
+    t.givenEnv({
+      BASE44_ACCESS_TOKEN: makeJwt({
+        sub: "alice@example.com",
+        exp: futureExp(),
+      }),
+    });
+
+    const result = await t.run("whoami");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("real@example.com");
+    const auth = await t.readAuthFile();
+    expect(auth?.email).toBe("real@example.com");
+  });
+});

--- a/packages/cli/tests/cli/scaffold.spec.ts
+++ b/packages/cli/tests/cli/scaffold.spec.ts
@@ -1,0 +1,102 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { setupCLITests } from "./testkit/index.js";
+
+const USER = { email: "test@example.com", name: "Test User" };
+
+async function readTempFile(
+  dir: string,
+  relativePath: string,
+): Promise<string | null> {
+  try {
+    return await readFile(join(dir, relativePath), "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+describe("scaffold command", () => {
+  const t = setupCLITests();
+
+  it("scaffolds for an existing app id without creating a new app", async () => {
+    await t.givenLoggedIn(USER);
+    // Note: mockCreateApp is intentionally NOT registered. If scaffold tried
+    // to create an app, the unmocked POST /api/apps would 404 and fail the run.
+
+    const result = await t.run(
+      "scaffold",
+      "--app-id",
+      "app-existing-123",
+      "--no-skills",
+    );
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("Project created successfully");
+    t.expectResult(result).toContain("app-existing-123");
+
+    const appConfig = await readTempFile(t.getTempDir(), "base44/.app.jsonc");
+    expect(appConfig).toContain("app-existing-123");
+  });
+
+  it("reads the app id from BASE44_APP_ID when --app-id is omitted", async () => {
+    await t.givenLoggedIn(USER);
+    t.givenEnv({ BASE44_APP_ID: "app-from-env" });
+
+    const result = await t.run("scaffold", "--no-skills");
+
+    t.expectResult(result).toSucceed();
+    const appConfig = await readTempFile(t.getTempDir(), "base44/.app.jsonc");
+    expect(appConfig).toContain("app-from-env");
+  });
+
+  it("prefers --app-id over the BASE44_APP_ID env var", async () => {
+    await t.givenLoggedIn(USER);
+    t.givenEnv({ BASE44_APP_ID: "app-from-env" });
+
+    const result = await t.run(
+      "scaffold",
+      "--app-id",
+      "app-from-flag",
+      "--no-skills",
+    );
+
+    t.expectResult(result).toSucceed();
+    const appConfig = await readTempFile(t.getTempDir(), "base44/.app.jsonc");
+    expect(appConfig).toContain("app-from-flag");
+    expect(appConfig).not.toContain("app-from-env");
+  });
+
+  it("fails with a helpful message when no app id is available", async () => {
+    await t.givenLoggedIn(USER);
+
+    const result = await t.run("scaffold", "--no-skills");
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("No app ID found");
+    t.expectResult(result).toContain("--app-id");
+  });
+
+  it("does not overwrite existing files when scaffolding", async () => {
+    await t.givenLoggedIn(USER);
+
+    // Pre-create base44/.gitignore (which the template would otherwise write).
+    // This does not match the project-config pattern (base44/config.*), so
+    // scaffold still proceeds, but the existing file must be preserved.
+    const base44Dir = join(t.getTempDir(), "base44");
+    await mkdir(base44Dir, { recursive: true });
+    await writeFile(join(base44Dir, ".gitignore"), "# pre-existing\nkeep-me\n");
+
+    const result = await t.run(
+      "scaffold",
+      "--app-id",
+      "app-skip-existing",
+      "--no-skills",
+    );
+
+    t.expectResult(result).toSucceed();
+
+    const gitignore = await readTempFile(t.getTempDir(), "base44/.gitignore");
+    expect(gitignore).toContain("keep-me");
+  });
+});

--- a/packages/cli/tests/cli/testkit/CLITestkit.ts
+++ b/packages/cli/tests/cli/testkit/CLITestkit.ts
@@ -136,6 +136,11 @@ export class CLITestkit {
     this.stdinContent = content;
   }
 
+  /** Set additional environment variables for subsequent run()/runLive() calls */
+  givenEnv(vars: Record<string, string>): void {
+    this.env = { ...this.env, ...vars };
+  }
+
   // ─── WHEN METHODS ─────────────────────────────────────────────
 
   /** Spawn the CLI as a child process and execute the command */

--- a/packages/cli/tests/cli/testkit/index.ts
+++ b/packages/cli/tests/cli/testkit/index.ts
@@ -38,6 +38,9 @@ export interface TestContext {
   /** Simulate piped stdin for the next run() call */
   givenStdin: (content: string) => void;
 
+  /** Set additional environment variables for subsequent run() calls */
+  givenEnv: (vars: Record<string, string>) => void;
+
   // ─── WHEN METHODS ──────────────────────────────────────────
 
   /** Execute CLI command */
@@ -124,6 +127,7 @@ export function setupCLITests(): TestContext {
     },
     givenLatestVersion: (version) => getKit().givenLatestVersion(version),
     givenStdin: (content) => getKit().givenStdin(content),
+    givenEnv: (vars) => getKit().givenEnv(vars),
 
     // When methods
     run: (...args) => getKit().run(...args),

--- a/packages/cli/tests/core/env.spec.ts
+++ b/packages/cli/tests/core/env.spec.ts
@@ -1,0 +1,116 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadProjectEnvFiles } from "@/core/utils/env.js";
+
+// Keys this suite manipulates; saved and restored around each test so we never
+// leak into the real process environment.
+const KEYS = [
+  "LPE_FOO",
+  "LPE_BAR",
+  "LPE_PRESET",
+  "BASE44_APP_ID",
+  "BASE44_PROJECTS_BASE44_APP_ID",
+  "ACME_BASE44_APP_ID",
+];
+
+describe("loadProjectEnvFiles", () => {
+  let dir: string;
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "b44-env-"));
+    saved = {};
+    for (const key of KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(async () => {
+    for (const key of KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("loads values from .env", async () => {
+    await writeFile(join(dir, ".env"), "LPE_FOO=from_env\n");
+
+    loadProjectEnvFiles(dir);
+
+    expect(process.env.LPE_FOO).toBe("from_env");
+  });
+
+  it("loads .env from the project root when run in a subdirectory", async () => {
+    await writeFile(join(dir, ".env"), "LPE_FOO=from_root\n");
+    const base44Dir = join(dir, "base44");
+    await mkdir(base44Dir, { recursive: true });
+    await writeFile(join(base44Dir, "config.jsonc"), "{}\n");
+    const sub = join(base44Dir, "functions");
+    await mkdir(sub, { recursive: true });
+
+    loadProjectEnvFiles(sub);
+
+    expect(process.env.LPE_FOO).toBe("from_root");
+  });
+
+  it("lets .env.local override .env", async () => {
+    await writeFile(join(dir, ".env"), "LPE_BAR=from_env\n");
+    await writeFile(join(dir, ".env.local"), "LPE_BAR=from_local\n");
+
+    loadProjectEnvFiles(dir);
+
+    expect(process.env.LPE_BAR).toBe("from_local");
+  });
+
+  it("never overrides a value already present in process.env", async () => {
+    process.env.LPE_PRESET = "ambient";
+    await writeFile(join(dir, ".env"), "LPE_PRESET=from_env\n");
+
+    loadProjectEnvFiles(dir);
+
+    expect(process.env.LPE_PRESET).toBe("ambient");
+  });
+
+  it("ignores missing files", () => {
+    expect(() => loadProjectEnvFiles(dir)).not.toThrow();
+  });
+
+  it("normalizes the Stripe-prefixed BASE44_APP_ID to the bare name", async () => {
+    // The Stripe Projects CLI writes BASE44_PROJECTS_BASE44_APP_ID.
+    await writeFile(
+      join(dir, ".env"),
+      "BASE44_PROJECTS_BASE44_APP_ID=app_prefixed\n",
+    );
+
+    loadProjectEnvFiles(dir);
+
+    expect(process.env.BASE44_APP_ID).toBe("app_prefixed");
+  });
+
+  it("does not override a bare BASE44_APP_ID with the Stripe-prefixed one", async () => {
+    process.env.BASE44_APP_ID = "app_bare";
+    await writeFile(
+      join(dir, ".env"),
+      "BASE44_PROJECTS_BASE44_APP_ID=app_prefixed\n",
+    );
+
+    loadProjectEnvFiles(dir);
+
+    expect(process.env.BASE44_APP_ID).toBe("app_bare");
+  });
+
+  it("ignores prefixes other than the Stripe one", async () => {
+    await writeFile(join(dir, ".env"), "ACME_BASE44_APP_ID=app_other\n");
+
+    loadProjectEnvFiles(dir);
+
+    expect(process.env.BASE44_APP_ID).toBeUndefined();
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Adds support for environment-supplied Base44 credentials so non-interactive flows (CI, agents, provisioning tools like the Stripe Projects CLI) can authenticate without an interactive login. At startup the CLI now loads `.env`/`.env.local`, normalizes Stripe-namespaced vars, and seeds `auth.json` from `BASE44_ACCESS_TOKEN`/`BASE44_REFRESH_TOKEN`. It also wires up the new `base44 scaffold` command for setting up a local project against an existing app, and refactors `findProjectRoot` into a synchronous, dependency-light helper that can run safely at bootstrap.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [x] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - **Env-supplied credentials**: `loadProjectEnvFiles()` (`core/utils/env.ts`) loads `.env.local` then `.env` at startup with precedence `process.env` > `.env.local` > `.env`, and copies Stripe-namespaced `BASE44_PROJECTS_BASE44_*` vars to the bare `BASE44_*` names.
> - **`seedAuthFromEnv()`** (`core/auth/config.ts`): decodes the `BASE44_ACCESS_TOKEN` JWT (`sub` to email, `exp` to `expiresAt`, no signature check — the server validates), pairs it with `BASE44_REFRESH_TOKEN`, and writes a standard `auth.json`. Called from the `ensureAuth` middleware before the login check.
> - **`cli/bootstrap-env.ts`**: new first import in `cli/index.ts` so env loads before the HTTP clients capture the API URL at module load.
> - **`base44 scaffold` command** (`cli/commands/project/scaffold.ts`): scaffolds a local project for an existing app, resolving the app id from `--app-id` or `BASE44_APP_ID`, reusing the shared post-scaffold logic via `scaffold-shared.ts`.
> - **`initProjectFiles()`** (`core/project/create.ts`): like `createProjectFiles` but skips the `createProject()` API call and renders the template with `skipExisting` so scaffolding into a non-empty dir never clobbers existing files (e.g. `.gitignore`).
> - **`renderTemplate()`** now accepts `{ skipExisting }` and returns the list of skipped files.
> - **Refactor**: extracted `findProjectRoot`/`findConfigInDir` into `core/project/find-root.ts`, made them synchronous (`globbySync`) and dependency-light, exported from the project index; updated callers (`config.ts`, `app-config.ts`, `link.ts`).
> - **Docs**: added an "Environment-Supplied Credentials" section to `api-patterns.md` and documented `scaffold` in `commands.md`.
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [x] I have commented my code, particularly in hard-to-understand areas
> - [x] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [x] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> Adds `givenEnv()` to the CLI testkit for setting env vars per run. New tests: `tests/cli/env-token-auth.spec.ts`, `tests/cli/scaffold.spec.ts`, and `tests/core/env.spec.ts`. A seeded auth file behaves like a normal login — a failed 401 refresh deletes it and it self-heals on the next command from the still-present env vars.
>
> ---
> <sub>🤖 Generated by Claude | 2026-06-10 14:40 UTC | 1c9b1e2</sub>