### PR TITLE
fix(cli): fix logs --app-id behavior when run from a project directory

### DIFF
--- a/packages/cli/src/core/project/app-config.ts
+++ b/packages/cli/src/core/project/app-config.ts
@@ -58,7 +58,7 @@ export async function initAppContext(
       throw new InvalidInputError("App id cannot be empty.");
     }
 
-    cache = { id, projectRoot: projectRoot?.root };
+    cache = { id };
     return cache;
   }
 

--- a/packages/cli/src/core/resources/function/schema.ts
+++ b/packages/cli/src/core/resources/function/schema.ts
@@ -188,7 +188,7 @@ export type FunctionWithCode = Omit<BackendFunction, "filePaths"> & {
 };
 
 /**
- * Known log levels from Deno Deploy runtime.
+ * Log levels from Deno Deploy runtime.
  */
 export const LogLevelSchema = z.enum(["info", "warning", "error", "debug"]);
 
@@ -196,10 +196,7 @@ export type LogLevel = z.infer<typeof LogLevelSchema>;
 
 const FunctionLogEntrySchema = z.object({
   time: z.string(),
-  level: z.preprocess(
-    (v) => (v === "warn" ? "warning" : v),
-    LogLevelSchema,
-  ),
+  level: LogLevelSchema,
   message: z.string(),
 });
 

--- a/packages/cli/src/core/resources/function/schema.ts
+++ b/packages/cli/src/core/resources/function/schema.ts
@@ -188,7 +188,7 @@ export type FunctionWithCode = Omit<BackendFunction, "filePaths"> & {
 };
 
 /**
- * Log levels from Deno Deploy runtime.
+ * Known log levels from Deno Deploy runtime.
  */
 export const LogLevelSchema = z.enum(["info", "warning", "error", "debug"]);
 
@@ -196,7 +196,10 @@ export type LogLevel = z.infer<typeof LogLevelSchema>;
 
 const FunctionLogEntrySchema = z.object({
   time: z.string(),
-  level: LogLevelSchema,
+  level: z.preprocess(
+    (v) => (v === "warn" ? "warning" : v),
+    LogLevelSchema,
+  ),
   message: z.string(),
 });
 


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> When an app id is provided explicitly via `--app-id`, the resolved app context no longer attaches the local `projectRoot` of the directory the command runs in. This ensures an explicitly-supplied app id is treated as projectless, so commands operate on the targeted app independently of any linked project the user happens to be inside.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - In `initAppContext`, when `options.appId` is supplied, cache only the app `id` and stop including `projectRoot` in the returned `AppContext`.
> - Ensures `--app-id` commands behave consistently as projectless, regardless of whether they are run from inside a linked project directory.
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> This is a small, targeted follow-up to the projectless app-id command behavior work: an explicit `--app-id` should not inherit the current directory's project root.
>
> ---
> <sub>🤖 Generated by Claude | 2026-06-16 12:50 UTC | 2cca7dc</sub>