### PR TITLE
feat(workflows): read-only workflows commands — list and runs

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -74,6 +74,10 @@ Entry files may also import `secrets` and `waitUntil` from `base44:runtime`. Loc
 
 Agent skills are app-scoped instruction snippets shared across the app's agents. Unlike other resources they are stored as one markdown file per skill under the agent-skills directory (`base44/agent-skills/`, or `agentSkillsDir` in `config.jsonc`): the filename (without `.md`) is the skill name, the frontmatter `description` is the summary, and the body is the instruction text. Agents reference skills by name via `selected_skill_names`; `selected_workspace_skill_ids` (org-shared workspace skills) is not managed here and is passed through pull/push/deploy untouched.
 
+## Workflow Module (Read-Only, Not a Resource)
+
+The workflow module at `packages/cli/src/core/resources/workflow/` is read-only — workflows are authored in the builder, not pulled/pushed from local files, so there is no `Resource<T>` implementation. It exposes `listWorkflows()` and `listWorkflowRuns(filters)` over `GET /api/apps/{app_id}/workflows[/runs]`, consumed by the `workflows list` / `workflows runs` commands. Apps that predate the Workflows system return 403 from these endpoints; the commands translate that into an explanation.
+
 ## Site Module (Not a Resource)
 
 The site module at `packages/cli/src/core/site/` handles deploying an app's built output. It follows a different pattern than resources — there is no item list, so no `readAll`/`push`.

--- a/packages/cli/src/cli/commands/project/logs.ts
+++ b/packages/cli/src/cli/commands/project/logs.ts
@@ -1,8 +1,7 @@
 import type { Command } from "commander";
 import { Option } from "commander";
-import ms, { type StringValue } from "ms";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";
-import { Base44Command } from "@/cli/utils/index.js";
+import { Base44Command, normalizeDatetime } from "@/cli/utils/index.js";
 import { ApiError, InvalidInputError } from "@/core/errors.js";
 import { readProjectConfig } from "@/core/index.js";
 import type {
@@ -75,15 +74,6 @@ function parseFunctionNames(option: string | undefined): string[] {
     .split(",")
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
-}
-
-function normalizeDatetime(value: string): string {
-  const duration = ms(value as StringValue);
-  if (duration !== undefined) {
-    return new Date(Date.now() - duration).toISOString();
-  }
-  if (/Z$|[+-]\d{2}:\d{2}$/.test(value)) return value;
-  return `${value}Z`;
 }
 
 function formatEntry(entry: LogEntry): string {

--- a/packages/cli/src/cli/commands/workflows/index.ts
+++ b/packages/cli/src/cli/commands/workflows/index.ts
@@ -1,0 +1,10 @@
+import { Command } from "commander";
+import { getWorkflowsListCommand } from "./list.js";
+import { getWorkflowsRunsCommand } from "./runs.js";
+
+export function getWorkflowsCommand(): Command {
+  return new Command("workflows")
+    .description("Inspect this app's workflows and their runs")
+    .addCommand(getWorkflowsListCommand())
+    .addCommand(getWorkflowsRunsCommand());
+}

--- a/packages/cli/src/cli/commands/workflows/legacy-app.ts
+++ b/packages/cli/src/cli/commands/workflows/legacy-app.ts
@@ -1,0 +1,13 @@
+import { ApiError, InvalidInputError } from "@/core/errors.js";
+
+const isWorkflowsNotEnabled = (error: unknown) =>
+  error instanceof ApiError && error.statusCode === 403;
+
+export function rethrowLegacyAppAsExplanation(error: unknown): never {
+  if (isWorkflowsNotEnabled(error)) {
+    throw new InvalidInputError(
+      "Workflows are not enabled for this app — it predates the Workflows system, so its automation runs are not readable via this command.",
+    );
+  }
+  throw error;
+}

--- a/packages/cli/src/cli/commands/workflows/limit.ts
+++ b/packages/cli/src/cli/commands/workflows/limit.ts
@@ -1,0 +1,14 @@
+import { InvalidInputError } from "@/core/errors.js";
+
+export const MAX_LIMIT = 200;
+
+export function parseLimit(limit: string | undefined): number | undefined {
+  if (limit === undefined) return undefined;
+  const parsed = Number.parseInt(limit, 10);
+  if (Number.isNaN(parsed) || parsed < 1 || parsed > MAX_LIMIT) {
+    throw new InvalidInputError(
+      `Invalid limit: "${limit}". Must be a number between 1 and ${MAX_LIMIT}.`,
+    );
+  }
+  return parsed;
+}

--- a/packages/cli/src/cli/commands/workflows/list.ts
+++ b/packages/cli/src/cli/commands/workflows/list.ts
@@ -1,0 +1,55 @@
+import type { Command } from "commander";
+import type { CLIContext, RunCommandResult } from "@/cli/types.js";
+import { Base44Command } from "@/cli/utils/index.js";
+import type { WorkflowListItem } from "@/core/resources/workflow/index.js";
+import { listWorkflows } from "@/core/resources/workflow/index.js";
+import { rethrowLegacyAppAsExplanation } from "./legacy-app.js";
+
+function formatWorkflowLine(workflow: WorkflowListItem): string {
+  const lastRun = workflow.lastRunAt
+    ? `last run ${workflow.lastRunStatus ?? "unknown"} at ${workflow.lastRunAt}`
+    : "never ran";
+  const failures =
+    workflow.consecutiveFailures > 0
+      ? ` (${workflow.consecutiveFailures} consecutive failures)`
+      : "";
+  return `${workflow.name}  [${workflow.status}]  runs: ${workflow.totalRuns}, ${lastRun}${failures}`;
+}
+
+async function listAction({
+  log,
+  runTask,
+  jsonMode,
+}: CLIContext): Promise<RunCommandResult> {
+  const workflows = await runTask(
+    "Fetching workflows from Base44",
+    async () => listWorkflows().catch(rethrowLegacyAppAsExplanation),
+    {
+      successMessage: "Workflows fetched successfully",
+      errorMessage: "Failed to fetch workflows",
+    },
+  );
+
+  if (jsonMode) {
+    return {
+      outroMessage: `Found ${workflows.length} workflows.`,
+      stdout: `${JSON.stringify({ workflows }, null, 2)}\n`,
+    };
+  }
+
+  if (workflows.length === 0) {
+    return { outroMessage: "This app has no workflows." };
+  }
+
+  for (const workflow of workflows) {
+    log.info(formatWorkflowLine(workflow));
+  }
+
+  return { outroMessage: `Found ${workflows.length} workflows.` };
+}
+
+export function getWorkflowsListCommand(): Command {
+  return new Base44Command("list")
+    .description("List this app's workflows")
+    .action(listAction);
+}

--- a/packages/cli/src/cli/commands/workflows/list.ts
+++ b/packages/cli/src/cli/commands/workflows/list.ts
@@ -4,6 +4,11 @@ import { Base44Command } from "@/cli/utils/index.js";
 import type { WorkflowListItem } from "@/core/resources/workflow/index.js";
 import { listWorkflows } from "@/core/resources/workflow/index.js";
 import { rethrowLegacyAppAsExplanation } from "./legacy-app.js";
+import { MAX_LIMIT, parseLimit } from "./limit.js";
+
+interface ListOptions {
+  limit?: string;
+}
 
 function formatWorkflowLine(workflow: WorkflowListItem): string {
   const lastRun = workflow.lastRunAt
@@ -16,14 +21,14 @@ function formatWorkflowLine(workflow: WorkflowListItem): string {
   return `${workflow.name}  [${workflow.status}]  runs: ${workflow.totalRuns}, ${lastRun}${failures}`;
 }
 
-async function listAction({
-  log,
-  runTask,
-  jsonMode,
-}: CLIContext): Promise<RunCommandResult> {
+async function listAction(
+  { log, runTask, jsonMode }: CLIContext,
+  options: ListOptions,
+): Promise<RunCommandResult> {
+  const limit = parseLimit(options.limit);
   const workflows = await runTask(
     "Fetching workflows from Base44",
-    async () => listWorkflows().catch(rethrowLegacyAppAsExplanation),
+    async () => listWorkflows(limit).catch(rethrowLegacyAppAsExplanation),
     {
       successMessage: "Workflows fetched successfully",
       errorMessage: "Failed to fetch workflows",
@@ -51,5 +56,9 @@ async function listAction({
 export function getWorkflowsListCommand(): Command {
   return new Base44Command("list")
     .description("List this app's workflows")
+    .option(
+      "-n, --limit <n>",
+      `Number of workflows to return (1-${MAX_LIMIT}, default: 30)`,
+    )
     .action(listAction);
 }

--- a/packages/cli/src/cli/commands/workflows/runs.ts
+++ b/packages/cli/src/cli/commands/workflows/runs.ts
@@ -1,0 +1,136 @@
+import type { Command } from "commander";
+import { Option } from "commander";
+import type { CLIContext, RunCommandResult } from "@/cli/types.js";
+import { Base44Command, normalizeDatetime } from "@/cli/utils/index.js";
+import { InvalidInputError } from "@/core/errors.js";
+import type {
+  WorkflowRun,
+  WorkflowRunStatus,
+} from "@/core/resources/workflow/index.js";
+import {
+  listWorkflowRuns,
+  listWorkflows,
+  WorkflowRunStatusSchema,
+} from "@/core/resources/workflow/index.js";
+import { rethrowLegacyAppAsExplanation } from "./legacy-app.js";
+
+interface RunsOptions {
+  status?: WorkflowRunStatus;
+  since?: string;
+  limit?: string;
+}
+
+const MAX_LIMIT = 200;
+
+function parseLimit(limit: string | undefined): number | undefined {
+  if (limit === undefined) return undefined;
+  const parsed = Number.parseInt(limit, 10);
+  if (Number.isNaN(parsed) || parsed < 1 || parsed > MAX_LIMIT) {
+    throw new InvalidInputError(
+      `Invalid limit: "${limit}". Must be a number between 1 and ${MAX_LIMIT}.`,
+    );
+  }
+  return parsed;
+}
+
+function formatDuration(durationMs: number): string {
+  if (durationMs === 0) return "";
+  return `  ${(durationMs / 1000).toFixed(1)}s`;
+}
+
+function formatRunTags(run: WorkflowRun): string {
+  const tags = [run.triggerType, run.isTestRun ? "test" : null].filter(Boolean);
+  return tags.length > 0 ? `  (${tags.join(", ")})` : "";
+}
+
+function formatFailureDetail(run: WorkflowRun): string {
+  const reason = run.statusReason ? ` [${run.statusReason}]` : "";
+  const message = run.errorMessage ? `\n    ${run.errorMessage}` : "";
+  return `${reason}${message}`;
+}
+
+function formatRunLine(run: WorkflowRun): string {
+  const time = (run.startedAt ?? "").substring(0, 19).replace("T", " ");
+  const status = run.status.toUpperCase().padEnd(9);
+  const base = `${time} ${status} ${run.workflowName}${formatRunTags(run)}${formatDuration(run.durationMs)}`;
+  const failureDetail =
+    run.status === "failed" || run.status === "cancelled"
+      ? formatFailureDetail(run)
+      : "";
+  return `${base}${failureDetail}`;
+}
+
+async function describeEmptyResult(hasFilters: boolean): Promise<string> {
+  const workflows = await listWorkflows().catch(() => null);
+  if (workflows === null) {
+    return "No runs found.";
+  }
+  if (workflows.length === 0) {
+    return "This app has no workflows, so there are no runs.";
+  }
+  const names = workflows.map((workflow) => workflow.name).join(", ");
+  return hasFilters
+    ? `No runs match your filters. Workflows in this app: ${names}.`
+    : `No runs yet. Workflows in this app: ${names}.`;
+}
+
+async function runsAction(
+  ctx: CLIContext,
+  options: RunsOptions,
+): Promise<RunCommandResult> {
+  const limit = parseLimit(options.limit);
+
+  const runs = await ctx.runTask(
+    "Fetching workflow runs from Base44",
+    async () =>
+      listWorkflowRuns({
+        status: options.status,
+        since: options.since,
+        limit,
+      }).catch(rethrowLegacyAppAsExplanation),
+    {
+      successMessage: "Workflow runs fetched successfully",
+      errorMessage: "Failed to fetch workflow runs",
+    },
+  );
+
+  if (ctx.jsonMode) {
+    return {
+      outroMessage: `Found ${runs.length} runs.`,
+      stdout: `${JSON.stringify({ runs }, null, 2)}\n`,
+    };
+  }
+
+  if (runs.length === 0) {
+    const hasFilters = Boolean(options.status || options.since);
+    return { outroMessage: await describeEmptyResult(hasFilters) };
+  }
+
+  for (const run of runs) {
+    ctx.log.info(formatRunLine(run));
+  }
+
+  return { outroMessage: `Found ${runs.length} runs.` };
+}
+
+export function getWorkflowsRunsCommand(): Command {
+  return new Base44Command("runs")
+    .description(
+      "List workflow runs for this app, newest first (includes scheduled, manual, and test runs)",
+    )
+    .addOption(
+      new Option("--status <status>", "Filter by run status").choices([
+        ...WorkflowRunStatusSchema.options,
+      ]),
+    )
+    .option(
+      "--since <datetime>",
+      "Show runs started after this time. ISO datetime or relative shorthand (e.g. 1h, 30m, 2d)",
+      normalizeDatetime,
+    )
+    .option(
+      "-n, --limit <n>",
+      `Number of runs to return (1-${MAX_LIMIT}, default: 30)`,
+    )
+    .action(runsAction);
+}

--- a/packages/cli/src/cli/commands/workflows/runs.ts
+++ b/packages/cli/src/cli/commands/workflows/runs.ts
@@ -2,7 +2,6 @@ import type { Command } from "commander";
 import { Option } from "commander";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";
 import { Base44Command, normalizeDatetime } from "@/cli/utils/index.js";
-import { InvalidInputError } from "@/core/errors.js";
 import type {
   WorkflowRun,
   WorkflowRunStatus,
@@ -13,24 +12,12 @@ import {
   WorkflowRunStatusSchema,
 } from "@/core/resources/workflow/index.js";
 import { rethrowLegacyAppAsExplanation } from "./legacy-app.js";
+import { MAX_LIMIT, parseLimit } from "./limit.js";
 
 interface RunsOptions {
   status?: WorkflowRunStatus;
   since?: string;
   limit?: string;
-}
-
-const MAX_LIMIT = 200;
-
-function parseLimit(limit: string | undefined): number | undefined {
-  if (limit === undefined) return undefined;
-  const parsed = Number.parseInt(limit, 10);
-  if (Number.isNaN(parsed) || parsed < 1 || parsed > MAX_LIMIT) {
-    throw new InvalidInputError(
-      `Invalid limit: "${limit}". Must be a number between 1 and ${MAX_LIMIT}.`,
-    );
-  }
-  return parsed;
 }
 
 function formatDuration(durationMs: number): string {

--- a/packages/cli/src/cli/program.ts
+++ b/packages/cli/src/cli/program.ts
@@ -20,6 +20,7 @@ import { getSandboxCommand } from "@/cli/commands/sandbox/index.js";
 import { getSecretsCommand } from "@/cli/commands/secrets/index.js";
 import { getSiteCommand } from "@/cli/commands/site/index.js";
 import { getTypesCommand } from "@/cli/commands/types/index.js";
+import { getWorkflowsCommand } from "@/cli/commands/workflows/index.js";
 import { getWorkspaceCommand } from "@/cli/commands/workspace/index.js";
 import { Base44Command } from "@/cli/utils/index.js";
 import { BASE44_APP_ID_ENV_VAR } from "@/core/consts.js";
@@ -93,6 +94,9 @@ export function createProgram(context: CLIContext): Command {
 
   // Register functions commands
   program.addCommand(getFunctionsCommand());
+
+  // Register workflows commands
+  program.addCommand(getWorkflowsCommand());
 
   // Register secrets commands
   program.addCommand(getSecretsCommand());

--- a/packages/cli/src/cli/utils/datetime.ts
+++ b/packages/cli/src/cli/utils/datetime.ts
@@ -1,0 +1,12 @@
+import ms, { type StringValue } from "ms";
+
+const HAS_TIMEZONE_SUFFIX = /Z$|[+-]\d{2}:\d{2}$/;
+
+export function normalizeDatetime(value: string): string {
+  const duration = ms(value as StringValue);
+  if (duration !== undefined) {
+    return new Date(Date.now() - duration).toISOString();
+  }
+  if (HAS_TIMEZONE_SUFFIX.test(value)) return value;
+  return `${value}Z`;
+}

--- a/packages/cli/src/cli/utils/index.ts
+++ b/packages/cli/src/cli/utils/index.ts
@@ -2,6 +2,7 @@ export * from "@base44-cli/logger";
 export * from "./banner.js";
 export * from "./command/index.js";
 export * from "./confirm-push.js";
+export * from "./datetime.js";
 export * from "./json.js";
 export * from "./prompts.js";
 export * from "./runTask.js";

--- a/packages/cli/src/core/resources/workflow/api.ts
+++ b/packages/cli/src/core/resources/workflow/api.ts
@@ -11,12 +11,19 @@ import {
   ListWorkflowsResponseSchema,
 } from "./schema.js";
 
-export async function listWorkflows(): Promise<ListWorkflowsResponse> {
+export async function listWorkflows(
+  limit?: number,
+): Promise<ListWorkflowsResponse> {
   const appClient = getAppClient();
+
+  const searchParams = new URLSearchParams();
+  if (limit !== undefined) {
+    searchParams.set("limit", String(limit));
+  }
 
   let response: KyResponse;
   try {
-    response = await appClient.get("workflows");
+    response = await appClient.get("workflows", { searchParams });
   } catch (error) {
     throw await ApiError.fromHttpError(error, "listing workflows");
   }

--- a/packages/cli/src/core/resources/workflow/api.ts
+++ b/packages/cli/src/core/resources/workflow/api.ts
@@ -1,0 +1,78 @@
+import type { KyResponse } from "ky";
+import { getAppClient } from "@/core/clients/index.js";
+import { ApiError, SchemaValidationError } from "@/core/errors.js";
+import type {
+  ListWorkflowRunsResponse,
+  ListWorkflowsResponse,
+  WorkflowRunFilters,
+} from "./schema.js";
+import {
+  ListWorkflowRunsResponseSchema,
+  ListWorkflowsResponseSchema,
+} from "./schema.js";
+
+export async function listWorkflows(): Promise<ListWorkflowsResponse> {
+  const appClient = getAppClient();
+
+  let response: KyResponse;
+  try {
+    response = await appClient.get("workflows");
+  } catch (error) {
+    throw await ApiError.fromHttpError(error, "listing workflows");
+  }
+
+  const result = ListWorkflowsResponseSchema.safeParse(await response.json());
+
+  if (!result.success) {
+    throw new SchemaValidationError(
+      "Invalid workflows response from server",
+      result.error,
+    );
+  }
+
+  return result.data;
+}
+
+function buildRunsQueryString(filters: WorkflowRunFilters): URLSearchParams {
+  const params = new URLSearchParams();
+
+  if (filters.status) {
+    params.set("status", filters.status);
+  }
+  if (filters.since) {
+    params.set("since", filters.since);
+  }
+  if (filters.limit !== undefined) {
+    params.set("limit", String(filters.limit));
+  }
+
+  return params;
+}
+
+export async function listWorkflowRuns(
+  filters: WorkflowRunFilters = {},
+): Promise<ListWorkflowRunsResponse> {
+  const appClient = getAppClient();
+
+  let response: KyResponse;
+  try {
+    response = await appClient.get("workflows/runs", {
+      searchParams: buildRunsQueryString(filters),
+    });
+  } catch (error) {
+    throw await ApiError.fromHttpError(error, "listing workflow runs");
+  }
+
+  const result = ListWorkflowRunsResponseSchema.safeParse(
+    await response.json(),
+  );
+
+  if (!result.success) {
+    throw new SchemaValidationError(
+      "Invalid workflow runs response from server",
+      result.error,
+    );
+  }
+
+  return result.data;
+}

--- a/packages/cli/src/core/resources/workflow/index.ts
+++ b/packages/cli/src/core/resources/workflow/index.ts
@@ -1,0 +1,10 @@
+export { listWorkflowRuns, listWorkflows } from "./api.js";
+export type {
+  ListWorkflowRunsResponse,
+  ListWorkflowsResponse,
+  WorkflowListItem,
+  WorkflowRun,
+  WorkflowRunFilters,
+  WorkflowRunStatus,
+} from "./schema.js";
+export { WorkflowRunStatusSchema } from "./schema.js";

--- a/packages/cli/src/core/resources/workflow/schema.ts
+++ b/packages/cli/src/core/resources/workflow/schema.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+export const WorkflowRunStatusSchema = z.enum([
+  "running",
+  "completed",
+  "failed",
+  "cancelled",
+]);
+
+export type WorkflowRunStatus = z.infer<typeof WorkflowRunStatusSchema>;
+
+const WorkflowListItemSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    description: z.string().nullable().optional(),
+    status: z.string(),
+    status_reason: z.string().nullable().optional(),
+    total_runs: z.number().default(0),
+    consecutive_failures: z.number().default(0),
+    last_run_at: z.string().nullable().optional(),
+    last_run_status: z.string().nullable().optional(),
+  })
+  .transform((data) => ({
+    id: data.id,
+    name: data.name,
+    description: data.description ?? null,
+    status: data.status,
+    statusReason: data.status_reason ?? null,
+    totalRuns: data.total_runs,
+    consecutiveFailures: data.consecutive_failures,
+    lastRunAt: data.last_run_at ?? null,
+    lastRunStatus: data.last_run_status ?? null,
+  }));
+
+export const ListWorkflowsResponseSchema = z.array(WorkflowListItemSchema);
+
+export type WorkflowListItem = z.infer<typeof WorkflowListItemSchema>;
+export type ListWorkflowsResponse = z.infer<typeof ListWorkflowsResponseSchema>;
+
+const WorkflowRunSchema = z
+  .object({
+    run_id: z.string(),
+    workflow_id: z.string(),
+    workflow_name: z.string().default(""),
+    trigger_type: z.string().default(""),
+    status: z.string(),
+    started_at: z.string().nullable().optional(),
+    completed_at: z.string().nullable().optional(),
+    duration_ms: z.number().default(0),
+    steps_count: z.number().default(0),
+    error_message: z.string().nullable().optional(),
+    is_test_run: z.boolean().default(false),
+    status_reason: z.string().default(""),
+  })
+  .transform((data) => ({
+    runId: data.run_id,
+    workflowId: data.workflow_id,
+    workflowName: data.workflow_name,
+    triggerType: data.trigger_type,
+    status: data.status,
+    startedAt: data.started_at ?? null,
+    completedAt: data.completed_at ?? null,
+    durationMs: data.duration_ms,
+    stepsCount: data.steps_count,
+    errorMessage: data.error_message ?? null,
+    isTestRun: data.is_test_run,
+    statusReason: data.status_reason,
+  }));
+
+export const ListWorkflowRunsResponseSchema = z.array(WorkflowRunSchema);
+
+export type WorkflowRun = z.infer<typeof WorkflowRunSchema>;
+export type ListWorkflowRunsResponse = z.infer<
+  typeof ListWorkflowRunsResponseSchema
+>;
+
+export interface WorkflowRunFilters {
+  status?: WorkflowRunStatus;
+  since?: string;
+  limit?: number;
+}

--- a/packages/cli/tests/cli/testkit/TestAPIServer.ts
+++ b/packages/cli/tests/cli/testkit/TestAPIServer.ts
@@ -687,8 +687,26 @@ export class TestAPIServer {
   /** Captured query params of workflow runs requests. */
   readonly workflowRunsRequests: Record<string, string>[] = [];
 
+  /** Captured query params of workflows list requests. */
+  readonly workflowsListRequests: Record<string, string>[] = [];
+
   mockWorkflowsList(response: WorkflowsListResponse): this {
-    return this.addRoute("GET", `/api/apps/${this.appId}/workflows`, response);
+    this.pendingRoutes.push({
+      method: "GET",
+      path: `/api/apps/${this.appId}/workflows`,
+      handler: (req, res) => {
+        this.workflowsListRequests.push(
+          Object.fromEntries(
+            Object.entries(req.query).map(([key, value]) => [
+              key,
+              String(value),
+            ]),
+          ),
+        );
+        res.status(200).json(response);
+      },
+    });
+    return this;
   }
 
   mockWorkflowsListError(error: ErrorResponse): this {

--- a/packages/cli/tests/cli/testkit/TestAPIServer.ts
+++ b/packages/cli/tests/cli/testkit/TestAPIServer.ts
@@ -70,6 +70,37 @@ interface FunctionLogEntry {
 
 type FunctionLogsResponse = FunctionLogEntry[];
 
+interface WorkflowListItem {
+  id: string;
+  name: string;
+  status: string;
+  description?: string | null;
+  status_reason?: string | null;
+  total_runs?: number;
+  consecutive_failures?: number;
+  last_run_at?: string | null;
+  last_run_status?: string | null;
+}
+
+type WorkflowsListResponse = WorkflowListItem[];
+
+interface WorkflowRunItem {
+  run_id: string;
+  workflow_id: string;
+  workflow_name?: string;
+  trigger_type?: string;
+  status: string;
+  started_at?: string | null;
+  completed_at?: string | null;
+  duration_ms?: number;
+  steps_count?: number;
+  error_message?: string | null;
+  is_test_run?: boolean;
+  status_reason?: string;
+}
+
+type WorkflowRunsResponse = WorkflowRunItem[];
+
 type SecretsListResponse = Record<string, string>;
 
 interface SecretsSetResponse {
@@ -648,6 +679,50 @@ export class TestAPIServer {
       "GET",
       `/api/apps/${this.appId}/functions-mgmt/${encodeURIComponent(functionName)}/logs`,
       response,
+    );
+  }
+
+  // ─── WORKFLOW ENDPOINTS ───────────────────────────────────
+
+  /** Captured query params of workflow runs requests. */
+  readonly workflowRunsRequests: Record<string, string>[] = [];
+
+  mockWorkflowsList(response: WorkflowsListResponse): this {
+    return this.addRoute("GET", `/api/apps/${this.appId}/workflows`, response);
+  }
+
+  mockWorkflowsListError(error: ErrorResponse): this {
+    return this.addErrorRoute(
+      "GET",
+      `/api/apps/${this.appId}/workflows`,
+      error,
+    );
+  }
+
+  mockWorkflowRuns(response: WorkflowRunsResponse): this {
+    this.pendingRoutes.push({
+      method: "GET",
+      path: `/api/apps/${this.appId}/workflows/runs`,
+      handler: (req, res) => {
+        this.workflowRunsRequests.push(
+          Object.fromEntries(
+            Object.entries(req.query).map(([key, value]) => [
+              key,
+              String(value),
+            ]),
+          ),
+        );
+        res.status(200).json(response);
+      },
+    });
+    return this;
+  }
+
+  mockWorkflowRunsError(error: ErrorResponse): this {
+    return this.addErrorRoute(
+      "GET",
+      `/api/apps/${this.appId}/workflows/runs`,
+      error,
     );
   }
 

--- a/packages/cli/tests/cli/workflows_list.spec.ts
+++ b/packages/cli/tests/cli/workflows_list.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { fixture, setupCLITests } from "./testkit/index.js";
+
+describe("workflows list command", () => {
+  const t = setupCLITests();
+
+  it("--json emits the workflows as camelCase records", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockWorkflowsList([
+      {
+        id: "wf-1",
+        name: "nightly-sync",
+        status: "active",
+        total_runs: 12,
+        consecutive_failures: 3,
+        last_run_at: "2026-08-04T03:00:00+00:00",
+        last_run_status: "failed",
+      },
+    ]);
+
+    const result = await t.run("workflows", "list", "--json");
+
+    t.expectResult(result).toSucceed();
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.workflows).toHaveLength(1);
+    expect(parsed.workflows[0].totalRuns).toBe(12);
+    expect(parsed.workflows[0].consecutiveFailures).toBe(3);
+    expect(parsed.workflows[0].lastRunStatus).toBe("failed");
+  });
+
+  it("lists workflows with run summary", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockWorkflowsList([
+      {
+        id: "wf-1",
+        name: "nightly-sync",
+        status: "active",
+        total_runs: 12,
+        consecutive_failures: 3,
+        last_run_at: "2026-08-04T03:00:00+00:00",
+        last_run_status: "failed",
+      },
+      { id: "wf-2", name: "weekly-digest", status: "paused" },
+    ]);
+
+    const result = await t.run("workflows", "list");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("nightly-sync");
+    t.expectResult(result).toContain("3 consecutive failures");
+    t.expectResult(result).toContain("weekly-digest");
+    t.expectResult(result).toContain("never ran");
+    t.expectResult(result).toContain("Found 2 workflows");
+  });
+
+  it("handles an app with no workflows", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockWorkflowsList([]);
+
+    const result = await t.run("workflows", "list");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("no workflows");
+  });
+
+  it("explains apps that predate Workflows instead of a bare 403", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockWorkflowsListError({
+      status: 403,
+      body: { detail: "Workflows are not enabled for this app" },
+    });
+
+    const result = await t.run("workflows", "list");
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("Workflows are not enabled");
+  });
+});

--- a/packages/cli/tests/cli/workflows_list.spec.ts
+++ b/packages/cli/tests/cli/workflows_list.spec.ts
@@ -63,6 +63,25 @@ describe("workflows list command", () => {
     t.expectResult(result).toContain("no workflows");
   });
 
+  it("--limit is sent to the API", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockWorkflowsList([]);
+
+    const result = await t.run("workflows", "list", "--limit", "200");
+
+    t.expectResult(result).toSucceed();
+    expect(t.api.workflowsListRequests[0]).toMatchObject({ limit: "200" });
+  });
+
+  it("rejects an out-of-range limit", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+
+    const result = await t.run("workflows", "list", "--limit", "500");
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("between 1 and 200");
+  });
+
   it("explains apps that predate Workflows instead of a bare 403", async () => {
     await t.givenLoggedInWithProject(fixture("basic"));
     t.api.mockWorkflowsListError({

--- a/packages/cli/tests/cli/workflows_runs.spec.ts
+++ b/packages/cli/tests/cli/workflows_runs.spec.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { fixture, setupCLITests } from "./testkit/index.js";
+
+const failedRun = {
+  run_id: "run-failed-1",
+  workflow_id: "wf-boom",
+  workflow_name: "probe-boom-wf",
+  trigger_type: "manual",
+  status: "failed",
+  started_at: "2026-08-04T13:45:57.423000+00:00",
+  completed_at: "2026-08-04T13:46:22.949000+00:00",
+  duration_ms: 25525,
+  steps_count: 0,
+  error_message:
+    "Task 'call_fn' failed: Backend function 'auto-boom' returned HTTP 500",
+  is_test_run: true,
+  status_reason: "",
+};
+
+const completedRun = {
+  run_id: "run-ok-1",
+  workflow_id: "wf-ok",
+  workflow_name: "probe-ok-wf",
+  trigger_type: "scheduled",
+  status: "completed",
+  started_at: "2026-08-04T13:45:56.770000+00:00",
+  completed_at: "2026-08-04T13:46:10.000000+00:00",
+  duration_ms: 13230,
+  steps_count: 1,
+  error_message: "",
+  is_test_run: false,
+  status_reason: "",
+};
+
+describe("workflows runs command", () => {
+  const t = setupCLITests();
+
+  it("--json emits the runs as camelCase records", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockWorkflowRuns([failedRun, completedRun]);
+
+    const result = await t.run("workflows", "runs", "--json");
+
+    t.expectResult(result).toSucceed();
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.runs).toHaveLength(2);
+    expect(parsed.runs[0].runId).toBe("run-failed-1");
+    expect(parsed.runs[0].workflowName).toBe("probe-boom-wf");
+    expect(parsed.runs[0].isTestRun).toBe(true);
+    expect(parsed.runs[1].triggerType).toBe("scheduled");
+  });
+
+  it("lists runs with status, trigger, test marker, and failure details", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockWorkflowRuns([failedRun, completedRun]);
+
+    const result = await t.run("workflows", "runs");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("FAILED");
+    t.expectResult(result).toContain("probe-boom-wf");
+    t.expectResult(result).toContain("(manual, test)");
+    t.expectResult(result).toContain("Task 'call_fn' failed");
+    t.expectResult(result).toContain("COMPLETED");
+    t.expectResult(result).toContain("(scheduled)");
+    t.expectResult(result).toContain("Found 2 runs");
+  });
+
+  it("--status failed is sent to the API", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockWorkflowRuns([failedRun]);
+
+    const result = await t.run("workflows", "runs", "--status", "failed");
+
+    t.expectResult(result).toSucceed();
+    expect(t.api.workflowRunsRequests[0]).toMatchObject({ status: "failed" });
+  });
+
+  it("rejects an unknown --status value", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+
+    const result = await t.run("workflows", "runs", "--status", "exploded");
+
+    t.expectResult(result).toFail();
+  });
+
+  it("--since accepts relative shorthand and sends an ISO datetime", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockWorkflowRuns([]);
+    t.api.mockWorkflowsList([]);
+
+    const result = await t.run("workflows", "runs", "--since", "1h");
+
+    t.expectResult(result).toSucceed();
+    const sent = t.api.workflowRunsRequests[0]?.since;
+    expect(sent).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it("rejects an out-of-range limit", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+
+    const result = await t.run("workflows", "runs", "--limit", "500");
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("between 1 and 200");
+  });
+
+  it("empty result names the existing workflows", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockWorkflowRuns([]);
+    t.api.mockWorkflowsList([
+      { id: "wf-1", name: "nightly-sync", status: "active" },
+      { id: "wf-2", name: "weekly-digest", status: "active" },
+    ]);
+
+    const result = await t.run("workflows", "runs");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("No runs yet");
+    t.expectResult(result).toContain("nightly-sync");
+    t.expectResult(result).toContain("weekly-digest");
+  });
+
+  it("empty result on an app with no workflows says so", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockWorkflowRuns([]);
+    t.api.mockWorkflowsList([]);
+
+    const result = await t.run("workflows", "runs");
+
+    t.expectResult(result).toSucceed();
+    t.expectResult(result).toContain("no workflows");
+  });
+
+  it("explains apps that predate Workflows instead of a bare 403", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockWorkflowRunsError({
+      status: 403,
+      body: { detail: "Workflows are not enabled for this app" },
+    });
+
+    const result = await t.run("workflows", "runs");
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("Workflows are not enabled");
+  });
+
+  it("fails on an invalid API response", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    // biome-ignore lint/suspicious/noExplicitAny: this is a test
+    t.api.mockWorkflowRuns([{ bad: "data" }] as any);
+
+    const result = await t.run("workflows", "runs");
+
+    t.expectResult(result).toFail();
+  });
+});


### PR DESCRIPTION
## What

New `base44 workflows` command group — the CLI answer to "did my scheduled work fail, and why":

```
base44 workflows list                  # workflows with status + run summary
base44 workflows runs                  # runs across the app, newest first
base44 workflows runs --status failed  # failures, each with its underlying error
base44 workflows runs --since 1d -n 50
```

Failed runs print the failing task and the underlying error (e.g. the backend function's HTTP 500). `--json` emits the real records (camelCase, Zod-validated).

## How

- New read-only core module `core/resources/workflow/` (schema + api) over `GET /api/apps/{app_id}/workflows` and `/workflows/runs` — workflows are authored in the builder, so no `Resource<T>`/pull/push.
- `cli/commands/workflows/` — `list`, `runs`, and a shared translation of the workflows-not-enabled 403 into an explanation (apps predating the Workflows system).
- Empty results are disambiguated ("this app has no workflows" vs "no runs match your filters") — one extra GET, only on the empty path.
- `run-now`/test runs are always shown, marked `(test)` / `isTestRun` — an agent verifying its own workflow only has test runs, so hiding them would make empty read as healthy.
- `--since` accepts ISO or relative shorthand (`1h`, `2d`) via `normalizeDatetime`, extracted from `logs.ts` into `cli/utils/datetime.ts` and shared by both commands.

## Tests

- 14 new specs (`workflows_list.spec.ts`, `workflows_runs.spec.ts`) + testkit mocks with query-param capture.
- Live-verified against a real app: real overnight scheduled cron runs, including a scheduled failure surfaced by `--status failed`.

## Notes

- Naming: plural `workflows` matching the existing command families (`functions`, `entities`, `connectors`); Guy's phrasing was singular `workflow` — flagged as an open item, rename is a one-liner if ruled.
- Deferred (recorded in suss-tasks): run detail with `steps[]`, `workflows open`, legacy-automations fallback.
- Companion skills-repo change (reference pages for both commands) is prepared on `base44/skills` branch `feat/workflows-runs-reference`, to merge after the CLI release that ships this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)