### PR TITLE
chore: drop the PostToolUse Edit/Write hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,43 +5,5 @@
       "Bash(git commit:*)",
       "Bash(git worktree:*)"
     ]
-  },
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Edit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bun run typecheck 2>&1 | head -30"
-          },
-          {
-            "type": "command",
-            "command": "bun run lint:fix 2>&1 | head -30"
-          },
-          {
-            "type": "command",
-            "command": "bun run knip:fix 2>&1 | head -50"
-          }
-        ]
-      },
-      {
-        "matcher": "Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bun run typecheck 2>&1 | head -30"
-          },
-          {
-            "type": "command",
-            "command": "bun run lint:fix 2>&1 | head -30"
-          },
-          {
-            "type": "command",
-            "command": "bun run knip:fix 2>&1 | head -50"
-          }
-        ]
-      }
-    ]
   }
 }


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> Removes the `PostToolUse` hooks from `.claude/settings.json` that ran `bun run typecheck`, `bun run lint:fix`, and `bun run knip:fix` after every `Edit` and `Write` tool call. Running three project-wide checks on each individual file edit was slow and noisy, and `knip:fix` in particular can delete code that is only referenced by work still in progress. Validation now happens where it belongs — explicitly before committing and in CI. Only the `permissions` block remains in the settings file.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [x] Other (please describe): Tooling / developer-environment configuration change
>
> ## Changes Made
>
> - Deleted the entire `hooks.PostToolUse` section from `.claude/settings.json` (38 lines)
> - Dropped the `Edit` matcher hooks: `bun run typecheck`, `bun run lint:fix`, `bun run knip:fix`
> - Dropped the `Write` matcher hooks: the same three commands
> - Left the `permissions.allow` list (`Bash(git commit:*)`, `Bash(git worktree:*)`) untouched
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> No production, source, or test code is touched — this only affects the local Claude Code agent configuration for this repo. Contributors who relied on the automatic post-edit checks should run `bun run typecheck`, `bun run lint:fix`, and `bun run knip:fix` manually before pushing; CI still enforces them.
>
> ---
> <sub>🤖 Generated by Claude | 2026-07-30 14:01 UTC | 90db4f5</sub>