### PR TITLE
Add read-only entity schema listing

### DIFF
--- a/packages/cli/src/cli/commands/entities/list.ts
+++ b/packages/cli/src/cli/commands/entities/list.ts
@@ -1,0 +1,15 @@
+import { Command } from "commander";
+import type { CLIContext, RunCommandResult } from "@/cli/types.js";
+import { Base44Command } from "@/cli/utils/index.js";
+import { listEntitySchemas } from "@/core/resources/entity/index.js";
+
+async function listEntitiesAction({ jsonMode }: CLIContext): Promise<RunCommandResult> {
+  const catalog = await listEntitySchemas();
+  return { stdout: jsonMode ? `${JSON.stringify(catalog)}\n` : undefined, outroMessage: jsonMode ? undefined : JSON.stringify(catalog, null, 2) };
+}
+
+export function getEntitiesListCommand(): Command {
+  return new Base44Command("list")
+    .description("List remote entity schemas (read-only)")
+    .action(listEntitiesAction);
+}

--- a/packages/cli/src/cli/commands/entities/push.ts
+++ b/packages/cli/src/cli/commands/entities/push.ts
@@ -3,6 +3,7 @@ import type { CLIContext, RunCommandResult } from "@/cli/types.js";
 import { Base44Command, confirmPush } from "@/cli/utils/index.js";
 import { readProjectConfig } from "@/core/index.js";
 import { pushEntities } from "@/core/resources/entity/index.js";
+import { getEntitiesListCommand } from "@/cli/commands/entities/list.js";
 
 interface PushOptions {
   yes?: boolean;
@@ -65,5 +66,6 @@ export function getEntitiesPushCommand(): Command {
         .description("Push local entities to Base44")
         .option("-y, --yes", "Skip confirmation prompt")
         .action(pushEntitiesAction),
-    );
+    )
+    .addCommand(getEntitiesListCommand());
 }

--- a/packages/cli/src/core/resources/entity/api.ts
+++ b/packages/cli/src/core/resources/entity/api.ts
@@ -7,6 +7,17 @@ import type {
 } from "@/core/resources/entity/schema.js";
 import { SyncEntitiesResponseSchema } from "@/core/resources/entity/schema.js";
 
+/** Read the remote entity catalog without touching records or mutating resources. */
+export async function listEntitySchemas(): Promise<unknown> {
+  const appClient = getAppClient();
+  try {
+    const response = await appClient.get("entity-schemas");
+    return await response.json();
+  } catch (error) {
+    throw await ApiError.fromHttpError(error, "listing entity schemas");
+  }
+}
+
 export async function syncEntities(
   entities: Entity[],
 ): Promise<SyncEntitiesResponse> {


### PR DESCRIPTION
## Summary
- add `base44 entities list` for the authenticated platform client
- perform only GET `/api/apps/:appId/entity-schemas`
- support machine-readable JSON output for governed schema audits

## Validation
- `bun run typecheck`
- focused entities CLI tests: 8/8 passed

This enables read-only schema-sensitive tooling without exporting `BASE44_AUTH_TOKEN`.
