### PR TITLE
fix(auth): deploy auth config with workspace keys

### DIFF
--- a/packages/cli/src/core/resources/auth-config/api.ts
+++ b/packages/cli/src/core/resources/auth-config/api.ts
@@ -1,4 +1,5 @@
 import type { KyResponse } from "ky";
+import { hasWorkspaceApiKeyAuth } from "@/core/auth/config.js";
 import { base44Client } from "@/core/clients/index.js";
 import { ApiError, SchemaValidationError } from "@/core/errors.js";
 import { getAppContext } from "@/core/project/index.js";
@@ -37,11 +38,24 @@ export async function pushAuthConfigToApi(
   config: AuthConfig,
 ): Promise<AuthConfig> {
   const { id } = getAppContext();
+  const payload = toAuthConfigPayload(config);
+
+  if (hasWorkspaceApiKeyAuth()) {
+    try {
+      await base44Client.put(`api/apps/${id}/deployment/auth-configuration`, {
+        json: payload,
+      });
+    } catch (error) {
+      throw await ApiError.fromHttpError(error, "updating auth config");
+    }
+
+    return config;
+  }
 
   let response: KyResponse;
   try {
     response = await base44Client.put(`api/apps/${id}`, {
-      json: { auth_config: toAuthConfigPayload(config) },
+      json: { auth_config: payload },
     });
   } catch (error) {
     throw await ApiError.fromHttpError(error, "updating auth config");

--- a/packages/cli/tests/cli/env-token-auth.spec.ts
+++ b/packages/cli/tests/cli/env-token-auth.spec.ts
@@ -1,3 +1,5 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { sign } from "jsonwebtoken";
 import { describe, expect, it } from "vitest";
 import { fixture, setupCLITests } from "./testkit/index.js";
@@ -150,6 +152,65 @@ describe("env credential seeding", () => {
 
     t.expectResult(result).toSucceed();
     t.expectResult(result).toContain("App deployed successfully");
+  });
+
+  it("pushes auth config through the deployment endpoint with a workspace API key", async () => {
+    await t.givenProject(fixture("with-entities"));
+    const authDir = join(t.getTempDir(), "project", "base44", "auth");
+    await mkdir(authDir, { recursive: true });
+    await writeFile(
+      join(authDir, "config.jsonc"),
+      JSON.stringify({
+        enableUsernamePassword: true,
+        enableGoogleLogin: false,
+        enableMicrosoftLogin: false,
+        enableFacebookLogin: false,
+        enableAppleLogin: false,
+        ssoProviderName: null,
+        enableSSOLogin: false,
+        googleOAuthMode: "default",
+        googleOAuthClientId: null,
+        useWorkspaceSSO: false,
+      }),
+    );
+
+    const workspaceApiKey =
+      "b44k_eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+    t.givenEnv({ BASE44_API_KEY: workspaceApiKey });
+    t.api.mockEntitiesPush({
+      created: ["Customer", "Product"],
+      updated: [],
+      deleted: [],
+    });
+    t.api.mockAgentsPush({ created: [], updated: [], deleted: [] });
+
+    let deploymentAuthConfigBody: unknown;
+    let deploymentApiKeyHeader: string | undefined;
+    let genericAppUpdateCalled = false;
+    t.api.mockRoute(
+      "PUT",
+      `/api/apps/${APP_ID}/deployment/auth-configuration`,
+      (req, res) => {
+        deploymentAuthConfigBody = req.body;
+        deploymentApiKeyHeader = req.headers.api_key as string | undefined;
+        res.status(200).json({ name: "auth_config", hash: "auth-hash" });
+      },
+    );
+    t.api.mockRoute("PUT", `/api/apps/${APP_ID}`, (_req, res) => {
+      genericAppUpdateCalled = true;
+      res.status(500).json({ error: "Unexpected generic app update" });
+    });
+
+    const result = await t.run("deploy", "-y");
+
+    t.expectResult(result).toSucceed();
+    expect(deploymentApiKeyHeader).toBe(workspaceApiKey);
+    expect(deploymentAuthConfigBody).toMatchObject({
+      enable_username_password: true,
+      enable_google_login: false,
+    });
+    expect(deploymentAuthConfigBody).not.toHaveProperty("auth_config");
+    expect(genericAppUpdateCalled).toBe(false);
   });
 
   it("ignores a non-workspace BASE44_API_KEY when OAuth auth exists", async () => {


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> When deploying with a workspace API key (`BASE44_API_KEY`), the auth config was being pushed through the generic app-update endpoint (`PUT api/apps/:id`), which workspace keys are not authorized to use. This PR routes auth-config pushes through the dedicated deployment endpoint (`PUT api/apps/:id/deployment/auth-configuration`) whenever workspace API key auth is in effect, so auth config deploys correctly in CI/automation contexts.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - `pushAuthConfigToApi` now checks `hasWorkspaceApiKeyAuth()` and, when true, sends the auth-config payload to the `deployment/auth-configuration` endpoint instead of the generic `api/apps/:id` update route.
> - Extracted the payload transform into a single `payload` variable reused across both code paths.
> - Preserved existing behavior (generic app-update endpoint with `{ auth_config: ... }`) for non-workspace-key auth.
> - Added an integration test verifying that with a workspace API key the auth config goes through the deployment endpoint (with the `api_key` header), the payload is snake_cased and not wrapped in `auth_config`, and the generic app-update route is never called.
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [ ] All tests pass (\`npm test\`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated \`docs/\` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The workspace-key path returns the original config object (not the API response) since the deployment endpoint returns a lightweight status payload rather than the full auth config. Error handling mirrors the existing path via \`ApiError.fromHttpError\`.
>
> ---
> <sub>🤖 Generated by Claude | 2026-07-13 08:06 UTC | 21ee30e</sub>