### PR TITLE
feat(exec): run scripts against the local dev server with --local

### DIFF
--- a/packages/cli/src/cli/commands/exec.ts
+++ b/packages/cli/src/cli/commands/exec.ts
@@ -1,8 +1,16 @@
 import type { Command } from "commander";
+import { createJwtToken } from "@/cli/dev/dev-server/auth/tokens.js";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";
 import { Base44Command } from "@/cli/utils/index.js";
+import { DEFAULT_DEV_SERVER_PORT } from "@/core/consts.js";
 import { InvalidInputError } from "@/core/errors.js";
 import { runScript } from "@/core/exec/index.js";
+import { readAuth } from "@/core/index.js";
+
+interface ExecOptions {
+  local?: boolean;
+  port?: string;
+}
 
 function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -16,10 +24,42 @@ function readStdin(): Promise<string> {
   });
 }
 
-async function execAction({
-  app,
-  isNonInteractive,
-}: CLIContext): Promise<RunCommandResult> {
+function parsePort(value: string): number {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new InvalidInputError(`Invalid --port value: "${value}".`, {
+      hints: [{ message: "Pass a port number, e.g. --port 4400" }],
+    });
+  }
+  return port;
+}
+
+/**
+ * Resolve the local `base44 dev` target: the SDK talks to
+ * `http://localhost:<port>` authenticated as the current user via a
+ * locally-minted dev JWT. The dev server decodes (does not verify) the token,
+ * and seeds the current user as an admin, so this matches the local session.
+ */
+async function resolveLocalTarget(
+  port: number,
+): Promise<{ serverUrl: string; token: string }> {
+  const { email } = await readAuth();
+  return {
+    serverUrl: `http://localhost:${port}`,
+    token: createJwtToken(email),
+  };
+}
+
+async function execAction(
+  { app, isNonInteractive }: CLIContext,
+  options: ExecOptions,
+): Promise<RunCommandResult> {
+  if (options.port !== undefined && !options.local) {
+    throw new InvalidInputError("--port can only be used with --local.", {
+      hints: [{ message: "Usage: base44 exec --local --port <port>" }],
+    });
+  }
+
   const noInputError = new InvalidInputError(
     "No input provided. Pipe a script to stdin.",
     {
@@ -43,7 +83,15 @@ async function execAction({
     throw noInputError;
   }
 
-  const { exitCode } = await runScript({ appId: app!.id, code });
+  const local = options.local
+    ? await resolveLocalTarget(
+        options.port !== undefined
+          ? parsePort(options.port)
+          : DEFAULT_DEV_SERVER_PORT,
+      )
+    : undefined;
+
+  const { exitCode } = await runScript({ appId: app!.id, code, local });
 
   if (exitCode !== 0) {
     process.exitCode = exitCode;
@@ -57,6 +105,14 @@ export function getExecCommand(): Command {
     .description(
       "Run a script with the Base44 SDK pre-authenticated as the current user",
     )
+    .option(
+      "--local",
+      "Run against the local `base44 dev` server instead of the deployed app",
+    )
+    .option(
+      "--port <number>",
+      `Port the local dev server is on (with --local; defaults to ${DEFAULT_DEV_SERVER_PORT})`,
+    )
     .addHelpText(
       "after",
       `
@@ -65,9 +121,10 @@ Examples:
     $ cat ./script.ts | base44 exec
 
   Inline script:
-    $ echo "const users = await base44.entities.User.list()" | base44 exec`,
+    $ echo "const users = await base44.entities.User.list()" | base44 exec
+
+  Against the local dev server (base44 dev must be running):
+    $ echo "await base44.entities.Task.create({ title: 'seed' })" | base44 exec --local`,
     )
-    .action(async (ctx: CLIContext) => {
-      return await execAction(ctx);
-    });
+    .action(execAction);
 }

--- a/packages/cli/src/core/consts.ts
+++ b/packages/cli/src/core/consts.ts
@@ -30,6 +30,15 @@ export const PROJECT_CONFIG_PATTERNS = [
 // Environment variables
 export const BASE44_APP_ID_ENV_VAR = "BASE44_APP_ID";
 
+// Local development server
+/**
+ * Default port the local `base44 dev` server binds to. `exec --local` targets
+ * this port unless `--port` is passed.
+ * NOTE: keep in sync with `DEFAULT_PORT` in `cli/dev/dev-server/main.ts` (that
+ * module owns the dev server and could later import this constant).
+ */
+export const DEFAULT_DEV_SERVER_PORT = 4400;
+
 // Types generation
 export const TYPES_OUTPUT_SUBDIR = ".types";
 export const TYPES_FILENAME = "types.d.ts";

--- a/packages/cli/src/core/exec/run-script.ts
+++ b/packages/cli/src/core/exec/run-script.ts
@@ -8,6 +8,12 @@ import { verifyDenoInstalled } from "@/core/utils/index.js";
 interface RunScriptOptions {
   appId: string;
   code: string;
+  /**
+   * When set, run against a local `base44 dev` server instead of the remote
+   * published app: the SDK's `serverUrl` and access token are taken from here
+   * rather than fetched via `getSiteUrl()` / `getAppUserToken()`.
+   */
+  local?: { serverUrl: string; token: string };
 }
 
 interface RunScriptResult {
@@ -17,7 +23,7 @@ interface RunScriptResult {
 export async function runScript(
   options: RunScriptOptions,
 ): Promise<RunScriptResult> {
-  const { appId, code } = options;
+  const { appId, code, local } = options;
 
   verifyDenoInstalled("to run scripts with exec");
 
@@ -28,10 +34,11 @@ export async function runScript(
   writeFileSync(tempScript.path, code, "utf-8");
   const scriptPath = `file://${tempScript.path}`;
 
-  const [appUserToken, appBaseUrl] = await Promise.all([
-    getAppUserToken(),
-    getSiteUrl(),
-  ]);
+  // Local mode uses the caller-provided token + local server URL; remote mode
+  // fetches the app-user token and the published site URL.
+  const [appUserToken, appBaseUrl] = local
+    ? [local.token, local.serverUrl]
+    : await Promise.all([getAppUserToken(), getSiteUrl()]);
 
   // Copy the exec wrapper to a temp location outside node_modules.
   // This works with both Deno 1.x and 2.x, but is required for Deno 2.x

--- a/packages/cli/tests/cli/exec.spec.ts
+++ b/packages/cli/tests/cli/exec.spec.ts
@@ -125,4 +125,54 @@ describe("exec command", () => {
 
     expect(result.exitCode).toBe(42);
   });
+
+  // ─── LOCAL DEV SERVER (--local) ──────────────────────────────
+
+  it("targets the local dev server with a local user JWT when --local is set", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    // The TestAPIServer stands in for `base44 dev`; point --local at its port.
+    // No mockAuthToken / mockSiteUrl: local mode must NOT call the remote
+    // token/published-url endpoints (it would 404 here if it did).
+    const port = new URL(t.api.baseUrl).port;
+
+    let capturedAuth: string | undefined;
+    t.api.mockRoute(
+      "GET",
+      `/api/apps/${t.api.appId}/entities/Task`,
+      (req, res) => {
+        capturedAuth = req.headers.authorization;
+        res.json([{ id: "1", title: "Local Task" }]);
+      },
+    );
+
+    t.givenStdin(
+      "const tasks = await base44.entities.Task.list();\n" +
+        "console.log(JSON.stringify(tasks));",
+    );
+
+    const result = await t.run("exec", "--local", "--port", port);
+
+    t.expectResult(result).toSucceed();
+    expect(result.stdout).toContain('{"id":"1","title":"Local Task"}');
+    // Local auth is a JWT minted for the current user, not the remote app-user
+    // token — decode the `sub` claim to prove it.
+    expect(capturedAuth?.startsWith("Bearer ")).toBe(true);
+    const jwtPayload = JSON.parse(
+      Buffer.from(
+        capturedAuth!.slice("Bearer ".length).split(".")[1],
+        "base64url",
+      ).toString(),
+    );
+    expect(jwtPayload.sub).toBe("test@example.com");
+  });
+
+  it("rejects --port without --local", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.givenStdin("console.log(1)");
+
+    const result = await t.run("exec", "--port", "4400");
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("--port can only be used with --local");
+  });
 });


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Adds a `--local` flag to `base44 exec` so scripts can run against a locally running `base44 dev` server instead of the deployed app. When `--local` is set, the SDK targets `http://localhost:<port>` authenticated as the current user via a locally-minted dev JWT (the dev server decodes and seeds that user as admin). An optional `--port` flag overrides the default dev server port (4400). This makes it easy to seed data and iterate against a local dev environment without deploying.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added `--local` and `--port <number>` options to `base44 exec` (`cli/commands/exec.ts`).
> - `resolveLocalTarget()` mints a dev JWT for the current authenticated user (via `createJwtToken`) and points the SDK at `http://localhost:<port>`.
> - `parsePort()` validates the port is an integer in `1–65535`, throwing `InvalidInputError` otherwise; `--port` without `--local` is also rejected.
> - Extended `runScript()` (`core/exec/run-script.ts`) with an optional `local` target: local mode uses the provided token + local server URL instead of fetching the remote app-user token and published site URL.
> - Added `DEFAULT_DEV_SERVER_PORT` (4400) to `core/consts.ts`, kept in sync with the dev server's `DEFAULT_PORT`.
> - Updated `exec` help text with a `--local` usage example.
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [x] All tests pass (\`npm test\`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [x] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated \`docs/\` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> Two new tests in \`tests/cli/exec.spec.ts\` cover the local path: one asserts the request carries a Bearer JWT whose \`sub\` is the current user's email (not the remote app-user token), and one asserts \`--port\` without \`--local\` is rejected. No \`docs/\` changes were needed since this extends an existing command rather than changing architecture.
>
> ---
> <sub>🤖 Generated by Claude | 2026-07-20 10:38 UTC | 0f0eefe</sub>