### PR TITLE
functions: Accept null repeat intervals

### DIFF
--- a/packages/cli/src/core/resources/function/schema.ts
+++ b/packages/cli/src/core/resources/function/schema.ts
@@ -49,7 +49,7 @@ const ScheduledSimpleSchema = AutomationBaseSchema.extend({
   schedule_mode: z.literal("recurring"),
   schedule_type: z.literal("simple"),
   repeat_unit: z.enum(["minutes", "hours", "days", "weeks", "months"]),
-  repeat_interval: z.number().int().positive().optional(),
+  repeat_interval: z.number().int().positive().nullable().optional(),
   start_time: z.string().nullable().optional(),
   repeat_on_days: z.array(z.number().int().min(0).max(6)).nullable().optional(),
   repeat_on_day_of_month: z.number().int().min(1).max(31).nullable().optional(),

--- a/packages/cli/tests/core/function-schema.spec.ts
+++ b/packages/cli/tests/core/function-schema.spec.ts
@@ -281,3 +281,32 @@ describe("Function connector automation schemas", () => {
     ]);
   });
 });
+
+describe("Function scheduled automation schemas", () => {
+  it("accepts null repeat intervals for weekly and monthly schedules", () => {
+    for (const repeatUnit of ["weeks", "months"]) {
+      const result = ListFunctionsResponseSchema.safeParse({
+        functions: [
+          {
+            name: "scheduled-function",
+            deployment_id: "dep_123",
+            entry: "entry.ts",
+            files: [{ path: "entry.ts", content: "" }],
+            automations: [
+              {
+                name: `${repeatUnit}-schedule`,
+                type: "scheduled",
+                schedule_mode: "recurring",
+                schedule_type: "simple",
+                repeat_unit: repeatUnit,
+                repeat_interval: null,
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result.success).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
### What?

Function list responses can include `repeat_interval: null` for weekly and monthly schedules. We now accept that shape and cover both schedule units in the response schema test.

### Why?

Before this, one such automation caused the entire functions response to fail with `SCHEMA_INVALID`, breaking list, pull, remote logs, and force deploy flows for affected apps.

---
🔗 **Origin task in dev3:** [open in dev3](https://dev3.h0x91b.com/open.html?task=2ca20129-62e3-4069-ba47-b1816823adac) · `dev3://task/2ca20129-62e3-4069-ba47-b1816823adac`