### PR TITLE
feat(logs): add --follow to stream logs live

### DIFF
--- a/packages/cli/src/cli/commands/project/logs.ts
+++ b/packages/cli/src/cli/commands/project/logs.ts
@@ -26,12 +26,13 @@ interface LogsOptions {
   limit?: string;
   order?: string;
   env?: LogEnv;
+  follow?: boolean;
 }
 
 /**
  * Unified log entry for display.
  */
-interface LogEntry {
+export interface LogEntry {
   time: string;
   level: string;
   message: string;
@@ -90,6 +91,88 @@ function formatEntry(entry: LogEntry): string {
   const level = entry.level.toUpperCase().padEnd(5);
   const message = entry.message.trim();
   return `${time} ${level} ${message}`;
+}
+
+/**
+ * State carried between follow polls so the inclusive `since` boundary doesn't
+ * re-print entries. `lastTime` is the newest ISO time already shown;
+ * `boundaryKeys` are the keys of entries sitting at exactly that timestamp.
+ */
+export interface FollowState {
+  lastTime: string;
+  boundaryKeys: Set<string>;
+}
+
+function entryKey(entry: LogEntry): string {
+  return `${entry.time} ${entry.message}`;
+}
+
+/**
+ * Given a fresh poll result and the previous follow state, return the entries
+ * not yet shown and the next state. Time comparison is lexicographic on ISO
+ * strings, matching the existing multi-function sort assumption.
+ */
+export function selectNewEntries(
+  entries: LogEntry[],
+  state: FollowState,
+): { fresh: LogEntry[]; nextState: FollowState } {
+  const fresh = entries.filter((e) => {
+    if (e.time < state.lastTime) return false;
+    if (e.time === state.lastTime && state.boundaryKeys.has(entryKey(e))) {
+      return false;
+    }
+    return true;
+  });
+
+  if (fresh.length === 0) return { fresh, nextState: state };
+
+  const newMax = fresh.reduce(
+    (max, e) => (e.time > max ? e.time : max),
+    state.lastTime,
+  );
+  const boundaryKeys =
+    newMax === state.lastTime ? new Set(state.boundaryKeys) : new Set<string>();
+  for (const e of fresh) {
+    if (e.time === newMax) boundaryKeys.add(entryKey(e));
+  }
+  return { fresh, nextState: { lastTime: newMax, boundaryKeys } };
+}
+
+function writeFollowLine(entry: LogEntry, jsonMode: boolean): void {
+  const line = jsonMode ? JSON.stringify(entry) : formatEntry(entry);
+  process.stdout.write(`${line}\n`);
+}
+
+/**
+ * Poll the logs endpoint forever, printing new entries as they appear.
+ * Returns `never` — the process exits on Ctrl-C.
+ */
+async function followLogs(
+  functionNames: string[],
+  options: LogsOptions,
+  availableFunctionNames: string[],
+  jsonMode: boolean,
+): Promise<never> {
+  let state: FollowState = { lastTime: "", boundaryKeys: new Set() };
+  let first = true;
+
+  while (true) {
+    const pollOptions = first ? options : { ...options, since: state.lastTime };
+    const entries = await fetchLogsForFunctions(
+      functionNames,
+      pollOptions,
+      availableFunctionNames,
+    );
+    const { fresh, nextState } = selectNewEntries(entries, state);
+    state = nextState;
+    // Force chronological output: the backend's order param isn't reliable for
+    // a single function, so sort ourselves (asc = oldest -> newest, tail style).
+    fresh.sort((a, b) => a.time.localeCompare(b.time));
+    for (const entry of fresh) writeFollowLine(entry, jsonMode);
+    first = false;
+    // ponytail: fixed 2s poll + errors are fatal; add --interval / transient-retry if users hit it.
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
 }
 
 /**
@@ -215,6 +298,21 @@ async function logsAction(
     };
   }
 
+  if (options.follow) {
+    if (options.until) {
+      throw new InvalidInputError(
+        "--until cannot be combined with --follow (a stream has no end).",
+      );
+    }
+    options.order = "asc"; // tail reads oldest -> newest
+    return followLogs(
+      functionNames,
+      options,
+      availableFunctionNames,
+      ctx.jsonMode,
+    );
+  }
+
   let entries = await fetchLogsForFunctions(
     functionNames,
     options,
@@ -262,6 +360,10 @@ export function getLogsCommand(): Command {
         .hideHelp(),
     )
     .option("-n, --limit <n>", "Results per page (1-1000, default: 50)")
+    .option(
+      "-f, --follow",
+      "Stream new logs as they arrive (poll every 2s). Exit with Ctrl-C",
+    )
     .addOption(
       new Option("--order <order>", "Sort order").choices(["asc", "desc"]),
     )

--- a/packages/cli/src/cli/commands/project/logs.ts
+++ b/packages/cli/src/cli/commands/project/logs.ts
@@ -170,7 +170,6 @@ async function followLogs(
     fresh.sort((a, b) => a.time.localeCompare(b.time));
     for (const entry of fresh) writeFollowLine(entry, jsonMode);
     first = false;
-    // ponytail: fixed 2s poll + errors are fatal; add --interval / transient-retry if users hit it.
     await new Promise((resolve) => setTimeout(resolve, 2000));
   }
 }
@@ -360,10 +359,7 @@ export function getLogsCommand(): Command {
         .hideHelp(),
     )
     .option("-n, --limit <n>", "Results per page (1-1000, default: 50)")
-    .option(
-      "-f, --follow",
-      "Stream new logs as they arrive (poll every 2s). Exit with Ctrl-C",
-    )
+    .option("-f, --follow", "Stream new logs as they arrive")
     .addOption(
       new Option("--order <order>", "Sort order").choices(["asc", "desc"]),
     )

--- a/packages/cli/src/cli/commands/project/logs.ts
+++ b/packages/cli/src/cli/commands/project/logs.ts
@@ -93,8 +93,6 @@ function formatEntry(entry: LogEntry): string {
   return `${time} ${level} ${message}`;
 }
 
-// Tracks what's already been shown so the inclusive `since` boundary doesn't
-// re-print: the newest ISO time seen, and the entries sitting at exactly it.
 export interface FollowState {
   lastTime: string;
   boundaryKeys: Set<string>;
@@ -104,8 +102,6 @@ function entryKey(entry: LogEntry): string {
   return `${entry.time} ${entry.message}`;
 }
 
-// Time comparison is lexicographic on ISO strings, matching the existing
-// multi-function sort assumption.
 export function selectNewEntries(
   entries: LogEntry[],
   state: FollowState,
@@ -137,7 +133,6 @@ function writeFollowLine(entry: LogEntry, jsonMode: boolean): void {
   process.stdout.write(`${line}\n`);
 }
 
-// Polls forever, printing new entries as they appear; exits on Ctrl-C.
 async function followLogs(
   functionNames: string[],
   options: LogsOptions,
@@ -156,8 +151,6 @@ async function followLogs(
     );
     const { fresh, nextState } = selectNewEntries(entries, state);
     state = nextState;
-    // The backend's order param isn't reliable for a single function, so sort
-    // ourselves to keep new lines appending oldest -> newest (tail style).
     fresh.sort((a, b) => a.time.localeCompare(b.time));
     for (const entry of fresh) writeFollowLine(entry, jsonMode);
     first = false;

--- a/packages/cli/src/cli/commands/project/logs.ts
+++ b/packages/cli/src/cli/commands/project/logs.ts
@@ -93,11 +93,8 @@ function formatEntry(entry: LogEntry): string {
   return `${time} ${level} ${message}`;
 }
 
-/**
- * State carried between follow polls so the inclusive `since` boundary doesn't
- * re-print entries. `lastTime` is the newest ISO time already shown;
- * `boundaryKeys` are the keys of entries sitting at exactly that timestamp.
- */
+// Tracks what's already been shown so the inclusive `since` boundary doesn't
+// re-print: the newest ISO time seen, and the entries sitting at exactly it.
 export interface FollowState {
   lastTime: string;
   boundaryKeys: Set<string>;
@@ -107,11 +104,8 @@ function entryKey(entry: LogEntry): string {
   return `${entry.time} ${entry.message}`;
 }
 
-/**
- * Given a fresh poll result and the previous follow state, return the entries
- * not yet shown and the next state. Time comparison is lexicographic on ISO
- * strings, matching the existing multi-function sort assumption.
- */
+// Time comparison is lexicographic on ISO strings, matching the existing
+// multi-function sort assumption.
 export function selectNewEntries(
   entries: LogEntry[],
   state: FollowState,
@@ -143,10 +137,7 @@ function writeFollowLine(entry: LogEntry, jsonMode: boolean): void {
   process.stdout.write(`${line}\n`);
 }
 
-/**
- * Poll the logs endpoint forever, printing new entries as they appear.
- * Returns `never` — the process exits on Ctrl-C.
- */
+// Polls forever, printing new entries as they appear; exits on Ctrl-C.
 async function followLogs(
   functionNames: string[],
   options: LogsOptions,
@@ -165,8 +156,8 @@ async function followLogs(
     );
     const { fresh, nextState } = selectNewEntries(entries, state);
     state = nextState;
-    // Force chronological output: the backend's order param isn't reliable for
-    // a single function, so sort ourselves (asc = oldest -> newest, tail style).
+    // The backend's order param isn't reliable for a single function, so sort
+    // ourselves to keep new lines appending oldest -> newest (tail style).
     fresh.sort((a, b) => a.time.localeCompare(b.time));
     for (const entry of fresh) writeFollowLine(entry, jsonMode);
     first = false;

--- a/packages/cli/src/cli/commands/project/logs.ts
+++ b/packages/cli/src/cli/commands/project/logs.ts
@@ -287,9 +287,9 @@ async function logsAction(
         "--until cannot be combined with --follow (a stream has no end).",
       );
     }
-    if (options.order?.toLowerCase() === "desc") {
+    if (options.order) {
       throw new InvalidInputError(
-        "--order desc cannot be combined with --follow (a live tail streams oldest to newest).",
+        "--order cannot be combined with --follow (a live tail always streams oldest to newest).",
       );
     }
     options.order = "asc"; // tail reads oldest -> newest

--- a/packages/cli/src/cli/commands/project/logs.ts
+++ b/packages/cli/src/cli/commands/project/logs.ts
@@ -287,6 +287,11 @@ async function logsAction(
         "--until cannot be combined with --follow (a stream has no end).",
       );
     }
+    if (options.order?.toLowerCase() === "desc") {
+      throw new InvalidInputError(
+        "--order desc cannot be combined with --follow (a live tail streams oldest to newest).",
+      );
+    }
     options.order = "asc"; // tail reads oldest -> newest
     return followLogs(
       functionNames,

--- a/packages/cli/tests/cli/logs.spec.ts
+++ b/packages/cli/tests/cli/logs.spec.ts
@@ -265,6 +265,38 @@ describe("logs command", () => {
     t.expectResult(result).toContain("No production logs found");
   });
 
+  it("rejects --follow combined with --order desc", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+
+    const result = await t.run(
+      "logs",
+      "--function",
+      "my-function",
+      "--follow",
+      "--order",
+      "desc",
+    );
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("--order desc cannot be combined");
+  });
+
+  it("rejects --follow combined with --until", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+
+    const result = await t.run(
+      "logs",
+      "--function",
+      "my-function",
+      "--follow",
+      "--until",
+      "1h",
+    );
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("--until cannot be combined");
+  });
+
   it("rejects an invalid --env value", async () => {
     await t.givenLoggedInWithProject(fixture("basic"));
 

--- a/packages/cli/tests/cli/logs.spec.ts
+++ b/packages/cli/tests/cli/logs.spec.ts
@@ -265,7 +265,7 @@ describe("logs command", () => {
     t.expectResult(result).toContain("No production logs found");
   });
 
-  it("rejects --follow combined with --order desc", async () => {
+  it("rejects --follow combined with --order", async () => {
     await t.givenLoggedInWithProject(fixture("basic"));
 
     const result = await t.run(
@@ -274,11 +274,11 @@ describe("logs command", () => {
       "my-function",
       "--follow",
       "--order",
-      "desc",
+      "asc",
     );
 
     t.expectResult(result).toFail();
-    t.expectResult(result).toContain("--order desc cannot be combined");
+    t.expectResult(result).toContain("--order cannot be combined");
   });
 
   it("rejects --follow combined with --until", async () => {

--- a/packages/cli/tests/cli/logs.spec.ts
+++ b/packages/cli/tests/cli/logs.spec.ts
@@ -1,5 +1,77 @@
 import { describe, expect, it } from "vitest";
+import {
+  type FollowState,
+  type LogEntry,
+  selectNewEntries,
+} from "@/cli/commands/project/logs.js";
 import { fixture, setupCLITests } from "./testkit/index.js";
+
+function entry(time: string, message: string): LogEntry {
+  return { time, level: "info", message, source: "fn" };
+}
+
+describe("selectNewEntries (follow dedup)", () => {
+  const empty: FollowState = { lastTime: "", boundaryKeys: new Set() };
+
+  it("returns all entries on the first poll and tracks the boundary", () => {
+    const entries = [
+      entry("2024-01-15T10:00:00Z", "a"),
+      entry("2024-01-15T10:00:01Z", "b"),
+    ];
+    const { fresh, nextState } = selectNewEntries(entries, empty);
+
+    expect(fresh).toHaveLength(2);
+    expect(nextState.lastTime).toBe("2024-01-15T10:00:01Z");
+    expect(nextState.boundaryKeys.has("2024-01-15T10:00:01Z b")).toBe(true);
+  });
+
+  it("drops entries already shown at the boundary timestamp", () => {
+    const first = selectNewEntries(
+      [entry("2024-01-15T10:00:01Z", "b")],
+      empty,
+    ).nextState;
+
+    // Next poll re-returns the boundary entry (inclusive since) plus a new one.
+    const { fresh, nextState } = selectNewEntries(
+      [entry("2024-01-15T10:00:01Z", "b"), entry("2024-01-15T10:00:02Z", "c")],
+      first,
+    );
+
+    expect(fresh.map((e) => e.message)).toEqual(["c"]);
+    expect(nextState.lastTime).toBe("2024-01-15T10:00:02Z");
+  });
+
+  it("keeps a new entry sharing the boundary timestamp", () => {
+    const first = selectNewEntries(
+      [entry("2024-01-15T10:00:01Z", "b")],
+      empty,
+    ).nextState;
+
+    const { fresh, nextState } = selectNewEntries(
+      [entry("2024-01-15T10:00:01Z", "b"), entry("2024-01-15T10:00:01Z", "b2")],
+      first,
+    );
+
+    expect(fresh.map((e) => e.message)).toEqual(["b2"]);
+    expect(nextState.boundaryKeys.has("2024-01-15T10:00:01Z b")).toBe(true);
+    expect(nextState.boundaryKeys.has("2024-01-15T10:00:01Z b2")).toBe(true);
+  });
+
+  it("returns nothing and preserves state when no new entries arrive", () => {
+    const first = selectNewEntries(
+      [entry("2024-01-15T10:00:01Z", "b")],
+      empty,
+    ).nextState;
+
+    const { fresh, nextState } = selectNewEntries(
+      [entry("2024-01-15T10:00:01Z", "b")],
+      first,
+    );
+
+    expect(fresh).toHaveLength(0);
+    expect(nextState).toBe(first);
+  });
+});
 
 describe("logs command", () => {
   const t = setupCLITests();

--- a/packages/cli/tests/cli/logs.spec.ts
+++ b/packages/cli/tests/cli/logs.spec.ts
@@ -31,7 +31,6 @@ describe("selectNewEntries (follow dedup)", () => {
       empty,
     ).nextState;
 
-    // Next poll re-returns the boundary entry (inclusive since) plus a new one.
     const { fresh, nextState } = selectNewEntries(
       [entry("2024-01-15T10:00:01Z", "b"), entry("2024-01-15T10:00:02Z", "c")],
       first,


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Adds a \`--follow\` (\`-f\`) flag to the \`logs\` command that streams new function logs live, polling every 2 seconds and printing only entries that haven't been shown yet. The flag forces ascending (oldest→newest) order and is mutually exclusive with \`--until\` and \`--order\`, since a live tail has no end and always streams in chronological order.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Add \`-f, --follow\` option to the \`logs\` command to stream new logs as they arrive.
> - Implement \`followLogs()\`, a polling loop (2s interval) that fetches logs, deduplicates already-seen entries, sorts them oldest→newest, and writes each line to stdout (JSON or formatted, respecting \`--json\`).
> - Add \`selectNewEntries()\` with \`FollowState\` (a \`lastTime\` watermark plus a \`boundaryKeys\` set) to track the timestamp boundary and avoid re-emitting entries that share the boundary timestamp across polls.
> - Reject \`--follow\` when combined with \`--until\` or \`--order\` (any value) via \`InvalidInputError\`; force \`order = "asc"\` internally for the tail.
> - Export \`LogEntry\`, \`FollowState\`, and \`selectNewEntries\` so the dedup logic can be unit-tested.
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [x] All tests pass (\`npm test\`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated \`docs/\` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> Unit tests cover the \`selectNewEntries\` dedup logic (first poll, boundary dedup, new entries sharing the boundary timestamp, and no-op polls), and CLI integration tests verify that \`--follow\` is rejected when combined with \`--order\` or \`--until\`.
>
> ---
> <sub>🤖 Generated by Claude | 2026-06-30 08:04 UTC | 01e80f2</sub>