### PR TITLE
link: two-step workspace picker + cross-workspace --app-id

### DIFF
--- a/packages/cli/src/cli/commands/project/link.ts
+++ b/packages/cli/src/cli/commands/project/link.ts
@@ -10,6 +10,7 @@ import {
   theme,
 } from "@/cli/utils/index.js";
 import {
+  ApiError,
   ConfigExistsError,
   ConfigNotFoundError,
   InvalidInputError,
@@ -19,6 +20,7 @@ import {
   appConfigExists,
   createProject,
   findProjectRoot,
+  getApp,
   listProjects,
   setAppContext,
   writeAppConfig,
@@ -134,6 +136,76 @@ async function promptForExistingProject(projects: Project[]): Promise<Project> {
   return selectedProject;
 }
 
+/**
+ * Validate an explicit `--app-id` by fetching the app directly, so linking
+ * works for any app the user can access — not just ones in their personal
+ * workspace. Editor-created (managed-source) apps are linkable too (#577).
+ */
+async function resolveExplicitAppId(
+  ctx: CLIContext,
+  appId: string,
+): Promise<string> {
+  await ctx
+    .runTask("Validating app...", () => getApp(appId), {
+      errorMessage: "Could not validate app",
+    })
+    .catch((error) => {
+      if (
+        error instanceof ApiError &&
+        (error.statusCode === 404 || error.statusCode === 403)
+      ) {
+        throw new InvalidInputError(
+          `App "${appId}" not found, or you don't have access to it.`,
+          {
+            hints: [
+              { message: "Check the app ID is correct" },
+              {
+                message:
+                  "Run 'base44 link' without --app-id to browse apps by workspace",
+              },
+            ],
+          },
+        );
+      }
+      throw error;
+    });
+
+  return appId;
+}
+
+/**
+ * Interactive existing-app selection: pick a workspace (skipped when you're in
+ * only one), then pick an app scoped to that workspace. Returns undefined when
+ * the chosen workspace has no apps.
+ */
+async function chooseProjectInteractively(
+  ctx: CLIContext,
+  options: LinkOptions,
+): Promise<string | undefined> {
+  const workspaceId = await resolveWorkspaceId(
+    ctx,
+    options.workspace ?? options.org,
+    !ctx.isNonInteractive,
+    { promptMessage: "Which workspace is the app in?" },
+  );
+
+  const projects = await ctx.runTask(
+    "Fetching projects...",
+    () => listProjects({ workspaceId }),
+    {
+      successMessage: "Projects fetched",
+      errorMessage: "Failed to fetch projects",
+    },
+  );
+
+  if (!projects.length) {
+    return undefined;
+  }
+
+  const selectedProject = await promptForExistingProject(projects);
+  return selectedProject.id;
+}
+
 async function link(
   ctx: CLIContext,
   options: LinkOptions,
@@ -179,38 +251,14 @@ async function link(
       : await promptForLinkAction();
 
   if (action === "choose") {
-    const projects = await runTask(
-      "Fetching projects...",
-      async () => listProjects(),
-      {
-        successMessage: "Projects fetched",
-        errorMessage: "Failed to fetch projects",
-      },
-    );
+    // Explicit --app-id links any app you can access (validated directly),
+    // regardless of workspace. Otherwise pick a workspace, then an app in it.
+    const linkedAppId = appId
+      ? await resolveExplicitAppId(ctx, appId)
+      : await chooseProjectInteractively(ctx, options);
 
-    if (!projects.length) {
+    if (!linkedAppId) {
       return { outroMessage: "No projects available for linking" };
-    }
-
-    let linkedAppId: string;
-
-    if (appId) {
-      const project = projects.find((p) => p.id === appId);
-      if (!project) {
-        throw new InvalidInputError(`App with ID "${appId}" not found.`, {
-          hints: [
-            { message: "Check the app ID is correct" },
-            {
-              message:
-                "Use 'base44 link' without --app-id to see available projects",
-            },
-          ],
-        });
-      }
-      linkedAppId = appId;
-    } else {
-      const selectedProject = await promptForExistingProject(projects);
-      linkedAppId = selectedProject.id;
     }
 
     await runTask(
@@ -281,7 +329,7 @@ export function getLinkCommand(): Command {
       .option("-d, --description <description>", "Project description")
       .option(
         "-w, --workspace <id>",
-        "Workspace (organization) ID to create the app in when using --create (defaults to your personal workspace)",
+        "Workspace (organization) ID to scope the app picker to (or create the app in, with --create). Defaults to your personal workspace",
       )
       .addOption(
         new CommanderOption("--org <id>", "Alias for --workspace").hideHelp(),

--- a/packages/cli/src/cli/commands/project/workspace-select.ts
+++ b/packages/cli/src/cli/commands/project/workspace-select.ts
@@ -19,12 +19,14 @@ function workspaceLabel(workspace: WorkspaceListEntry): string {
 }
 
 /**
- * Resolve the workspace a new app should belong to.
+ * Resolve which workspace a command should target (creating an app in it, or
+ * scoping the app list for `link`). The server is the source of truth for
+ * permissions — the CLI never filters or validates by role:
  *
- * - `--workspace <id>` set: pass it straight through — the server authorizes
- *   creation in that workspace and returns a clear error if you can't.
+ * - `--workspace <id>` set: pass it straight through; the server returns a clear
+ *   error if you can't use it.
  * - interactive with more than one workspace: prompt to pick (no role filter;
- *   personal first). The server rejects a workspace you can't create in.
+ *   personal first).
  * - otherwise: return `undefined` so the server defaults to the personal
  *   workspace (no extra API call in the common single-workspace case).
  */
@@ -32,6 +34,7 @@ export async function resolveWorkspaceId(
   ctx: CLIContext,
   flagWorkspaceId: string | undefined,
   isInteractive: boolean,
+  options: { promptMessage?: string } = {},
 ): Promise<string | undefined> {
   if (flagWorkspaceId) {
     return flagWorkspaceId;
@@ -47,14 +50,15 @@ export async function resolveWorkspaceId(
     return undefined;
   }
 
-  const options: PromptOption<string>[] = workspaces.map((w) => ({
+  const promptOptions: PromptOption<string>[] = workspaces.map((w) => ({
     value: w.id,
     label: workspaceLabel(w),
   }));
 
   const selected = await select({
-    message: "Which workspace should this app belong to?",
-    options,
+    message:
+      options.promptMessage ?? "Which workspace should this app belong to?",
+    options: promptOptions,
     initialValue: workspaces[0].id,
   });
 

--- a/packages/cli/src/core/project/api.ts
+++ b/packages/cli/src/core/project/api.ts
@@ -78,7 +78,9 @@ export async function setAppVisibility(
   }
 }
 
-export async function listProjects(): Promise<ProjectsResponse> {
+export async function listProjects(
+  options: { workspaceId?: string } = {},
+): Promise<ProjectsResponse> {
   let response: KyResponse;
   try {
     response = await base44Client.get("api/apps", {
@@ -86,6 +88,9 @@ export async function listProjects(): Promise<ProjectsResponse> {
         sort: "-updated_date",
         fields: "id,name,user_description,is_managed_source_code",
         limit: 50,
+        // Scope to a specific workspace when given; otherwise the server
+        // scopes to the caller's active/personal workspace.
+        ...(options.workspaceId ? { workspace_id: options.workspaceId } : {}),
       },
     });
   } catch (error) {

--- a/packages/cli/tests/cli/link.spec.ts
+++ b/packages/cli/tests/cli/link.spec.ts
@@ -44,13 +44,11 @@ describe("link command", () => {
 
   it("links an existing app with --app-id", async () => {
     await t.givenLoggedInWithProject(fixture("no-app-config"));
-    t.api.mockListProjects([
-      {
-        id: "existing-app-id",
-        name: "Existing App",
-        is_managed_source_code: false,
-      },
-    ]);
+    t.api.mockGetApp({
+      id: "existing-app-id",
+      name: "Existing App",
+      is_managed_source_code: false,
+    });
 
     const result = await t.run("link", "--app-id", "existing-app-id");
 
@@ -67,13 +65,11 @@ describe("link command", () => {
 
   it("links an editor-created app (managed source code)", async () => {
     await t.givenLoggedInWithProject(fixture("no-app-config"));
-    t.api.mockListProjects([
-      {
-        id: "editor-app-id",
-        name: "Editor App",
-        is_managed_source_code: true,
-      },
-    ]);
+    t.api.mockGetApp({
+      id: "editor-app-id",
+      name: "Editor App",
+      is_managed_source_code: true,
+    });
 
     const result = await t.run("link", "--app-id", "editor-app-id");
 
@@ -82,15 +78,42 @@ describe("link command", () => {
     t.expectResult(result).toContain("editor-app-id");
   });
 
+  it("links an app that lives in another workspace via --app-id", async () => {
+    await t.givenLoggedInWithProject(fixture("no-app-config"));
+    // An app whose organization_id is a workspace other than the caller's
+    // personal one — previously unreachable because the picker was
+    // personal-scoped. Now validated directly via getApp.
+    t.api.mockGetApp({
+      id: "other-ws-app",
+      name: "Team App",
+      organization_id: "ws-team",
+      is_managed_source_code: false,
+    });
+
+    const result = await t.run("link", "--app-id", "other-ws-app");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("Project linked");
+    t.expectResult(result).toContain("other-ws-app");
+  });
+
+  it("fails with a clear message when --app-id is not found", async () => {
+    await t.givenLoggedInWithProject(fixture("no-app-config"));
+    // No mockGetApp registered → server 404.
+
+    const result = await t.run("link", "--app-id", "does-not-exist");
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("not found");
+  });
+
   it("links an existing app with legacy --project-id", async () => {
     await t.givenLoggedInWithProject(fixture("no-app-config"));
-    t.api.mockListProjects([
-      {
-        id: "legacy-app-id",
-        name: "Legacy App",
-        is_managed_source_code: false,
-      },
-    ]);
+    t.api.mockGetApp({
+      id: "legacy-app-id",
+      name: "Legacy App",
+      is_managed_source_code: false,
+    });
 
     const result = await t.run("link", "--project-id", "legacy-app-id");
 
@@ -101,13 +124,11 @@ describe("link command", () => {
 
   it("links an existing app with legacy --projectId", async () => {
     await t.givenLoggedInWithProject(fixture("no-app-config"));
-    t.api.mockListProjects([
-      {
-        id: "camel-legacy-app-id",
-        name: "Camel Legacy App",
-        is_managed_source_code: false,
-      },
-    ]);
+    t.api.mockGetApp({
+      id: "camel-legacy-app-id",
+      name: "Camel Legacy App",
+      is_managed_source_code: false,
+    });
 
     const result = await t.run("link", "--projectId", "camel-legacy-app-id");
 

--- a/packages/cli/tests/cli/testkit/TestAPIServer.ts
+++ b/packages/cli/tests/cli/testkit/TestAPIServer.ts
@@ -593,6 +593,17 @@ export class TestAPIServer {
     return this.addRoute("GET", "/api/apps", response);
   }
 
+  /** Mock GET /api/apps/{appId} - Fetch a single app's details. Keyed off the
+   * response's own `id`, so tests can mock apps other than the context app. */
+  mockGetApp(response: {
+    id: string;
+    name?: string;
+    organization_id?: string | null;
+    is_managed_source_code?: boolean;
+  }): this {
+    return this.addRoute("GET", `/api/apps/${response.id}`, response);
+  }
+
   /** Mock GET /api/workspace/workspaces - List the user's workspaces */
   mockListWorkspaces(workspaces: WorkspaceResponse[]): this {
     return this.addRoute("GET", "/api/workspace/workspaces", { workspaces });


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Reworks the existing-app selection in `base44 link` to be workspace-aware. Interactive linking becomes a two-step flow — pick a workspace (skipped when you belong to only one), then pick an app scoped to that workspace — instead of listing only apps in your personal/active workspace. `--app-id` is now validated directly via `getApp` rather than being looked up in the app list, so it links **any** app you can access, including apps in other workspaces. The server remains the source of truth for permissions; the CLI never filters or validates by role.
>
> ## Related Issue
>
> Builds on #577 (`fix(link): list editor-created apps for linking`), which landed on `main` while this PR was open — editor-created (managed-source) apps stay linkable here. No issue is closed by this PR.
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - **`link.ts`** — extracted the `choose` branch into two helpers:
>   - `resolveExplicitAppId()` validates `--app-id` by fetching the app directly (`getApp`), making cross-workspace apps linkable; 404/403 surface an `InvalidInputError` with hints ("Check the app ID is correct", "Run `base44 link` without `--app-id` to browse apps by workspace").
>   - `chooseProjectInteractively()` resolves the target workspace via `resolveWorkspaceId()`, then fetches and prompts for an app scoped to that workspace; returns `undefined` when the workspace has no apps (falls through to the existing "No projects available for linking" outro).
> - **`workspace-select.ts`** — `resolveWorkspaceId()` takes an optional `{ promptMessage }` so `link` can ask "Which workspace is the app in?" instead of the create-oriented wording; the local `options` variable was renamed to `promptOptions` to avoid shadowing. Doc comment updated to cover both the create and link cases.
> - **`core/project/api.ts`** — `listProjects()` accepts an optional `{ workspaceId }` and forwards it as the `workspace_id` search param on `GET /api/apps`; omitted means the server scopes to the caller's active/personal workspace.
> - **`--workspace/-w` help text** — now documents that the flag also scopes the app picker, not just app creation.
> - **Tests** — added `TestAPIServer.mockGetApp()` (routes on the response's own `id`, so tests can mock apps other than the context app); `link.spec.ts` switched from `mockListProjects` to `mockGetApp` for the `--app-id` / legacy `--project-id` / `--projectId` cases, plus new coverage for linking an app in another workspace and for the not-found (404) error path.
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [x] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [ ] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> - Backwards compatible: legacy `--project-id` / `--projectId` aliases and the `--org` alias for `--workspace` still work, and non-interactive runs are unaffected (`resolveWorkspaceId` returns `undefined`, so the server applies its default).
> - Behavioral note vs. the pre-rebase version of this PR: the managed-source filter and the `--app-id` managed-source rejection were dropped to honor #577, so editor-created apps remain linkable. `main`'s editor-created-app test is kept, adapted to `mockGetApp`.
> - No `docs/` updates: this is a behavior change inside an existing command rather than an architectural one; command help text was updated in place.
> - The test-run boxes are left unchecked because the suite was not executed in this analysis environment — only the diff was reviewed.
>
> ---
> <sub>🤖 Generated by Claude | 2026-08-02 09:37 UTC | c08ba20</sub>