### PR TITLE
fix(cli): allow underscores in entity names

### DIFF
--- a/packages/cli/src/core/resources/entity/schema.ts
+++ b/packages/cli/src/core/resources/entity/schema.ts
@@ -138,7 +138,10 @@ export const EntitySchema = z.looseObject({
   name: z
     .string()
     .min(1)
-    .regex(/^[a-zA-Z0-9]+$/, "Entity name must be alphanumeric only"),
+    .regex(
+      /^[a-zA-Z0-9_]+$/,
+      "Entity name can only contain letters, numbers, and underscores",
+    ),
   title: z.string().optional(),
   description: z.string().optional(),
   properties: z.record(z.string(), PropertyDefinitionSchema).default({}),

--- a/packages/cli/tests/cli/entities_push.spec.ts
+++ b/packages/cli/tests/cli/entities_push.spec.ts
@@ -53,6 +53,20 @@ describe("entities push command", () => {
     t.expectResult(result).toContain("Updated: Product");
   });
 
+  it("pushes entities with snake_case names", async () => {
+    await t.givenLoggedInWithProject(fixture("with-snake-case-entities"));
+    t.api.mockEntitiesPush({
+      created: ["line_items"],
+      updated: [],
+      deleted: [],
+    });
+
+    const result = await t.run("entities", "push");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("Created: line_items");
+  });
+
   it("fails with helpful error when entity is missing required fields", async () => {
     await t.givenLoggedInWithProject(fixture("invalid-entity"));
 

--- a/packages/cli/tests/core/entity-schema.spec.ts
+++ b/packages/cli/tests/core/entity-schema.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { EntitySchema } from "@/core/resources/entity/schema.js";
+
+describe("Entity name validation", () => {
+  it("accepts alphanumeric names", () => {
+    const result = EntitySchema.safeParse({ name: "Customer" });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts snake_case names", () => {
+    const result = EntitySchema.safeParse({ name: "line_items" });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts names with a leading underscore", () => {
+    const result = EntitySchema.safeParse({ name: "_internal" });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects names with dashes", () => {
+    const result = EntitySchema.safeParse({ name: "line-items" });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe(
+      "Entity name can only contain letters, numbers, and underscores",
+    );
+  });
+
+  it("rejects names with spaces", () => {
+    const result = EntitySchema.safeParse({ name: "line items" });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects names with dots", () => {
+    const result = EntitySchema.safeParse({ name: "line.items" });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty names", () => {
+    const result = EntitySchema.safeParse({ name: "" });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/cli/tests/core/project.spec.ts
+++ b/packages/cli/tests/core/project.spec.ts
@@ -35,6 +35,15 @@ describe("readProjectConfig", () => {
     expect(result.agents).toEqual([]);
   });
 
+  it("reads project with snake_case entity names", async () => {
+    const result = await readProjectConfig(
+      resolve(FIXTURES_DIR, "with-snake-case-entities"),
+    );
+
+    expect(result.entities).toHaveLength(1);
+    expect(result.entities[0].name).toBe("line_items");
+  });
+
   it("reads project with functions and entities", async () => {
     const result = await readProjectConfig(
       resolve(FIXTURES_DIR, "with-functions-and-entities"),

--- a/packages/cli/tests/fixtures/with-snake-case-entities/base44/.app.jsonc
+++ b/packages/cli/tests/fixtures/with-snake-case-entities/base44/.app.jsonc
@@ -1,0 +1,4 @@
+// Base44 App Configuration
+{
+    "id": "test-app-id"
+}

--- a/packages/cli/tests/fixtures/with-snake-case-entities/base44/config.jsonc
+++ b/packages/cli/tests/fixtures/with-snake-case-entities/base44/config.jsonc
@@ -1,0 +1,3 @@
+{
+  "name": "Snake Case Entities Test Project"
+}

--- a/packages/cli/tests/fixtures/with-snake-case-entities/base44/entities/line-items.json
+++ b/packages/cli/tests/fixtures/with-snake-case-entities/base44/entities/line-items.json
@@ -1,0 +1,15 @@
+{
+  "name": "line_items",
+  "type": "object",
+  "properties": {
+    "sku": {
+      "type": "string",
+      "description": "Stock keeping unit"
+    },
+    "quantity": {
+      "type": "number",
+      "description": "Quantity ordered"
+    }
+  },
+  "required": ["sku"]
+}


### PR DESCRIPTION
## Summary

Fixes #543.

The entity name pattern introduced in #151 (`/^[a-zA-Z0-9]+$/`) rejects snake_case names the platform already accepts and serves in production. Because `readProjectConfig()` eagerly validates every entity file, a single entity like `"name": "line_items"` aborts `site deploy`, `functions deploy`, `functions pull`, `deploy`, and `dev` — including commands that never touch entities. This relaxes the pattern to `/^[a-zA-Z0-9_]+$/`.

## Why underscores specifically

- The platform accepts and serves snake_case entity names (live production apps, addressable via `base44.entities.line_items`)
- Type generation already anticipates them: `toPascalCase()` splits on `/[-_\s]+/` and `EntityTypeRegistry` emits quoted keys
- Function automations and agent tool configs already reference entities via unrestricted `entity_name` fields — such entities just couldn't be *defined*
- Sibling rules allow them: plugin namespaces (`[a-zA-Z0-9_-]`), connector custom types (`[a-z0-9_-]/i`)
- Dashes/dots/spaces are still rejected — no evidence the platform accepts those. Happy to adjust the character set if the backend rule differs.

## Testing

- New unit spec `tests/core/entity-schema.spec.ts` covering accepted/rejected names
- New fixture `with-snake-case-entities` + integration tests: `readProjectConfig()` loads a `line_items` entity, and `entities push` succeeds end-to-end against the mock API
- `bun run test`, `bun run typecheck`, and Biome all pass on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)