### PR TITLE
fix(exec): ship the SDK with the CLI instead of fetching it at run time

### DIFF
--- a/packages/cli/backend-runtime/import-map.json
+++ b/packages/cli/backend-runtime/import-map.json
@@ -1,5 +1,6 @@
 {
   "imports": {
-    "base44:runtime": "./base44-runtime.ts"
+    "base44:runtime": "./base44-runtime.ts",
+    "npm:@base44/sdk": "./vendor/base44-sdk.js"
   }
 }

--- a/packages/cli/infra/build-binaries.ts
+++ b/packages/cli/infra/build-binaries.ts
@@ -56,6 +56,9 @@ for (const required of [
 	"dist/assets/backend-runtime/main.ts",
 	"dist/assets/backend-runtime/import-map.json",
 	"dist/assets/backend-runtime/base44-runtime.ts",
+	// The import map points at this bundle, so a binary built without it would
+	// only fail once a user actually runs `base44 exec`.
+	"dist/assets/backend-runtime/vendor/base44-sdk.js",
 ]) {
 	if (!existsSync(join(ROOT, required))) {
 		console.error(

--- a/packages/cli/infra/build.ts
+++ b/packages/cli/infra/build.ts
@@ -40,6 +40,19 @@ const copyBackendRuntime = () => {
   return outDir;
 };
 
+// The Deno wrappers import `npm:@base44/sdk`, which the import map redirects to
+// this bundle. Fetching it from a registry at run time fails wherever the
+// registry is proxied behind a TLS-intercepting gateway, so it ships with the
+// CLI and the SDK version is pinned to the release.
+const bundleVendoredSdk = () =>
+  runBuild({
+    entrypoints: ["./infra/vendor/base44-sdk.ts"],
+    outdir: "./dist/assets/backend-runtime/vendor",
+    // Third-party code the user never debugs through us; the map would add
+    // ~1MB to the published package for nothing.
+    sourcemap: "none",
+  });
+
 // Runtime dependencies of the local workerd function runtime. They cannot be
 // bundled (workerd and esbuild ship native binaries; @deno/loader ships WASM),
 // so they are real npm `dependencies` resolved from node_modules at runtime —
@@ -55,6 +68,7 @@ const runAllBuilds = async () => {
     external: RUNTIME_EXTERNALS,
   });
   const backendRuntimePath = copyBackendRuntime();
+  await bundleVendoredSdk();
   return {
     cli,
     backendRuntimePath,

--- a/packages/cli/infra/vendor/base44-sdk.ts
+++ b/packages/cli/infra/vendor/base44-sdk.ts
@@ -1,0 +1,4 @@
+// Bundle entry for the vendored SDK shipped to the Deno runtimes. The exec
+// wrapper imports `npm:@base44/sdk`, which the runtime import map redirects
+// here so Deno never fetches it from a registry at run time.
+export * from "@base44/sdk";

--- a/packages/cli/src/core/assets.ts
+++ b/packages/cli/src/core/assets.ts
@@ -17,6 +17,10 @@ function getBackendRuntimeDir(): string {
   return join(ASSETS_DIR, "backend-runtime");
 }
 
+export function getImportMapPath(): string {
+  return join(getBackendRuntimeDir(), "import-map.json");
+}
+
 export function getDenoWrapperPath(): string {
   return join(getBackendRuntimeDir(), "main.ts");
 }

--- a/packages/cli/src/core/exec/run-script.ts
+++ b/packages/cli/src/core/exec/run-script.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { copyFileSync, writeFileSync } from "node:fs";
 import { file } from "tmp-promise";
-import { getExecWrapperPath } from "@/core/assets.js";
+import { getExecWrapperPath, getImportMapPath } from "@/core/assets.js";
 import { getAppUserToken, getSiteUrl } from "@/core/project/api.js";
 import { verifyDenoInstalled } from "@/core/utils/index.js";
 
@@ -50,11 +50,23 @@ export async function runScript(
   cleanupFns.push(tempWrapper.cleanup);
   copyFileSync(getExecWrapperPath(), tempWrapper.path);
 
+  // Redirects the wrapper's `npm:@base44/sdk` import to the SDK bundled with
+  // this release. Its entries resolve relative to the map itself, so it stays
+  // correct even though the wrapper runs from a temp directory.
+  const importMapPath = getImportMapPath();
+
   try {
     const exitCode = await new Promise<number>((resolvePromise) => {
       const child = spawn(
         "deno",
-        ["run", "--allow-all", "--node-modules-dir=auto", tempWrapper.path],
+        [
+          "run",
+          "--allow-all",
+          "--node-modules-dir=auto",
+          "--import-map",
+          importMapPath,
+          tempWrapper.path,
+        ],
         {
           env: {
             ...process.env,


### PR DESCRIPTION
## The bug

`base44 exec` spawns a Deno wrapper whose first job is `import { createClient } from "npm:@base44/sdk"` — a **live registry fetch on every invocation**. That breaks wherever the npm registry is proxied behind a TLS-intercepting gateway (the wix-embargo setup): the gateway serves its **CA certificate as the server certificate**, and Deno's TLS stack rejects a CA cert used as a server identity *before* consulting any trust store:

```
error: Failed loading https://registry.npmjs.org/@base44%2fsdk for package "@base44/sdk"
  invalid peer certificate: Other(OtherError(CaUsedAsEndEntity))
```

No client-side configuration can fix that — `DENO_CERT`, `DENO_TLS_CA_STORE`, `NODE_EXTRA_CA_CERTS`, keychain trust and `--cert` were all verified failing, because the rejection is about the certificate's *role*, not its trust. npm tolerates the same certificate, which is why only Deno breaks.

Impact today: **14 of 17 `exec.spec.ts` tests red** on any branch on an embargo machine, and the same in CI — see main's run [31506489004](https://github.com/base44/cli/actions/runs/31506489004) (104× `CaUsedAsEndEntity` across all four matrix legs).

## The fix

Stop fetching at run time. The SDK is bundled into the runtime assets at build time, and the specifier is redirected there through the import map the Deno runtimes **already ship** — the same mechanism `function-manager.ts` uses for `base44:runtime`.

| Touchpoint | Change |
|---|---|
| `infra/vendor/base44-sdk.ts` | new 1-line bundle entry (`export * from "@base44/sdk"`) |
| `infra/build.ts` | bundles it to `dist/assets/backend-runtime/vendor/base44-sdk.js` |
| `backend-runtime/import-map.json` | maps `npm:@base44/sdk` → `./vendor/base44-sdk.js` |
| `src/core/exec/run-script.ts` | passes `--import-map` to the Deno spawn (it passed none) |
| `src/core/assets.ts` | exports `getImportMapPath()` |

No new dependencies: `@base44/sdk` was already a `devDependency` (`^0.8.23`), and the bundle is produced by the existing Bun build. Import map entries resolve relative to **the map**, which is what makes this correct even though `run-script.ts` copies the wrapper to a temp file before running it.

## Verification

The interesting failure mode only appears with a **cold Deno cache and no `.npmrc`** — a warm cache or a dev machine's `~/.npmrc` (which points Deno at an internal mirror) hides it, which is exactly why this looked CI-only. So the mechanism was proved directly, replaying the CLI's own Deno invocation with the shipped artifacts:

- with the shipped import map → wrapper runs, `base44` global is live, **zero network access**
- identical invocation **without** `--import-map` → still fails with `CaUsedAsEndEntity` (control, so the test can fail)

Suite results on an embargo machine: **`exec.spec.ts` 17/17 (was 3/17)**, full suite **732/732**, typecheck / lint / knip clean.

## Decisions & trade-offs recorded

1. **SDK version is now pinned to the CLI release** (0.8.23 per the lockfile) instead of resolving to whatever is latest at run time. More reproducible, but an SDK release now needs a CLI release to reach `exec`. Registry latest is 0.8.41 — bumping is a separate, deliberate call, not folded in here.
2. **The map is shared with the functions runtime**, so functions that import `npm:@base44/sdk` get the vendored copy too. Deliberate: same benefit, one artifact.
3. **This covers our own import only.** A *user* script that imports npm packages under `base44 exec` still needs a working registry path — the general fix remains gateway-side (serve a `CA:FALSE` leaf signed by the existing embargo CA), which is being pursued separately with the platform team.
4. **`--unsafely-ignore-certificate-errors` was rejected** as a shipped default: it works and would also rescue user scripts, but it disables TLS verification for a host on every user's machine. If ever wanted, it should be an explicit opt-in env var.
5. **No sourcemap for the vendored bundle** — third-party code nobody debugs through us; it would add ~1MB to the published package.
6. **`ensureNpmAssets` guard left alone.** I first extended it to require the new `vendor/` dir and a test correctly caught that this breaks its one-time-bootstrap contract (local edits must survive). A published version always ships identical assets, so a same-version dir can never legitimately lack the bundle — the guard would have been ghost code. Dev machines using `bun link` still need `rm -rf ~/.base44/assets/<version>` after changing assets, which is pre-existing and documented.

Background and full evidence: `suss-tasks/exec_tests_broken_by_wix_embargo.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)