### PR TITLE
feat(cli): steer `create` to `scaffold` when an app id is in the env (4/4)

### DIFF
--- a/packages/cli/src/cli/commands/project/create.ts
+++ b/packages/cli/src/cli/commands/project/create.ts
@@ -1,6 +1,6 @@
 import { basename, resolve } from "node:path";
 import type { Option } from "@clack/prompts";
-import { group, select, text } from "@clack/prompts";
+import { confirm, group, isCancel, select, text } from "@clack/prompts";
 import { Argument, type Command } from "commander";
 import kebabCase from "lodash/kebabCase";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";
@@ -25,6 +25,7 @@ interface CreateOptions {
   template?: string;
   deploy?: boolean;
   skills?: boolean;
+  force?: boolean;
 }
 
 function validateNonInteractiveFlags(command: Command): void {
@@ -174,6 +175,39 @@ async function createAction(
   name: string | undefined,
   options: CreateOptions,
 ): Promise<RunCommandResult> {
+  // An app id in the environment (e.g. provisioned externally) means this
+  // context already has a Base44 app. `create` would make a NEW one and ignore
+  // it — steer toward `base44 scaffold`. Hard-stop for agents (non-interactive),
+  // confirm for humans. `--force` overrides the guard in both modes.
+  const existingAppId = process.env.BASE44_APP_ID;
+  if (existingAppId && !options.force) {
+    if (isNonInteractive) {
+      throw new InvalidInputError(
+        `BASE44_APP_ID is set (${existingAppId}) — this environment already has a Base44 app, so \`create\` won't make a new one.`,
+        {
+          hints: [
+            {
+              message:
+                "Run `base44 scaffold` to set up a project for the existing app",
+            },
+            { message: "Or pass --force to create a new app anyway" },
+          ],
+        },
+      );
+    }
+
+    const proceed = await confirm({
+      message: `BASE44_APP_ID is set (${existingAppId}). This environment already has a Base44 app — \`base44 scaffold\` sets up a project for it, while \`create\` makes a new one. Create a new app anyway?`,
+      initialValue: false,
+    });
+    if (isCancel(proceed) || !proceed) {
+      return {
+        outroMessage:
+          "Run `base44 scaffold` to set up a project for the existing app",
+      };
+    }
+  }
+
   if (name && !options.path) {
     options.path = `./${kebabCase(name)}`;
   }
@@ -218,6 +252,10 @@ export function getCreateCommand(): Command {
     )
     .option("--deploy", "Build and deploy the site")
     .option("--no-skills", "Skip AI agent skills installation")
+    .option(
+      "--force",
+      "Create a new app even when BASE44_APP_ID is set in the environment",
+    )
     .addHelpText(
       "after",
       `

--- a/packages/cli/tests/cli/create.spec.ts
+++ b/packages/cli/tests/cli/create.spec.ts
@@ -79,4 +79,43 @@ describe("create command", () => {
     t.expectResult(result).toSucceed();
     t.expectResult(result).toContain("Project created successfully");
   });
+
+  it("refuses to create when BASE44_APP_ID is set, pointing to scaffold", async () => {
+    await t.givenLoggedIn({ email: "test@example.com", name: "Test User" });
+    t.givenEnv({ BASE44_APP_ID: "app-existing-123" });
+    // mockCreateApp intentionally NOT registered: the guard must stop before any
+    // create-app API call.
+
+    const result = await t.run(
+      "create",
+      "My App",
+      "--path",
+      join(t.getTempDir(), "my-app"),
+      "--no-skills",
+    );
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("BASE44_APP_ID");
+    t.expectResult(result).toContain("scaffold");
+    t.expectResult(result).toContain("--force");
+  });
+
+  it("creates a new app with --force even when BASE44_APP_ID is set", async () => {
+    await t.givenLoggedIn({ email: "test@example.com", name: "Test User" });
+    t.givenEnv({ BASE44_APP_ID: "app-existing-123" });
+    t.api.mockCreateApp({ id: "brand-new-id", name: "My App" });
+
+    const result = await t.run(
+      "create",
+      "My App",
+      "--path",
+      join(t.getTempDir(), "my-app"),
+      "--no-skills",
+      "--force",
+    );
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("Project created successfully");
+    t.expectResult(result).toContain("brand-new-id");
+  });
 });


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> When `BASE44_APP_ID` is set in the environment, the current context already has a Base44 app, so running `create` (which makes a brand-new app and ignores the existing one) is almost certainly a mistake. This PR adds a guard to `base44 create` that detects this and steers the user toward `base44 scaffold` instead. Agents (non-interactive runs) hit a hard stop with actionable hints, humans get a confirmation prompt, and a new `--force` flag overrides the guard in either mode.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added a guard in `createAction` that checks for `BASE44_APP_ID` in the environment before creating a new app.
> - Non-interactive (agent) runs throw an `InvalidInputError` with hints pointing to `base44 scaffold` and `--force`.
> - Interactive runs show a `confirm` prompt; declining (or cancelling) exits with an outro message pointing to `base44 scaffold`.
> - Added a `--force` option to `base44 create` that creates a new app even when `BASE44_APP_ID` is set, in both interactive and non-interactive modes.
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [x] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [x] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> Two new tests cover the guard: one asserts `create` refuses (without ever hitting the create-app API) and surfaces `BASE44_APP_ID`, `scaffold`, and `--force` in its output; the other asserts `--force` bypasses the guard and creates a new app. This builds on the companion `scaffold` command introduced on the target branch.
>
> ---
> <sub>🤖 Generated by Claude | 2026-06-10 08:13 UTC | 4825ad9</sub>