### PR TITLE
fix(logs): normalize Deno Deploy "warn" level to "warning"

### DIFF
--- a/packages/cli/src/core/resources/function/schema.ts
+++ b/packages/cli/src/core/resources/function/schema.ts
@@ -196,7 +196,8 @@ export type LogLevel = z.infer<typeof LogLevelSchema>;
 
 const FunctionLogEntrySchema = z.object({
   time: z.string(),
-  level: LogLevelSchema,
+  // ponytail: Deno Deploy returns "warn" in some runtime versions; normalize to "warning"
+  level: z.preprocess((v) => (v === "warn" ? "warning" : v), LogLevelSchema),
   message: z.string(),
 });
 

--- a/packages/cli/src/core/resources/function/schema.ts
+++ b/packages/cli/src/core/resources/function/schema.ts
@@ -196,7 +196,6 @@ export type LogLevel = z.infer<typeof LogLevelSchema>;
 
 const FunctionLogEntrySchema = z.object({
   time: z.string(),
-  // ponytail: Deno Deploy returns "warn" in some runtime versions; normalize to "warning"
   level: z.preprocess((v) => (v === "warn" ? "warning" : v), LogLevelSchema),
   message: z.string(),
 });

--- a/packages/cli/src/core/resources/function/schema.ts
+++ b/packages/cli/src/core/resources/function/schema.ts
@@ -188,7 +188,7 @@ export type FunctionWithCode = Omit<BackendFunction, "filePaths"> & {
 };
 
 /**
- * Log levels from Deno Deploy runtime.
+ * Log levels emitted by backend function runtimes.
  */
 export const LogLevelSchema = z.enum(["info", "warning", "error", "debug"]);
 

--- a/packages/cli/src/core/resources/function/schema.ts
+++ b/packages/cli/src/core/resources/function/schema.ts
@@ -196,7 +196,10 @@ export type LogLevel = z.infer<typeof LogLevelSchema>;
 
 const FunctionLogEntrySchema = z.object({
   time: z.string(),
-  level: z.preprocess((v) => (v === "warn" ? "warning" : v), LogLevelSchema),
+  level: z.preprocess(
+    (v) => (v === "warn" ? "warning" : !v || v === "log" ? "info" : v),
+    LogLevelSchema,
+  ),
   message: z.string(),
 });
 


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Backend function log entries can arrive with runtime-specific log levels that don't match the canonical set the CLI expects (`info`, `warning`, `error`, `debug`). These non-canonical values caused Zod validation to fail when displaying logs. This PR adds a `z.preprocess` step that normalizes incoming levels — mapping `"warn"` to `"warning"` (Deno Deploy, Cloudflare) and empty/missing or `"log"` values to `"info"` (Cloudflare) — before schema validation.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Wrapped the \`level\` field of \`FunctionLogEntrySchema\` in a \`z.preprocess\` that normalizes incoming log levels to canonical values.
> - Mapped \`"warn"\` → \`"warning"\` and empty/falsy or \`"log"\` → \`"info"\` so logs from Deno Deploy and Cloudflare runtimes validate correctly.
> - Updated the \`LogLevelSchema\` doc comment to reflect that levels are emitted by all backend function runtimes, not just Deno Deploy.
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (\`npm test\`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated \`docs/\` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The fix preserves any already-canonical level unchanged, so it is fully backward compatible. No tests were added for the normalization logic.
>
> ---
> <sub>🤖 Generated by Claude | 2026-06-22 13:45 UTC | 43ef1d0</sub>