### PR TITLE
fix(link): list editor-created apps for linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - App visibility: `base44 visibility <public|private|workspace>` sets it on the server directly (accepts `--app-id` to target any app). Also configurable via `"visibility"` in `config.jsonc`, which `base44 deploy` applies. New projects scaffold `"visibility": "public"`.
 
+### Fixed
+
+- `base44 link` now lists editor-created apps; previously only apps created by the CLI could be linked.
+
 ## [0.0.51] - 2026-04-28
 
 ### Added

--- a/packages/cli/src/cli/commands/project/link.ts
+++ b/packages/cli/src/cli/commands/project/link.ts
@@ -68,7 +68,7 @@ async function promptForLinkAction(): Promise<LinkAction> {
   actionOptions.push({
     value: "choose",
     label: "Link an existing project",
-    hint: "Choose from one of your available projects previously created by the Base44 CLI",
+    hint: "Choose from one of your existing Base44 apps",
   });
 
   const action = await select({
@@ -115,15 +115,11 @@ async function promptForNewProjectDetails() {
   };
 }
 
-async function promptForExistingProject(
-  linkableProjects: Project[],
-): Promise<Project> {
-  const projectOptions: PromptOption<Project>[] = linkableProjects.map(
-    (project) => ({
-      value: project,
-      label: project.name,
-    }),
-  );
+async function promptForExistingProject(projects: Project[]): Promise<Project> {
+  const projectOptions: PromptOption<Project>[] = projects.map((project) => ({
+    value: project,
+    label: project.name,
+  }));
 
   const selectedProject = await select({
     message: "Choose a project to link",
@@ -192,36 +188,28 @@ async function link(
       },
     );
 
-    const linkableProjects = projects.filter(
-      (p) => p.isManagedSourceCode !== true,
-    );
-
-    if (!linkableProjects.length) {
+    if (!projects.length) {
       return { outroMessage: "No projects available for linking" };
     }
 
     let linkedAppId: string;
 
     if (appId) {
-      // Validate that the provided app ID exists and is linkable
-      const project = linkableProjects.find((p) => p.id === appId);
+      const project = projects.find((p) => p.id === appId);
       if (!project) {
-        throw new InvalidInputError(
-          `App with ID "${appId}" not found or not available for linking.`,
-          {
-            hints: [
-              { message: "Check the app ID is correct" },
-              {
-                message:
-                  "Use 'base44 link' without --app-id to see available projects",
-              },
-            ],
-          },
-        );
+        throw new InvalidInputError(`App with ID "${appId}" not found.`, {
+          hints: [
+            { message: "Check the app ID is correct" },
+            {
+              message:
+                "Use 'base44 link' without --app-id to see available projects",
+            },
+          ],
+        });
       }
       linkedAppId = appId;
     } else {
-      const selectedProject = await promptForExistingProject(linkableProjects);
+      const selectedProject = await promptForExistingProject(projects);
       linkedAppId = selectedProject.id;
     }
 

--- a/packages/cli/tests/cli/link.spec.ts
+++ b/packages/cli/tests/cli/link.spec.ts
@@ -65,6 +65,23 @@ describe("link command", () => {
     expect(appConfig).toContain("existing-app-id");
   });
 
+  it("links an editor-created app (managed source code)", async () => {
+    await t.givenLoggedInWithProject(fixture("no-app-config"));
+    t.api.mockListProjects([
+      {
+        id: "editor-app-id",
+        name: "Editor App",
+        is_managed_source_code: true,
+      },
+    ]);
+
+    const result = await t.run("link", "--app-id", "editor-app-id");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("Project linked");
+    t.expectResult(result).toContain("editor-app-id");
+  });
+
   it("links an existing app with legacy --project-id", async () => {
     await t.givenLoggedInWithProject(fixture("no-app-config"));
     t.api.mockListProjects([


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> `base44 link` filtered the app list to `isManagedSourceCode !== true`, so apps created in the Base44 editor were invisible to the picker and were rejected by `--app-id` with "not available for linking". That filter no longer matches product direction — the platform's own repo migration gitignores `base44/.app.jsonc` and tells users to run `base44 link`, and its `ensure_cli_configs` codemod injects `base44/config.jsonc` into editor apps' repos precisely so the CLI can consume them. This PR drops the filter so every app the user owns is listable and linkable.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - `packages/cli/src/cli/commands/project/link.ts`: removed the `isManagedSourceCode !== true` filter — the "Link an existing project" picker and `--app-id` now operate on the full project list returned by the API (still bounded by the existing 50-app page).
> - Simplified the `--app-id` failure message to `App with ID "<id>" not found.` (hints unchanged), since "not available for linking" is no longer a possible cause.
> - Updated the picker hint from "previously created by the Base44 CLI" to "your existing Base44 apps", and renamed `linkableProjects` → `projects` now that no subset exists.
> - `packages/cli/tests/cli/link.spec.ts`: added a test that links an app with `is_managed_source_code: true` via `--app-id`.
> - `CHANGELOG.md`: new `### Fixed` entry under Unreleased.
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [x] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> - `base44 eject` intentionally keeps its inverse filter (`isManagedSourceCode !== false`, `eject.ts:56`) — it downloads a *copy* of a managed app and is a separate flow, so it is untouched.
> - Author reports end-to-end verification against a real editor-created app (hand-written `.app.jsonc` standing in for the link step): `functions list`, `entities push`, `functions deploy`, and `base44 dev` (vite-plugin proxy engaged) all work against a managed-source app. The link suite is reported at 16/16; `exec.spec.ts` failed on the author's machine due to no route to `registry.npmjs.org`, unrelated to this change. Tests were not re-run in this environment.
> - No `docs/` updates needed: this changes command behavior only, not architecture.
>
> ---
> <sub>🤖 Generated by Claude | 2026-07-27 08:58 UTC | 1701370</sub>
