### PR TITLE
feat(dev): show where to open the app in the browser

### DIFF
--- a/packages/cli/src/cli/commands/dev.ts
+++ b/packages/cli/src/cli/commands/dev.ts
@@ -53,7 +53,7 @@ async function devAction(
   });
 
   const outroMessage = isServingFrontend
-    ? "Open your app using the frontend dev server URL"
+    ? "Open your app in the browser once the frontend URL is printed"
     : `Dev server is available at ${theme.colors.links(localServerUrl(resolvedPort))}`;
 
   return { outroMessage };

--- a/packages/cli/src/cli/dev/dev-server/main.ts
+++ b/packages/cli/src/cli/dev/dev-server/main.ts
@@ -258,6 +258,10 @@ export async function createDevServer(
         VITE_BASE44_APP_BASE_URL: baseUrl,
       },
       logger: createDevLogger("frontend", theme.colors.base44Orange),
+      onUrl: (url) =>
+        devLogger.log(
+          `Open your app in the browser: ${theme.colors.links(url)}`,
+        ),
     });
   }
 

--- a/packages/cli/src/cli/dev/dev-server/serve-runner.ts
+++ b/packages/cli/src/cli/dev/dev-server/serve-runner.ts
@@ -8,13 +8,19 @@ interface ServeRunnerOptions {
   cwd: string;
   env: Record<string, string>;
   logger: DevLogger;
+  /** Called once with the first local URL the serve command prints (e.g. Vite's). */
+  onUrl?: (url: string) => void;
 }
+
+const LOCALHOST_URL = /https?:\/\/(?:localhost|127\.0\.0\.1):\d+/;
 
 export class ServeRunner {
   private readonly command: string;
   private readonly cwd: string;
   private readonly env: Record<string, string>;
   private readonly logger: DevLogger;
+  private readonly onUrl?: (url: string) => void;
+  private urlReported = false;
   private child?: ChildProcess;
   private stopping = false;
   private stopPromise?: Promise<void>;
@@ -25,6 +31,7 @@ export class ServeRunner {
     this.cwd = options.cwd;
     this.env = options.env;
     this.logger = options.logger;
+    this.onUrl = options.onUrl;
   }
 
   start(): void {
@@ -121,7 +128,19 @@ export class ServeRunner {
         this.logger.error(line);
       } else {
         this.logger.log(line);
+        this.reportUrl(line);
       }
+    }
+  }
+
+  private reportUrl(line: string): void {
+    if (this.urlReported || !this.onUrl) {
+      return;
+    }
+    const match = line.match(LOCALHOST_URL);
+    if (match) {
+      this.urlReported = true;
+      this.onUrl(match[0]);
     }
   }
 }

--- a/packages/cli/tests/cli/dev.spec.ts
+++ b/packages/cli/tests/cli/dev.spec.ts
@@ -100,6 +100,8 @@ describe("dev command", () => {
     expect(output).toContain("[frontend]");
     // The backend is announced (labeled) before the frontend output.
     expect(output).toContain("Backend running on http://localhost:");
+    // The frontend URL sniffed from the serve output is surfaced to the user.
+    expect(output).toContain("Open your app in the browser:");
   });
 
   it("tears the dev server down when the frontend exits", async () => {

--- a/packages/cli/tests/cli/serve-runner.spec.ts
+++ b/packages/cli/tests/cli/serve-runner.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DevLogger } from "@/cli/dev/createDevLogger.js";
+import { ServeRunner } from "@/cli/dev/dev-server/serve-runner.js";
+
+const noopLogger: DevLogger = {
+  log: () => {},
+  error: () => {},
+  warn: () => {},
+};
+
+describe("ServeRunner", () => {
+  it("reports the first localhost URL the serve command prints", async () => {
+    const urls: string[] = [];
+    const runner = new ServeRunner({
+      command: `node -e "console.log('  Local:   http://localhost:5173/'); console.log('  Network: http://localhost:5174/')"`,
+      cwd: process.cwd(),
+      env: {},
+      logger: noopLogger,
+      onUrl: (url) => urls.push(url),
+    });
+
+    runner.start();
+
+    await vi.waitFor(() => expect(urls).toEqual(["http://localhost:5173"]));
+    await runner.stop();
+  });
+
+  it("does not report a URL when the serve output has none", async () => {
+    const urls: string[] = [];
+    const exited = new Promise<void>((resolve) => {
+      const runner = new ServeRunner({
+        command: `node -e "console.log('starting up, nothing to open')"`,
+        cwd: process.cwd(),
+        env: {},
+        logger: noopLogger,
+        onUrl: (url) => urls.push(url),
+      });
+      runner.onExit(() => resolve());
+      runner.start();
+    });
+
+    await exited;
+    expect(urls).toEqual([]);
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> When running the dev server with a frontend (`base44 dev`), the CLI now sniffs the first `localhost` URL that the frontend serve command prints (e.g. Vite's dev URL) and surfaces it to the user with a clear "Open your app in the browser" message. This removes the guesswork of having to scan the raw serve output to find where the app is being served, and updates the outro to point at the printed frontend URL.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [x] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Added an optional `onUrl` callback to `ServeRunner` that fires once with the first `localhost`/`127.0.0.1` URL matched in the serve command's stdout.
> - `ServeRunner` now scans each logged line via a `LOCALHOST_URL` regex and reports the URL a single time (guarded by a `urlReported` flag).
> - Wired the callback in `createDevServer` (`main.ts`) to log \"Open your app in the browser: <url>\" through the frontend dev logger.
> - Updated the `dev` command outro message to \"Open your app in the browser once the frontend URL is printed\".
> - Added a dedicated `serve-runner.spec.ts` unit test and extended `dev.spec.ts` to assert the frontend URL is surfaced.
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [x] All tests pass (\`npm test\`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [x] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated \`docs/\` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> Only the first URL is reported (subsequent lines are ignored via the \`urlReported\` guard), and the callback is optional so non-frontend serve runners are unaffected. When the serve output contains no localhost URL, nothing is reported.
>
> ---
> <sub>🤖 Generated by Claude | 2026-07-23 08:24 UTC | 218ee97</sub>