### PR TITLE
fix(logs): filter --level client-side when the backend ignores it

### DIFF
--- a/packages/cli/src/cli/commands/project/logs.ts
+++ b/packages/cli/src/cli/commands/project/logs.ts
@@ -223,8 +223,15 @@ async function fetchLogsForFunctions(
       throw error;
     }
 
+    // The backend does not filter by level for every runtime (per-app
+    // Cloudflare deployments return the full stream), so filter defensively
+    // here. Entry levels are already normalized by the response schema.
+    const matchingLogs = filters.level
+      ? logs.filter((entry) => entry.level === filters.level)
+      : logs;
+
     allEntries.push(
-      ...logs.map((entry) => normalizeLogEntry(entry, functionName)),
+      ...matchingLogs.map((entry) => normalizeLogEntry(entry, functionName)),
     );
   }
 

--- a/packages/cli/tests/cli/logs.spec.ts
+++ b/packages/cli/tests/cli/logs.spec.ts
@@ -333,6 +333,71 @@ describe("logs command", () => {
     t.expectResult(result).toContain("Error message");
   });
 
+  it("drops other levels client-side when the backend ignores --level", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    // The mock, like per-app Cloudflare deployments, ignores the level query
+    // param and returns the full stream.
+    t.api.mockFunctionLogs("my-function", [
+      {
+        time: "2024-01-15T10:30:00.050Z",
+        level: "error",
+        message: "Error message",
+      },
+      {
+        time: "2024-01-15T10:30:01.050Z",
+        level: "info",
+        message: "Info message",
+      },
+      {
+        time: "2024-01-15T10:30:02.050Z",
+        // The wire value predates schema normalization to "warning".
+        level: "warn" as "warning",
+        message: "Warn message normalized to warning",
+      },
+    ]);
+
+    const result = await t.run(
+      "logs",
+      "--function",
+      "my-function",
+      "--level",
+      "error",
+    );
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("Error message");
+    t.expectResult(result).toNotContain("Info message");
+    t.expectResult(result).toNotContain("Warn message");
+  });
+
+  it("keeps normalized warn entries when filtering by --level warning", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockFunctionLogs("my-function", [
+      {
+        time: "2024-01-15T10:30:00.050Z",
+        level: "warn" as "warning",
+        message: "Warn message",
+      },
+      {
+        time: "2024-01-15T10:30:01.050Z",
+        level: "info",
+        message: "Info message",
+      },
+    ]);
+
+    const result = await t.run(
+      "logs",
+      "--function",
+      "my-function",
+      "--level",
+      "warning",
+    );
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("Warn message");
+    t.expectResult(result).toNotContain("Info message");
+  });
+
   it("fails with invalid level option", async () => {
     await t.givenLoggedInWithProject(fixture("basic"));
 


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> The `base44 logs --level <level>` filter relied on the backend to honor the `level` query parameter, but not every runtime does — per-app Cloudflare deployments ignore it and return the full log stream. This PR adds a defensive client-side filter so `--level` is always respected regardless of backend behavior, using the schema-normalized entry levels for the comparison.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - In `fetchLogsForFunctions`, filter fetched log entries by `filters.level` client-side before normalizing/appending them, so results match the requested level even when the backend ignores the query param.
> - Rely on the response schema normalization (e.g. wire value `warn` → `warning`) so the comparison stays correct.
> - Added tests covering: dropping other levels when the backend returns the full stream, and keeping normalized `warn`→`warning` entries when filtering by `--level warning`.
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [x] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The filter is intentionally defensive: when the backend does correctly filter by level, this is a no-op; when it does not, the CLI now enforces the requested level. Level comparison uses the already-normalized values from the response schema.
>
> ---
> <sub>🤖 Generated by Claude | 2026-07-07 08:18 UTC | 234c4ed</sub>