### PR TITLE
feat(cli): add `scaffold` command to set up an existing app (3/3)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -143,7 +143,9 @@ export function getMyCommand(): Command {
 }
 ```
 
-Commands that only use `logger.*` (display-only, no input) don't need this guard. See `project/create.ts`, `project/link.ts`, and `project/eject.ts` for real examples.
+Commands that only use `logger.*` (display-only, no input) don't need this guard. See `project/create.ts`, `project/scaffold.ts`, `project/link.ts`, and `project/eject.ts` for real examples.
+
+`project/create.ts` and `project/scaffold.ts` share their post-scaffold logic (push entities, deploy site, install skills, print summary) via `project/scaffold-shared.ts` — `create` mints a new app, `scaffold` reuses an existing app id (from `--app-id` or `BASE44_APP_ID`).
 
 ## runTask (Async Operations with Spinners)
 

--- a/packages/cli/src/cli/commands/project/scaffold.ts
+++ b/packages/cli/src/cli/commands/project/scaffold.ts
@@ -1,0 +1,95 @@
+import { basename, resolve } from "node:path";
+import { Argument, type Command } from "commander";
+import type { CLIContext, RunCommandResult } from "@/cli/types.js";
+import { Base44Command, theme } from "@/cli/utils/index.js";
+import { InvalidInputError } from "@/core/errors.js";
+import { initProjectFiles, setAppConfig } from "@/core/project/index.js";
+import {
+  completeProjectSetup,
+  getTemplateById,
+  printProjectSummary,
+} from "./scaffold-shared.js";
+
+interface ScaffoldOptions {
+  appId?: string;
+  skills?: boolean;
+}
+
+function resolveAppId(options: ScaffoldOptions): string {
+  const appId = options.appId ?? process.env.BASE44_APP_ID;
+  if (!appId) {
+    throw new InvalidInputError(
+      "No app ID found. `base44 scaffold` sets up a local project for an existing Base44 app.",
+      {
+        hints: [{ message: "Pass it explicitly with --app-id <id>" }],
+      },
+    );
+  }
+  return appId;
+}
+
+async function scaffoldAction(
+  ctx: CLIContext,
+  name: string | undefined,
+  options: ScaffoldOptions,
+): Promise<RunCommandResult> {
+  const { log, runTask } = ctx;
+  const appId = resolveAppId(options);
+  const resolvedPath = resolve("./");
+  const projectName = (name ?? basename(resolvedPath)).trim();
+  const template = await getTemplateById("backend-only");
+
+  log.info(`Scaffolding project at ${resolvedPath}`);
+
+  const { projectId } = await runTask(
+    "Setting up your project...",
+    async () => {
+      return await initProjectFiles({
+        name: projectName,
+        path: resolvedPath,
+        template,
+        appId,
+      });
+    },
+    {
+      successMessage: theme.colors.base44Orange("Project created successfully"),
+      errorMessage: "Failed to create project",
+    },
+  );
+
+  setAppConfig({ id: projectId, projectRoot: resolvedPath });
+
+  const summary = await completeProjectSetup(
+    {
+      projectId,
+      name: projectName,
+      resolvedPath,
+      deploy: false,
+      skills: options.skills,
+      isInteractive: false,
+    },
+    ctx,
+  );
+  printProjectSummary(summary, log);
+
+  return { outroMessage: "Your project is set up and ready to use" };
+}
+
+export function getScaffoldCommand(): Command {
+  return new Base44Command("scaffold", {
+    requireAppConfig: false,
+    fullBanner: true,
+  })
+    .description("Scaffold a local project for an existing Base44 app")
+    .addArgument(new Argument("name", "Project name").argOptional())
+    .option("--app-id <id>", "Existing Base44 app ID")
+    .option("--no-skills", "Skip AI agent skills installation")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  $ base44 scaffold --app-id app_123         Scaffolds the current dir for the given app
+  $ base44 scaffold my-app --app-id app_123  Scaffolds the current dir, named "my-app"`,
+    )
+    .action(scaffoldAction);
+}

--- a/packages/cli/src/cli/program.ts
+++ b/packages/cli/src/cli/program.ts
@@ -12,6 +12,7 @@ import { getCreateCommand } from "@/cli/commands/project/create.js";
 import { getDeployCommand } from "@/cli/commands/project/deploy.js";
 import { getLinkCommand } from "@/cli/commands/project/link.js";
 import { getLogsCommand } from "@/cli/commands/project/logs.js";
+import { getScaffoldCommand } from "@/cli/commands/project/scaffold.js";
 import { getSecretsCommand } from "@/cli/commands/secrets/index.js";
 import { getSiteCommand } from "@/cli/commands/site/index.js";
 import { getTypesCommand } from "@/cli/commands/types/index.js";
@@ -50,6 +51,7 @@ export function createProgram(context: CLIContext): Command {
 
   // Register project commands
   program.addCommand(getCreateCommand());
+  program.addCommand(getScaffoldCommand());
   program.addCommand(getDashboardCommand());
   program.addCommand(getDeployCommand());
   program.addCommand(getLinkCommand());

--- a/packages/cli/src/core/project/create.ts
+++ b/packages/cli/src/core/project/create.ts
@@ -53,6 +53,41 @@ export async function createProjectFiles(
   };
 }
 
+/**
+ * Like {@link createProjectFiles} but skips the `createProject()` API call — the
+ * app already exists, so the caller supplies its `appId`.
+ */
+export async function initProjectFiles(options: {
+  name: string;
+  description?: string;
+  path: string;
+  template: Template;
+  appId: string;
+}): Promise<CreateProjectResult & { skippedFiles: string[] }> {
+  const { name, description, path: basePath, template, appId } = options;
+
+  await assertProjectNotExists(basePath);
+
+  // Skip files that already exist so scaffolding into a non-empty directory
+  // never clobbers existing files like .gitignore.
+  const skippedFiles = await renderTemplate(
+    template,
+    basePath,
+    {
+      name,
+      description,
+      projectId: appId,
+    },
+    { skipExisting: true },
+  );
+
+  return {
+    projectId: appId,
+    projectDir: basePath,
+    skippedFiles,
+  };
+}
+
 export async function createProjectFilesForExistingProject(options: {
   projectId: string;
   projectPath: string;

--- a/packages/cli/src/core/project/template.ts
+++ b/packages/cli/src/core/project/template.ts
@@ -6,7 +6,12 @@ import { getTemplatesDir, getTemplatesIndexPath } from "@/core/assets.js";
 import { SchemaValidationError } from "@/core/errors.js";
 import type { Template } from "@/core/project/schema.js";
 import { TemplatesConfigSchema } from "@/core/project/schema.js";
-import { copyFile, readJsonFile, writeFile } from "@/core/utils/fs.js";
+import {
+  copyFile,
+  pathExists,
+  readJsonFile,
+  writeFile,
+} from "@/core/utils/fs.js";
 
 interface TemplateData {
   name: string;
@@ -34,6 +39,14 @@ export async function listTemplates(): Promise<Template[]> {
   return result.data.templates;
 }
 
+interface RenderTemplateOptions {
+  /**
+   * Leave existing destination files untouched instead of overwriting — used
+   * when scaffolding into a non-empty dir (must not clobber `.gitignore`).
+   */
+  skipExisting?: boolean;
+}
+
 /**
  * Render a template directory to a destination path.
  * - Files ending in .ejs are rendered with EJS and written without the .ejs extension
@@ -44,7 +57,9 @@ export async function renderTemplate(
   template: Template,
   destPath: string,
   data: TemplateData,
-): Promise<void> {
+  options: RenderTemplateOptions = {},
+): Promise<string[]> {
+  const { skipExisting = false } = options;
   const templateDir = join(getTemplatesDir(), template.path);
 
   // Get all files in the template directory
@@ -53,6 +68,8 @@ export async function renderTemplate(
     dot: true,
     onlyFiles: true,
   });
+
+  const skipped: string[] = [];
 
   for (const file of files) {
     const srcPath = join(templateDir, file);
@@ -67,10 +84,19 @@ export async function renderTemplate(
           : file.replace(/\.ejs$/, "");
         const destFilePath = join(destPath, destFile);
 
+        if (skipExisting && (await pathExists(destFilePath))) {
+          skipped.push(destFile);
+          continue;
+        }
         await writeFile(destFilePath, body);
       } else {
         // Copy file directly
         const destFilePath = join(destPath, file);
+
+        if (skipExisting && (await pathExists(destFilePath))) {
+          skipped.push(file);
+          continue;
+        }
         await copyFile(srcPath, destFilePath);
       }
     } catch (error) {
@@ -78,4 +104,6 @@ export async function renderTemplate(
       throw new Error(`Failed to process template file "${file}": ${message}`);
     }
   }
+
+  return skipped;
 }

--- a/packages/cli/tests/cli/scaffold.spec.ts
+++ b/packages/cli/tests/cli/scaffold.spec.ts
@@ -1,0 +1,102 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { setupCLITests } from "./testkit/index.js";
+
+const USER = { email: "test@example.com", name: "Test User" };
+
+async function readTempFile(
+  dir: string,
+  relativePath: string,
+): Promise<string | null> {
+  try {
+    return await readFile(join(dir, relativePath), "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+describe("scaffold command", () => {
+  const t = setupCLITests();
+
+  it("scaffolds for an existing app id without creating a new app", async () => {
+    await t.givenLoggedIn(USER);
+    // Note: mockCreateApp is intentionally NOT registered. If scaffold tried
+    // to create an app, the unmocked POST /api/apps would 404 and fail the run.
+
+    const result = await t.run(
+      "scaffold",
+      "--app-id",
+      "app-existing-123",
+      "--no-skills",
+    );
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("Project created successfully");
+    t.expectResult(result).toContain("app-existing-123");
+
+    const appConfig = await readTempFile(t.getTempDir(), "base44/.app.jsonc");
+    expect(appConfig).toContain("app-existing-123");
+  });
+
+  it("reads the app id from BASE44_APP_ID when --app-id is omitted", async () => {
+    await t.givenLoggedIn(USER);
+    t.givenEnv({ BASE44_APP_ID: "app-from-env" });
+
+    const result = await t.run("scaffold", "--no-skills");
+
+    t.expectResult(result).toSucceed();
+    const appConfig = await readTempFile(t.getTempDir(), "base44/.app.jsonc");
+    expect(appConfig).toContain("app-from-env");
+  });
+
+  it("prefers --app-id over the BASE44_APP_ID env var", async () => {
+    await t.givenLoggedIn(USER);
+    t.givenEnv({ BASE44_APP_ID: "app-from-env" });
+
+    const result = await t.run(
+      "scaffold",
+      "--app-id",
+      "app-from-flag",
+      "--no-skills",
+    );
+
+    t.expectResult(result).toSucceed();
+    const appConfig = await readTempFile(t.getTempDir(), "base44/.app.jsonc");
+    expect(appConfig).toContain("app-from-flag");
+    expect(appConfig).not.toContain("app-from-env");
+  });
+
+  it("fails with a helpful message when no app id is available", async () => {
+    await t.givenLoggedIn(USER);
+
+    const result = await t.run("scaffold", "--no-skills");
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("No app ID found");
+    t.expectResult(result).toContain("--app-id");
+  });
+
+  it("does not overwrite existing files when scaffolding", async () => {
+    await t.givenLoggedIn(USER);
+
+    // Pre-create base44/.gitignore (which the template would otherwise write).
+    // This does not match the project-config pattern (base44/config.*), so
+    // scaffold still proceeds, but the existing file must be preserved.
+    const base44Dir = join(t.getTempDir(), "base44");
+    await mkdir(base44Dir, { recursive: true });
+    await writeFile(join(base44Dir, ".gitignore"), "# pre-existing\nkeep-me\n");
+
+    const result = await t.run(
+      "scaffold",
+      "--app-id",
+      "app-skip-existing",
+      "--no-skills",
+    );
+
+    t.expectResult(result).toSucceed();
+
+    const gitignore = await readTempFile(t.getTempDir(), "base44/.gitignore");
+    expect(gitignore).toContain("keep-me");
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Adds a new `base44 scaffold` command that sets up a local project for an **existing** Base44 app, without minting a new app. It reads the app ID from `--app-id` or the `BASE44_APP_ID` env var, scaffolds the `backend-only` template into the current directory, and runs the shared post-scaffold setup (push entities, deploy site, install skills, print summary). Scaffolding is non-destructive — existing files such as `.gitignore` are preserved rather than overwritten.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Add `getScaffoldCommand()` (`scaffold.ts`) and register it in `program.ts`; resolves the app ID from `--app-id` or `BASE44_APP_ID`, throwing a helpful `InvalidInputError` when neither is present.
> - Add `initProjectFiles()` in `core/project/create.ts` — like `createProjectFiles()` but skips the `createProject()` API call since the app already exists, reusing the caller-supplied `appId`.
> - Extend `renderTemplate()` with a `skipExisting` option that leaves existing destination files untouched and returns the list of skipped files, so scaffolding into a non-empty directory never clobbers files like `.gitignore`.
> - Reuse the shared post-scaffold logic in `scaffold-shared.ts` (push entities, deploy site, install skills, print summary) via `completeProjectSetup` / `getTemplateById` / `printProjectSummary`.
> - Update `docs/commands.md` to document the `create`/`scaffold` split and shared logic.
> - Add `tests/cli/scaffold.spec.ts` covering existing-app scaffolding, env-var fallback, flag precedence, the missing-app-ID error, and the non-destructive file behavior.
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [ ] All tests pass (\`npm test\`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [x] I have commented my code, particularly in hard-to-understand areas
> - [x] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [x] I have updated \`docs/\` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> Builds on the `feature/env-token-auth` branch — `scaffold` pairs with env-supplied credentials and `BASE44_APP_ID` to enable non-interactive setup of an existing app in CI/agent contexts.
>
> ---
> <sub>🤖 Generated by Claude | 2026-06-10 13:14 UTC | 4e35114</sub>