### PR TITLE
feat(logs): add --env flag to fetch preview, prod, or all logs

### DIFF
--- a/packages/cli/src/cli/commands/project/logs.ts
+++ b/packages/cli/src/cli/commands/project/logs.ts
@@ -23,7 +23,6 @@ interface LogsOptions {
   level?: string;
   limit?: string;
   order?: string;
-  json?: boolean;
   env?: "preview" | "prod";
 }
 
@@ -227,11 +226,11 @@ async function logsAction(
   }
 
   const env = options.env ?? "preview";
-  const logsOutput = options.json
+  const logsOutput = ctx.jsonMode
     ? `${JSON.stringify(entries, null, 2)}\n`
     : formatLogs(entries, env);
 
-  const shouldOutputOutroMessage = !options.json;
+  const shouldOutputOutroMessage = !ctx.jsonMode;
   return {
     outroMessage: shouldOutputOutroMessage ? "Fetched logs" : undefined,
     stdout: logsOutput,
@@ -270,6 +269,5 @@ export function getLogsCommand(): Command {
         "Which deployment to read logs from: preview (current draft) or prod (published). Default: preview",
       ).choices(["preview", "prod"]),
     )
-    .option("--json", "Output as JSON (clean stdout, safe to pipe to jq)")
     .action(logsAction);
 }

--- a/packages/cli/src/cli/commands/project/logs.ts
+++ b/packages/cli/src/cli/commands/project/logs.ts
@@ -24,6 +24,7 @@ interface LogsOptions {
   limit?: string;
   order?: string;
   json?: boolean;
+  env?: "preview" | "prod";
 }
 
 /**
@@ -59,6 +60,10 @@ function parseFunctionFilters(options: LogsOptions): FunctionLogFilters {
     filters.order = options.order.toLowerCase() as "asc" | "desc";
   }
 
+  if (options.env) {
+    filters.env = options.env;
+  }
+
   return filters;
 }
 
@@ -89,8 +94,11 @@ function formatEntry(entry: LogEntry): string {
 /**
  * Build function logs output (log-file style).
  */
-function formatLogs(entries: LogEntry[]): string {
+function formatLogs(entries: LogEntry[], env: "preview" | "prod"): string {
   if (entries.length === 0) {
+    if (env === "prod") {
+      return "No production logs found. Has this app been published? Try --env preview to see draft logs.\n";
+    }
     return "No logs found matching the filters.\n";
   }
 
@@ -218,9 +226,10 @@ async function logsAction(
     entries = entries.slice(0, limit);
   }
 
+  const env = options.env ?? "preview";
   const logsOutput = options.json
     ? `${JSON.stringify(entries, null, 2)}\n`
-    : formatLogs(entries);
+    : formatLogs(entries, env);
 
   const shouldOutputOutroMessage = !options.json;
   return {
@@ -254,6 +263,12 @@ export function getLogsCommand(): Command {
     .option("-n, --limit <n>", "Results per page (1-1000, default: 50)")
     .addOption(
       new Option("--order <order>", "Sort order").choices(["asc", "desc"]),
+    )
+    .addOption(
+      new Option(
+        "--env <env>",
+        "Which deployment to read logs from: preview (current draft) or prod (published). Default: preview",
+      ).choices(["preview", "prod"]),
     )
     .option("--json", "Output as JSON (clean stdout, safe to pipe to jq)")
     .action(logsAction);

--- a/packages/cli/src/cli/commands/project/logs.ts
+++ b/packages/cli/src/cli/commands/project/logs.ts
@@ -8,10 +8,12 @@ import { readProjectConfig } from "@/core/index.js";
 import type {
   FunctionLogFilters,
   FunctionLogsResponse,
+  LogEnv,
   LogLevel,
 } from "@/core/resources/function/index.js";
 import {
   fetchFunctionLogs,
+  LogEnvSchema,
   LogLevelSchema,
   listDeployedFunctions,
 } from "@/core/resources/function/index.js";
@@ -23,7 +25,7 @@ interface LogsOptions {
   level?: string;
   limit?: string;
   order?: string;
-  env?: "preview" | "prod";
+  env?: LogEnv;
 }
 
 /**
@@ -93,7 +95,7 @@ function formatEntry(entry: LogEntry): string {
 /**
  * Build function logs output (log-file style).
  */
-function formatLogs(entries: LogEntry[], env: "preview" | "prod"): string {
+function formatLogs(entries: LogEntry[], env: LogEnv): string {
   if (entries.length === 0) {
     if (env === "prod") {
       return "No production logs found. Has this app been published? Try --env preview to see draft logs.\n";
@@ -267,7 +269,7 @@ export function getLogsCommand(): Command {
       new Option(
         "--env <env>",
         "Which deployment to read logs from: preview (current draft) or prod (published). Default: preview",
-      ).choices(["preview", "prod"]),
+      ).choices([...LogEnvSchema.options]),
     )
     .action(logsAction);
 }

--- a/packages/cli/src/core/resources/function/api.ts
+++ b/packages/cli/src/core/resources/function/api.ts
@@ -96,6 +96,9 @@ function buildLogsQueryString(filters: FunctionLogFilters): URLSearchParams {
   if (filters.order) {
     params.set("order", filters.order);
   }
+  if (filters.env) {
+    params.set("env", filters.env);
+  }
 
   return params;
 }

--- a/packages/cli/src/core/resources/function/schema.ts
+++ b/packages/cli/src/core/resources/function/schema.ts
@@ -194,6 +194,10 @@ export const LogLevelSchema = z.enum(["info", "warning", "error", "debug"]);
 
 export type LogLevel = z.infer<typeof LogLevelSchema>;
 
+export const LogEnvSchema = z.enum(["preview", "prod"]);
+
+export type LogEnv = z.infer<typeof LogEnvSchema>;
+
 const FunctionLogEntrySchema = z.object({
   time: z.string(),
   level: z.preprocess(
@@ -213,5 +217,5 @@ export interface FunctionLogFilters {
   level?: LogLevel;
   limit?: number;
   order?: "asc" | "desc";
-  env?: "preview" | "prod";
+  env?: LogEnv;
 }

--- a/packages/cli/src/core/resources/function/schema.ts
+++ b/packages/cli/src/core/resources/function/schema.ts
@@ -213,4 +213,5 @@ export interface FunctionLogFilters {
   level?: LogLevel;
   limit?: number;
   order?: "asc" | "desc";
+  env?: "preview" | "prod";
 }

--- a/packages/cli/tests/cli/logs.spec.ts
+++ b/packages/cli/tests/cli/logs.spec.ts
@@ -178,6 +178,36 @@ describe("logs command", () => {
     t.expectResult(result).toContain("No logs found matching the filters.");
   });
 
+  it("accepts --env prod and shows the published-app hint when empty", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockFunctionLogs("my-function", []);
+
+    const result = await t.run(
+      "logs",
+      "--function",
+      "my-function",
+      "--env",
+      "prod",
+    );
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("No production logs found");
+  });
+
+  it("rejects an invalid --env value", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+
+    const result = await t.run(
+      "logs",
+      "--function",
+      "my-function",
+      "--env",
+      "staging",
+    );
+
+    t.expectResult(result).toFail();
+  });
+
   it("filters function logs by --level", async () => {
     await t.givenLoggedInWithProject(fixture("basic"));
     t.api.mockFunctionLogs("my-function", [


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Adds an `--env preview|prod` flag to the `logs` command so users can choose which deployment to read function logs from: the current draft (`preview`, default) or the published app (`prod`). It also drops the command-local `--json` option in favor of the global `--json` flag, and centralizes the env values in a reusable `LogEnvSchema` Zod enum.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [x] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Add `--env <env>` option to the `logs` command, restricted to `preview` (default) and `prod` via `.choices()`.
> - Plumb the `env` filter through `parseFunctionFilters`, `FunctionLogFilters`, and `buildLogsQueryString` so it is sent as an `env` query param to the logs API.
> - Show a published-app hint (\"No production logs found. Has this app been published? Try --env preview to see draft logs.\") when a `prod` query returns no entries.
> - Remove the command-local \`--json\` option and honor the global \`--json\` flag (\`ctx.jsonMode\`) for both the JSON output and the outro message.
> - Introduce \`LogEnvSchema\`/\`LogEnv\` in the function schema and reuse the enum's options to drive the CLI choices.
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [x] All tests pass (\`npm test\`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated \`docs/\` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> Removing the local \`--json\` option is behavior-aligning rather than breaking: the global \`--json\` flag now drives the same machine-readable output. Tests cover both the \`--env prod\` empty-state hint and rejection of invalid \`--env\` values.
>
> ---
> <sub>🤖 Generated by Claude | 2026-06-28 13:50 UTC | cd949a6</sub>