### PR TITLE
ci: SHA-pin all actions (org SHA-lock policy)

### DIFF
--- a/.github/workflows/check-wix-proxy.yml
+++ b/.github/workflows/check-wix-proxy.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Wix gateway proxy (mandatory)
         uses: ./.github/actions/wix-gateway-proxy
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
 
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@5ef2e550a465a721f4f45e4a7d3c340c873e1dcc # v1
         with:
           show_full_output: true
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
 
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@5ef2e550a465a721f4f45e4a7d3c340c873e1dcc # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 

--- a/.github/workflows/daily-error-report.yml
+++ b/.github/workflows/daily-error-report.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
 
@@ -29,7 +29,7 @@ jobs:
         uses: ./.github/actions/wix-gateway-proxy
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 
@@ -77,7 +77,7 @@ jobs:
 
       - name: Generate report with Claude
         if: steps.check-errors.outputs.has_errors == 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@5ef2e550a465a721f4f45e4a7d3c340c873e1dcc # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |

--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -12,19 +12,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Wix gateway proxy (mandatory)
         uses: ./.github/actions/wix-gateway-proxy
 
       - name: Setup Bun
         id: setup-bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ steps.setup-bun.outputs.bun-version }}-${{ hashFiles('**/bun.lock') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,19 +12,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Wix gateway proxy (mandatory)
         uses: ./.github/actions/wix-gateway-proxy
 
       - name: Setup Bun
         id: setup-bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ steps.setup-bun.outputs.bun-version }}-${{ hashFiles('**/bun.lock') }}

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -42,20 +42,20 @@ jobs:
 
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ vars.BASE44_GITHUB_ACTIONS_APP_ID }}
           private-key: ${{ secrets.BASE44_GITHUB_ACTIONS_APP_PRIVATE_KEY }}
           owner: base44
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".node-version"
           registry-url: "https://registry.npmjs.org"
@@ -65,12 +65,12 @@ jobs:
 
       - name: Setup Bun
         id: setup-bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ steps.setup-bun.outputs.bun-version }}-${{ hashFiles('**/bun.lock') }}
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload sourcemaps to PostHog
         if: github.event.inputs.dry_run == 'false'
-        uses: PostHog/upload-source-maps@v0.4.6
+        uses: PostHog/upload-source-maps@e798a054427efc710af080354f8450d3c154c584 # v0.4.6
         with:
           directory: ./${{ env.CLI_PACKAGE_DIR }}/dist/cli
           env-id: ${{ vars.POSTHOG_PROJECT_ID }}
@@ -179,7 +179,7 @@ jobs:
 
       - name: Notify skills repo
         if: github.event.inputs.dry_run == 'false' && github.event.inputs.notify_skills_repo == 'true'
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           token: ${{ steps.generate-token.outputs.token }}
           repository: base44/skills

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run Claude to Generate PR Description
         id: claude-description
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@5ef2e550a465a721f4f45e4a7d3c340c873e1dcc # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |

--- a/.github/workflows/preview-publish.yml
+++ b/.github/workflows/preview-publish.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Wix gateway proxy (mandatory)
         uses: ./.github/actions/wix-gateway-proxy
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: ".node-version"
           registry-url: "https://registry.npmjs.org"
@@ -30,12 +30,12 @@ jobs:
 
       - name: Setup Bun
         id: setup-bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ steps.setup-bun.outputs.bun-version }}-${{ hashFiles('**/bun.lock') }}
@@ -149,7 +149,7 @@ jobs:
           fi
 
       - name: Comment PR with install instructions
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
         with:
           script: |
             const fullPackage = '${{ steps.preview_info.outputs.full_package }}';

--- a/.github/workflows/readme-check.yml
+++ b/.github/workflows/readme-check.yml
@@ -21,7 +21,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
 
@@ -29,12 +29,12 @@ jobs:
         uses: ./.github/actions/wix-gateway-proxy
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
 
@@ -68,7 +68,7 @@ jobs:
           )" --allowedTools "Read,Glob,Grep,Write(packages/cli/README.md),Edit(packages/cli/README.md)"
 
       - name: Restore lychee cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.sha }}
@@ -76,7 +76,7 @@ jobs:
 
       - name: Check for broken links in README
         id: lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
         with:
           args: --verbose --no-progress --cache --max-cache-age 1d packages/cli/README.md
           output: .lychee-results.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,13 @@ jobs:
         working-directory: packages/cli
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Wix gateway proxy (mandatory)
         uses: ./.github/actions/wix-gateway-proxy
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
@@ -35,7 +35,7 @@ jobs:
         run: bun run build:binaries
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist
           path: packages/cli/dist
@@ -55,24 +55,24 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Wix gateway proxy (mandatory)
         uses: ./.github/actions/wix-gateway-proxy
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "22"
 
       - name: Setup Bun
         id: setup-bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ steps.setup-bun.outputs.bun-version }}-${{ hashFiles('**/bun.lock') }}
@@ -80,7 +80,7 @@ jobs:
             ${{ runner.os }}-bun-${{ steps.setup-bun.outputs.bun-version }}-
 
       - name: Setup Deno
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2
         with:
           deno-version: v2.x
 
@@ -89,7 +89,7 @@ jobs:
         working-directory: .
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: dist
           path: packages/cli/dist

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -15,19 +15,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Wix gateway proxy (mandatory)
         uses: ./.github/actions/wix-gateway-proxy
 
       - name: Setup Bun
         id: setup-bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ steps.setup-bun.outputs.bun-version }}-${{ hashFiles('**/bun.lock') }}

--- a/.github/workflows/wix-gateway-proxy-check.yml
+++ b/.github/workflows/wix-gateway-proxy-check.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm install mermaid-rs-wasm@0.0.3
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 


### PR DESCRIPTION
## Summary

Actions were re-enabled on the base44 org (~12:20 today) with a new policy: third-party actions must be SHA-locked. Tag-pinned workflows now fail at startup (`startup_failure`, 0s — observed on PR #598's branch, where only the already-SHA-pinned cooldown check survived).

This PR pins **every** `uses:` reference across all 13 workflows to a full commit SHA, keeping the tag as a trailing comment — the same form the surviving workflows already use for `actions/checkout@3d3c42e…`. GitHub-owned `actions/*` are pinned too: it matches the surviving example and cannot violate any narrower reading of the policy.

| Action | Pinned SHA | Tag |
|---|---|---|
| actions/checkout | `11d5960a326750d5838078e36cf38b85af677262` | v4 |
| actions/setup-node | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4 |
| actions/setup-python | `ece7cb06caefa5fff74198d8649806c4678c61a1` | v6 |
| actions/cache | `caa296126883cff596d87d8935842f9db880ef25` / `0057852bfaa89a56745cba8c7296529d2fc39830` | v5 / v4 |
| actions/upload-artifact | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4 |
| actions/download-artifact | `d3f86a106a0bac45b974a628896c90dbdf5c8093` | v4 |
| actions/github-script | `d7906e4ad0b1822421a7e6a35d5ca353c962f410` | v6 |
| actions/create-github-app-token | `fee1f7d63c2ff003460e3d139729b119787bc349` | v2 |
| oven-sh/setup-bun | `0c5077e51419868618aeaa5fe8019c62421857d6` | v2 |
| denoland/setup-deno | `22d081ff2d3a40755e97629de92e3bcbfa7cf2ed` | v2 |
| anthropics/claude-code-action | `5ef2e550a465a721f4f45e4a7d3c340c873e1dcc` | v1 |
| PostHog/upload-source-maps | `e798a054427efc710af080354f8450d3c154c584` | v0.4.6 |
| peter-evans/repository-dispatch | `28959ce8df70de7be546dd1250a005dd32156697` | v4 |
| lycheeverse/lychee-action | `e7477775783ea5526144ba13e8db5eec57747ce8` | v2 |

Every SHA resolved today via `gh api repos/{owner}/{repo}/commits/{tag}`. No behavior changes — pins only. The local composite action (`./.github/actions/wix-gateway-proxy`) contains no nested `uses:` and needs nothing.

No overlap with #598 (it only adds new files). This PR's own CI run doubles as the policy verification: workflows should now START (whether they pass is a separate question — see `suss-tasks/exec_tests_broken_by_wix_embargo.md` for the known exec-suite red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)