### PR TITLE
fix(dev): scaffold apps with the injected local dev server URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - App visibility: `base44 visibility <public|private|workspace>` sets it on the server directly (accepts `--app-id` to target any app). Also configurable via `"visibility"` in `config.jsonc`, which `base44 deploy` applies. New projects scaffold `"visibility": "public"`.
 
+### Fixed
+
+- Newly scaffolded apps talk to the local dev backend under `base44 dev`: the generated client reads the `VITE_BASE44_APP_BASE_URL` env var the dev server injects, falling back to the production server when unset (e.g. plain `npm run dev`).
+
 ## [0.0.51] - 2026-04-28
 
 ### Added

--- a/packages/cli/templates/backend-and-client/src/api/base44Client.js.ejs
+++ b/packages/cli/templates/backend-and-client/src/api/base44Client.js.ejs
@@ -2,4 +2,8 @@ import { createClient } from '@base44/sdk';
 
 export const base44 = createClient({
   appId: '<%= projectId %>',
+  // `base44 dev` injects VITE_BASE44_APP_BASE_URL (http://localhost:<port>) so the
+  // SDK targets the local dev backend; unset in prod builds, so it falls back to
+  // the SDK's default server.
+  serverUrl: import.meta.env.VITE_BASE44_APP_BASE_URL || undefined,
 });

--- a/packages/cli/tests/cli/create.spec.ts
+++ b/packages/cli/tests/cli/create.spec.ts
@@ -76,6 +76,34 @@ describe("create command", () => {
     expect(config).toContain('"visibility": "public"');
   });
 
+  it("scaffolds a client that targets the dev server URL injected by base44 dev", async () => {
+    await t.givenLoggedIn({ email: "test@example.com", name: "Test User" });
+    t.api.mockCreateApp({ id: "dev-url-app-id", name: "Dev Url App" });
+
+    const projectPath = join(t.getTempDir(), "dev-url-app");
+
+    const result = await t.run(
+      "create",
+      "Dev Url App",
+      "--path",
+      projectPath,
+      "--template",
+      "backend-and-client",
+      "--no-skills",
+    );
+
+    t.expectResult(result).toSucceed();
+
+    const client = await readFile(
+      join(projectPath, "src", "api", "base44Client.js"),
+      "utf-8",
+    );
+    expect(client).toContain("dev-url-app-id");
+    expect(client).toContain(
+      "serverUrl: import.meta.env.VITE_BASE44_APP_BASE_URL || undefined",
+    );
+  });
+
   it("infers path from name when --path is not provided", async () => {
     await t.givenLoggedIn({ email: "test@example.com", name: "Test User" });
     t.api.mockCreateApp({ id: "inferred-path-id", name: "My App" });


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Newly scaffolded `backend-and-client` apps hardcoded no `serverUrl`, so the generated `@base44/sdk` client always talked to the production Base44 server — even when running under `base44 dev`, which spins up a local backend. This PR makes the scaffolded client read the `VITE_BASE44_APP_BASE_URL` env var that the dev server already injects into the `site.serveCommand` process, falling back to the SDK default when the var is unset (plain `npm run dev`, production builds). No CLI code changes are needed; the dev server already exports the variable in `packages/cli/src/cli/dev/dev-server/main.ts`.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - `packages/cli/templates/backend-and-client/src/api/base44Client.js.ejs`: pass `serverUrl: import.meta.env.VITE_BASE44_APP_BASE_URL || undefined` to `createClient()`, with a comment explaining the dev-vs-prod behavior.
> - `packages/cli/tests/cli/create.spec.ts`: new integration test asserting that `base44 create --template backend-and-client` scaffolds `src/api/base44Client.js` containing both the app id and the `serverUrl` env-var read.
> - `CHANGELOG.md`: added a `### Fixed` entry under the unreleased section.
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [x] I have commented my code, particularly in hard-to-understand areas
> - [x] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The fallback is `|| undefined` rather than an empty string so the SDK applies its own default server URL instead of receiving a falsy override. Only the `backend-and-client` template is affected; other templates do not generate an SDK client. The test suite was not executed in this environment (build/test commands were unavailable), so the "tested locally" and "all tests pass" boxes are left unchecked pending CI.
>
> ---
> <sub>🤖 Generated by Claude | 2026-07-27 09:01 UTC | 7e17867</sub>