### PR TITLE
fix(logs): show --level in `base44 logs --help`

### DIFF
--- a/packages/cli/src/cli/commands/project/logs.ts
+++ b/packages/cli/src/cli/commands/project/logs.ts
@@ -350,9 +350,9 @@ export function getLogsCommand(): Command {
       normalizeDatetime,
     )
     .addOption(
-      new Option("--level <level>", "Filter by log level")
-        .choices([...LogLevelSchema.options])
-        .hideHelp(),
+      new Option("--level <level>", "Filter by log level").choices([
+        ...LogLevelSchema.options,
+      ]),
     )
     .option("-n, --limit <n>", "Results per page (1-1000, default: 50)")
     .option("-f, --follow", "Stream new logs as they arrive")

--- a/packages/cli/tests/cli/logs.spec.ts
+++ b/packages/cli/tests/cli/logs.spec.ts
@@ -311,6 +311,13 @@ describe("logs command", () => {
     t.expectResult(result).toFail();
   });
 
+  it("documents --level in --help", async () => {
+    const result = await t.run("logs", "--help");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("--level <level>");
+  });
+
   it("filters function logs by --level", async () => {
     await t.givenLoggedInWithProject(fixture("basic"));
     t.api.mockFunctionLogs("my-function", [


### PR DESCRIPTION
## Problem

`base44 logs --help` does not list `--level`, even though the flag works. It is registered with `.hideHelp()`:

```ts
new Option("--level <level>", "Filter by log level")
  .choices([...LogLevelSchema.options])
  .hideHelp(),
```

## How this surfaced

Our own `base44-troubleshooter` skill (repo `base44/skills`) makes `--level` **the first action of its troubleshooting flow** — `SKILL.md:41`, under "### 1. Check Recent Errors":

```bash
npx base44 logs --level error
```

It appears again at `SKILL.md:49` and `:55`, and in `references/project-logs.md` at line 20 (options table), 36 and 57. So the skill teaches a flag that `--help` says does not exist.

An agent debugging a live app (silent per-item drops in a function returning `200 {"ok":true}`) hit exactly that mismatch. The reported cost is the strongest argument here: catching the skill apparently "lying" once made it **stop trusting the skill's flag guidance and start guessing at CLI behaviour** — which produced a false bug report (`--order asc silently drops the newest entries`) that had to be retracted. A working-but-hidden flag doesn't just cost a lookup; it pushes agents from reading docs to guessing, and guesses become bogus findings.

Scope, verified rather than assumed: all 8 flags in the reference's option table were checked against `logs --help`. **`--level` is the only mismatch** — `--function`, `--since`, `--until`, `-n/--limit`, `--order`, `--env`, `-f/--follow` all appear, and `--json` is correctly a global flag. (Other `logs` defects were found in the same session — `--order` being a no-op for a single function, `--limit`'s documented default, log ingestion lag. Those are sibling findings tracked separately, deliberately not folded into this one-line fix.)

Credit to the `logs-detective` agent for the investigation and for correcting its own initial framing (the gap is help-text-vs-reference-docs, not "undocumented").

## The hide was deliberate — this PR argues for reversing it

`--level` was added *and* hidden in the same commit, a88ce8e (#323, @kfirstri), whose description says:

> The `--level` option is hidden from help output (`.hideHelp()`) to keep the command surface minimal while still supporting level-based filtering for power users.

Why it should be reversed anyway:

- **The stated goal backfired.** Hiding it didn't keep the surface clean — it made our own skill's step 1 look wrong, at the cost above.
- **Inconsistent.** `--order` and `--env` are equally niche and both appear in help.
- **Every other `hideHelp()` in the repo means something different** — deprecated aliases (`--org`, `--project-id`/`--projectId`). `--level` is the only hidden flag that is a live feature, so it reads like legacy.
- **Weak provenance.** #323's body is machine-generated (`🤖 Generated by Claude`), so that sentence may narrate the diff rather than record intent; the PR merged 14 min after opening with its one review `DISMISSED` and no inline comments.

@kfirstri — if the minimal-surface call was deliberately yours and you still want it, say so and I'll close this.

## Fix

Drop `.hideHelp()`:

```
  --level <level>     Filter by log level (choices: "debug", "info", "warning", "error")
```

## Tests

Added `documents --level in --help`, confirmed to discriminate (fails with `hideHelp()`, passes without).

- `bun run test tests/cli/logs.spec.ts` → 30 passed; `typecheck` clean; `lint` has 1 pre-existing info in an unrelated file
- 14 local `exec.spec.ts` failures were Deno unable to reach `registry.npmjs.org` in my sandbox; CI's ubuntu+windows × npm+binary jobs all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)