### PR TITLE
fix(dev): accept prod-minted sessions and keep logout on localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 ### Fixed
 
 - `base44 link` now lists editor-created apps; previously only apps created by the CLI could be linked.
+- `base44 dev` accepts sessions from production-minted tokens (e.g. Google OAuth round-trips): a valid
+  token whose subject never registered locally now gets a local user record instead of a 404 on `User/me`
+  that left the app stuck logged out.
+- `base44 dev` handles `/api/apps/auth/logout` locally and redirects back to the app's `from_url`;
+  previously the request bounced to production, which drops localhost redirect targets and stranded the
+  browser on base44.com.
 
 ## [0.0.51] - 2026-04-28
 

--- a/packages/cli/src/cli/dev/dev-server/main.ts
+++ b/packages/cli/src/cli/dev/dev-server/main.ts
@@ -30,6 +30,18 @@ import { WatchBase44 } from "./watcher.js";
 const DEFAULT_PORT = 4400;
 const BASE44_APP_URL = "https://base44.app";
 
+function isLocalRedirectTarget(value: string): boolean {
+  try {
+    const { protocol, hostname } = new URL(value);
+    return (
+      (protocol === "http:" || protocol === "https:") &&
+      (hostname === "localhost" || hostname === "127.0.0.1")
+    );
+  } catch {
+    return false;
+  }
+}
+
 interface DevServerOptions {
   log: Logger;
   port?: number;
@@ -78,6 +90,18 @@ export async function createDevServer(
       credentials: true,
     }),
   );
+
+  // Handled locally (and registered before the auth redirect below): local
+  // sessions are JWTs the SDK already cleared client-side, and production's
+  // logout drops foreign from_url targets — bouncing there strands the
+  // browser on base44.com instead of returning to the app.
+  app.get("/api/apps/auth/logout", (req, res) => {
+    const fromUrl = req.query.from_url;
+    if (typeof fromUrl === "string" && isLocalRedirectTarget(fromUrl)) {
+      return res.redirect(fromUrl);
+    }
+    res.send("Logged out");
+  });
 
   // Redirect OAuth routes to base44.app directly — proxying breaks the
   // redirect flow and session cookies set by the provider.

--- a/packages/cli/src/cli/dev/dev-server/routes/auth-router.ts
+++ b/packages/cli/src/cli/dev/dev-server/routes/auth-router.ts
@@ -11,7 +11,7 @@ import {
   PRIVATE_USER_COLLECTION,
   USER_COLLECTION,
 } from "../db/database.js";
-import { getNowISOTimestamp } from "../utils.js";
+import { deriveFullNameFromEmail, getNowISOTimestamp } from "../utils.js";
 
 const TEN_MINUTES = 10 * 60 * 1000;
 
@@ -184,8 +184,7 @@ export function createAuthRouter(db: Database, logger: DevLogger): Router {
 
         const collection = db.getCollection(USER_COLLECTION);
         const now = getNowISOTimestamp();
-        const nameFromEmailMatch = /^([^@]+)/.exec(email);
-        const fullName = nameFromEmailMatch ? nameFromEmailMatch[1] : email;
+        const fullName = deriveFullNameFromEmail(email);
         await collection?.insertAsync({
           id: privateUserData.id,
           email: email,

--- a/packages/cli/src/cli/dev/dev-server/routes/entities/current-user.ts
+++ b/packages/cli/src/cli/dev/dev-server/routes/entities/current-user.ts
@@ -1,6 +1,7 @@
 import type { Document } from "@seald-io/nedb";
 import type { Request } from "express";
 import jwt, { type JwtPayload } from "jsonwebtoken";
+import { nanoid } from "nanoid";
 import {
   isServiceSubject,
   SERVICE_ROLE_EMAIL,
@@ -9,6 +10,10 @@ import {
   type Database,
   USER_COLLECTION,
 } from "@/cli/dev/dev-server/db/database.js";
+import {
+  deriveFullNameFromEmail,
+  getNowISOTimestamp,
+} from "@/cli/dev/dev-server/utils.js";
 
 export type UserDocument = Document<{
   email: string;
@@ -64,12 +69,47 @@ export async function resolveCurrentUser(
       .getCollection(USER_COLLECTION)
       ?.findOneAsync<UserDocument>({ email: subject });
 
-    if (!currentUser) {
+    if (currentUser) {
+      return { ok: true, user: currentUser };
+    }
+
+    // Tokens minted by production (e.g. Google OAuth round-trips) carry
+    // subjects that never registered locally — create them on first sight so
+    // the session works instead of 404ing on User/me.
+    const externallyAuthenticatedUser = await createLocalUser(db, subject);
+
+    if (!externallyAuthenticatedUser) {
       return { ok: false, reason: "not_found" };
     }
 
-    return { ok: true, user: currentUser };
+    return { ok: true, user: externallyAuthenticatedUser };
   } catch {
     return { ok: false, reason: "invalid" };
   }
+}
+
+async function createLocalUser(
+  db: Database,
+  email: string,
+): Promise<UserDocument | undefined> {
+  const collection = db.getCollection(USER_COLLECTION);
+  if (!collection) {
+    return undefined;
+  }
+
+  const now = getNowISOTimestamp();
+  const inserted = await collection.insertAsync({
+    id: nanoid(),
+    email,
+    full_name: deriveFullNameFromEmail(email),
+    is_service: false,
+    is_verified: true,
+    disabled: null,
+    role: "user",
+    collaborator_role: "editor",
+    created_date: now,
+    updated_date: now,
+  });
+
+  return inserted as unknown as UserDocument;
 }

--- a/packages/cli/src/cli/dev/dev-server/utils.ts
+++ b/packages/cli/src/cli/dev/dev-server/utils.ts
@@ -17,3 +17,8 @@ export function stripInternalFields<T extends Record<string, unknown>>(
 export const getNowISOTimestamp = () => {
   return new Date().toISOString().replace("Z", "000");
 };
+
+export const deriveFullNameFromEmail = (email: string) => {
+  const nameFromEmailMatch = /^([^@]+)/.exec(email);
+  return nameFromEmailMatch ? nameFromEmailMatch[1] : email;
+};

--- a/packages/cli/tests/cli/dev-auth.spec.ts
+++ b/packages/cli/tests/cli/dev-auth.spec.ts
@@ -8,12 +8,13 @@ describe("auth in dev", () => {
   const t = setupCLITests();
   let handle: RunLiveHandle;
   let base44: Base44Client;
+  let serverUrl: string;
 
   beforeEach(async () => {
     await t.givenLoggedInWithProject(fixture("basic"));
 
     handle = await t.runLive("dev");
-    const serverUrl = await waitForDevServer(handle);
+    serverUrl = await waitForDevServer(handle);
 
     base44 = createClient({
       appId: t.kit.api.appId,
@@ -59,5 +60,42 @@ describe("auth in dev", () => {
       await base44.auth.loginViaEmailPassword(email, password);
 
     expect(jwt.decode(access_token_login)?.sub).toBe(email);
+  });
+
+  it("creates a local user for a valid token whose subject never registered locally", async () => {
+    const email = "oauth-minted@example.com";
+    const externalToken = jwt.sign({}, "external-secret", { subject: email });
+
+    const authedClient = createClient({
+      appId: t.kit.api.appId,
+      serverUrl,
+      token: externalToken,
+    });
+
+    const me = await authedClient.auth.me();
+    expect(me.email).toBe(email);
+
+    const meAgain = await authedClient.auth.me();
+    expect(meAgain.id).toBe(me.id);
+  });
+
+  it("redirects logout back to a localhost from_url instead of production", async () => {
+    const fromUrl = "http://localhost:5173/";
+    const response = await fetch(
+      `${serverUrl}/api/apps/auth/logout?from_url=${encodeURIComponent(fromUrl)}`,
+      { redirect: "manual" },
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(fromUrl);
+  });
+
+  it("does not redirect logout to foreign origins", async () => {
+    const response = await fetch(
+      `${serverUrl}/api/apps/auth/logout?from_url=${encodeURIComponent("https://evil.example.com/")}`,
+      { redirect: "manual" },
+    );
+
+    expect(response.status).toBe(200);
   });
 });


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Fixes two auth gaps in the `base44 dev` local server that left cli-created apps stuck in a broken login loop. First, a token minted by production (e.g. after a Google OAuth round-trip) was rejected locally because `resolveCurrentUser` only knew about users created through local OTP signup, so `User/me` returned 404 and the app stayed logged out despite holding a valid token. Second, the SDK’s `logout()` navigates to `/api/apps/auth/logout?from_url=<app>`, which the dev server bounced to production — prod rejects foreign `from_url` targets and redirects to its own host, stranding the browser on base44.com.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - **`routes/entities/current-user.ts`** — when a valid token carries a subject with no local user record, create one on first sight (via a new `createLocalUser` helper) instead of returning `not_found`. The inserted document mirrors the shape written by the OTP registration path (`id`, `email`, `full_name`, `is_service`, `is_verified`, `disabled`, `role`, `collaborator_role`, timestamps), so subsequent requests resolve the same stable user.
> - **`main.ts`** — handle `GET /api/apps/auth/logout` locally, registered *before* the existing `/api/apps/auth/*` redirect carve-out. A new `isLocalRedirectTarget()` guard only honours `from_url` values on `http(s)://localhost` or `127.0.0.1`; anything else falls through to a plain `Logged out` response rather than becoming an open redirect.
> - **`utils.ts`** — extract `deriveFullNameFromEmail()` and reuse it from both `auth-router.ts` (OTP registration) and the new local-user creation path, removing the duplicated regex.
> - **`tests/cli/dev-auth.spec.ts`** — hoist `serverUrl` to suite scope and add three cases: a prod-minted token yields a working session with a stable id across calls, logout 302s back to a localhost `from_url`, and a foreign origin is not used as a redirect target.
> - **`CHANGELOG.md`** — two entries under Fixed describing both behaviours.
>
> ## Testing
>
> - [x] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project’s style guidelines
> - [x] I have performed a self-review of my own code
> - [x] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The logout route is intentionally answered locally rather than loosening production’s `from_url` sanitisation, which is a shared security control — local sessions are client-side JWTs the SDK has already cleared, so there is no server-side session to tear down. Note that `resolveCurrentUser` decodes rather than verifies the JWT, so the create-on-first-sight path trusts any well-formed token subject; that is consistent with the existing dev-server behaviour and acceptable for a localhost-only development server, but it means the dev user store can accumulate records for arbitrary subjects.
>
> ---
> <sub>🤖 Generated by Claude | 2026-07-28 13:50 UTC | 8e3e3da</sub>