### PR TITLE
tests: Use neutral npm proxy wording

### DIFF
--- a/packages/cli/tests/cli/exec.spec.ts
+++ b/packages/cli/tests/cli/exec.spec.ts
@@ -2,7 +2,7 @@ import stripAnsi from "strip-ansi";
 import { describe, expect, it } from "vitest";
 import { fixture, setupCLITests } from "./testkit/index.js";
 
-describe.skip("exec command (Deno rejects the Wix npm proxy CA used as a TLS leaf)", () => {
+describe.skip("exec command (npm proxy TLS is incompatible with Deno)", () => {
   const t = setupCLITests();
 
   it("fails with helpful error when stdin is empty", async () => {


### PR DESCRIPTION
### What?

The skipped `exec` suite now describes the test-environment limitation as an npm proxy TLS incompatibility with Deno. This keeps the reason visible in Vitest without referring to the proxy operator.

Follow-up to #603.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=a223448a-f7ee-412b-b926-47ad2f5b6316) · `dev3://task/a223448a-f7ee-412b-b926-47ad2f5b6316`