### PR TITLE
feat(agents): support memory_config in baas agent config

### DIFF
--- a/packages/cli/src/core/resources/agent/schema.ts
+++ b/packages/cli/src/core/resources/agent/schema.ts
@@ -17,11 +17,19 @@ const ToolConfigSchema = z.union([
   BackendFunctionToolConfigSchema,
 ]);
 
+const MemoryConfigSchema = z.object({
+  enabled: z.boolean().default(true),
+  scope: z.enum(["global", "user", "both"]).default("both"),
+  include_other_conversation_context: z.boolean().default(false),
+  instructions: z.string().nullable().optional(),
+});
+
 export const AgentConfigSchema = z.looseObject({
   name: z.string().trim().min(1).max(100),
   description: z.string().trim().min(1, "Description is required"),
   instructions: z.string().trim().min(1, "Instructions are required"),
   tool_configs: z.array(ToolConfigSchema).optional().default([]),
+  memory_config: MemoryConfigSchema.optional(),
   whatsapp_greeting: z.string().nullable().optional(),
 });
 

--- a/packages/cli/templates/backend-and-client/base44/agents/task_manager.jsonc
+++ b/packages/cli/templates/backend-and-client/base44/agents/task_manager.jsonc
@@ -7,5 +7,13 @@
       "entity_name": "Task",
       "allowed_operations": ["read", "create", "update", "delete"]
     }
-  ]
+  ],
+  // Optional: let the agent remember facts across conversations.
+  // scope: "user" (per end-user), "global" (shared), or "both".
+  "memory_config": {
+    "enabled": true,
+    "scope": "both",
+    "include_other_conversation_context": false,
+    "instructions": null
+  }
 }

--- a/packages/cli/tests/core/agents-schema.spec.ts
+++ b/packages/cli/tests/core/agents-schema.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { AgentConfigSchema } from "@/core/resources/agent/schema.js";
+
+const baseAgent = {
+  name: "support",
+  description: "Help desk",
+  instructions: "Be helpful",
+};
+
+describe("AgentConfigSchema memory_config", () => {
+  it("fills backend-matching defaults for a partial memory_config", () => {
+    const result = AgentConfigSchema.safeParse({
+      ...baseAgent,
+      memory_config: { scope: "user" },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error("Expected agent config to parse");
+    }
+
+    // readAllAgents deploys the parsed object, so defaults here are what we push.
+    expect(result.data.memory_config).toEqual({
+      enabled: true,
+      scope: "user",
+      include_other_conversation_context: false,
+    });
+  });
+
+  it("accepts an agent without memory_config", () => {
+    const result = AgentConfigSchema.safeParse(baseAgent);
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error("Expected agent config to parse");
+    }
+    expect(result.data.memory_config).toBeUndefined();
+  });
+
+  it("rejects an unknown memory scope the backend also rejects", () => {
+    const result = AgentConfigSchema.safeParse({
+      ...baseAgent,
+      memory_config: { scope: "per_user" },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("preserves unknown pass-through fields (model, skills) via looseObject", () => {
+    const result = AgentConfigSchema.safeParse({
+      ...baseAgent,
+      model: "claude_sonnet_4_6",
+      selected_skill_names: ["billing-help"],
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error("Expected agent config to parse");
+    }
+    expect(result.data.model).toBe("claude_sonnet_4_6");
+    expect(result.data.selected_skill_names).toEqual(["billing-help"]);
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Adds support for an optional `memory_config` block in a Base44 agent's config, letting agents remember facts across conversations. The new field is validated with Zod (mirroring the backend's accepted shape and defaults) and documented inline in the scaffolding template so users can enable it out of the box.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added `MemoryConfigSchema` to `packages/cli/src/core/resources/agent/schema.ts` with `enabled` (default `true`), `scope` (`global` | `user` | `both`, default `both`), `include_other_conversation_context` (default `false`), and optional nullable `instructions`.
> - Wired the schema in as an optional `memory_config` field on `AgentConfigSchema`; unknown fields still pass through via `looseObject`.
> - Documented `memory_config` in the `task_manager.jsonc` scaffolding template with inline comments explaining the `scope` options.
> - Added unit tests covering default-filling, absence of the field, rejection of invalid scopes, and pass-through of unknown fields.
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [x] All tests pass (\`npm test\`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [x] I have commented my code, particularly in hard-to-understand areas
> - [x] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated \`docs/\` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The Zod defaults intentionally mirror the backend's accepted shape, since \`readAllAgents\` deploys the parsed object — so the filled defaults are exactly what gets pushed. \`instructions\` has no default and is omitted when not supplied.
>
> ---
> <sub>🤖 Generated by Claude | 2026-07-05 12:34 UTC | 14ada15</sub>