### PR TITLE
fix(logs): avoid loading local project resources

### DIFF
--- a/packages/cli/src/cli/commands/project/logs.ts
+++ b/packages/cli/src/cli/commands/project/logs.ts
@@ -3,7 +3,6 @@ import { Option } from "commander";
 import type { CLIContext, RunCommandResult } from "@/cli/types.js";
 import { Base44Command, normalizeDatetime } from "@/cli/utils/index.js";
 import { ApiError, InvalidInputError } from "@/core/errors.js";
-import { readProjectConfig } from "@/core/index.js";
 import type {
   FunctionLogFilters,
   FunctionLogsResponse,
@@ -188,27 +187,29 @@ async function fetchLogsForFunctions(
     try {
       logs = await fetchFunctionLogs(functionName, filters);
     } catch (error) {
-      if (
-        error instanceof ApiError &&
-        error.statusCode === 404 &&
-        availableFunctionNames.length > 0
-      ) {
-        const available = availableFunctionNames.join(", ");
-        throw new InvalidInputError(
-          `Function "${functionName}" was not found in this app`,
-          {
-            hints: [
-              {
-                message: `Available functions in this project: ${available}`,
-              },
-              {
-                message:
-                  "Make sure the function has been deployed before fetching logs",
-                command: "base44 functions deploy",
-              },
-            ],
-          },
-        );
+      if (error instanceof ApiError && error.statusCode === 404) {
+        const namesForHint =
+          availableFunctionNames.length > 0
+            ? availableFunctionNames
+            : await getRemoteFunctionNames();
+        if (namesForHint.length > 0) {
+          const available = namesForHint.join(", ");
+          throw new InvalidInputError(
+            `Function "${functionName}" was not found in this app`,
+            {
+              hints: [
+                {
+                  message: `Available functions in this app: ${available}`,
+                },
+                {
+                  message:
+                    "Make sure the function has been deployed before fetching logs",
+                  command: "base44 functions deploy",
+                },
+              ],
+            },
+          );
+        }
       }
       throw error;
     }
@@ -235,11 +236,6 @@ async function fetchLogsForFunctions(
   return allEntries;
 }
 
-async function getProjectFunctionNames(projectRoot: string): Promise<string[]> {
-  const { functions } = await readProjectConfig(projectRoot);
-  return functions.map((fn) => fn.name);
-}
-
 async function getRemoteFunctionNames(): Promise<string[]> {
   const { functions } = await listDeployedFunctions();
   return functions.map((fn) => fn.name);
@@ -261,21 +257,13 @@ async function logsAction(
 ): Promise<RunCommandResult> {
   validateLimit(options.limit);
   const specifiedFunctions = parseFunctionNames(options.function);
-  const localProjectRoot = ctx.app?.projectRoot;
-
-  const availableFunctionNames = localProjectRoot
-    ? await getProjectFunctionNames(localProjectRoot)
-    : await getRemoteFunctionNames();
-
+  const availableFunctionNames =
+    specifiedFunctions.length === 0 ? await getRemoteFunctionNames() : [];
   const functionNames =
     specifiedFunctions.length > 0 ? specifiedFunctions : availableFunctionNames;
 
   if (functionNames.length === 0) {
-    return {
-      outroMessage: localProjectRoot
-        ? "No functions found in this project."
-        : "No functions found in this app.",
-    };
+    return { outroMessage: "No functions found in this app." };
   }
 
   if (options.follow) {
@@ -327,7 +315,7 @@ export function getLogsCommand(): Command {
     .description("Fetch function logs for this app")
     .option(
       "--function <names>",
-      "Filter by function name(s), comma-separated. If omitted, fetches logs for all project functions",
+      "Filter by function name(s), comma-separated. If omitted, fetches logs for all deployed functions",
     )
     .option(
       "--since <datetime>",

--- a/packages/cli/src/cli/commands/project/logs.ts
+++ b/packages/cli/src/cli/commands/project/logs.ts
@@ -174,45 +174,6 @@ function normalizeLogEntry(
   };
 }
 
-async function getRemoteFunctionNames(): Promise<string[]> {
-  const { functions } = await listDeployedFunctions();
-  return functions.map((fn) => fn.name);
-}
-
-async function getFunctionNamesForHint(
-  availableFunctionNames: string[],
-  logsError: ApiError,
-): Promise<string[]> {
-  if (availableFunctionNames.length > 0) return availableFunctionNames;
-  try {
-    return await getRemoteFunctionNames();
-  } catch {
-    throw logsError;
-  }
-}
-
-function createFunctionNotFoundError(
-  functionName: string,
-  availableFunctionNames: string[],
-  logsError: ApiError,
-) {
-  const available = availableFunctionNames.join(", ");
-  return new InvalidInputError(
-    `Function "${functionName}" was not found in this app`,
-    {
-      cause: logsError,
-      hints: [
-        { message: `Available functions in this app: ${available}` },
-        {
-          message:
-            "Make sure the function has been deployed before fetching logs",
-          command: "base44 functions deploy",
-        },
-      ],
-    },
-  );
-}
-
 async function fetchLogsForFunctions(
   functionNames: string[],
   options: LogsOptions,
@@ -226,13 +187,32 @@ async function fetchLogsForFunctions(
     try {
       logs = await fetchFunctionLogs(functionName, filters);
     } catch (error) {
-      if (!(error instanceof ApiError) || error.statusCode !== 404) throw error;
-      const namesForHint = await getFunctionNamesForHint(
-        availableFunctionNames,
-        error,
-      );
-      if (namesForHint.length === 0) throw error;
-      throw createFunctionNotFoundError(functionName, namesForHint, error);
+      if (error instanceof ApiError && error.statusCode === 404) {
+        const namesForHint = await getFunctionNamesForHint(
+          availableFunctionNames,
+          error,
+        );
+        if (namesForHint.length > 0) {
+          const available = namesForHint.join(", ");
+          throw new InvalidInputError(
+            `Function "${functionName}" was not found in this app`,
+            {
+              cause: error,
+              hints: [
+                {
+                  message: `Available functions in this app: ${available}`,
+                },
+                {
+                  message:
+                    "Make sure the function has been deployed before fetching logs",
+                  command: "base44 functions deploy",
+                },
+              ],
+            },
+          );
+        }
+      }
+      throw error;
     }
 
     // The backend does not filter by level for every runtime (per-app
@@ -257,6 +237,23 @@ async function fetchLogsForFunctions(
   return allEntries;
 }
 
+async function getRemoteFunctionNames(): Promise<string[]> {
+  const { functions } = await listDeployedFunctions();
+  return functions.map((fn) => fn.name);
+}
+
+async function getFunctionNamesForHint(
+  availableFunctionNames: string[],
+  logsError: ApiError,
+): Promise<string[]> {
+  if (availableFunctionNames.length > 0) return availableFunctionNames;
+  try {
+    return await getRemoteFunctionNames();
+  } catch {
+    throw logsError;
+  }
+}
+
 function validateLimit(limit: string | undefined): void {
   if (limit === undefined) return;
   const n = Number.parseInt(limit, 10);
@@ -275,7 +272,6 @@ async function logsAction(
   const specifiedFunctions = parseFunctionNames(options.function);
   const availableFunctionNames =
     specifiedFunctions.length === 0 ? await getRemoteFunctionNames() : [];
-
   const functionNames =
     specifiedFunctions.length > 0 ? specifiedFunctions : availableFunctionNames;
 

--- a/packages/cli/src/cli/commands/project/logs.ts
+++ b/packages/cli/src/cli/commands/project/logs.ts
@@ -194,11 +194,13 @@ async function getFunctionNamesForHint(
 function createFunctionNotFoundError(
   functionName: string,
   availableFunctionNames: string[],
+  logsError: ApiError,
 ) {
   const available = availableFunctionNames.join(", ");
   return new InvalidInputError(
     `Function "${functionName}" was not found in this app`,
     {
+      cause: logsError,
       hints: [
         { message: `Available functions in this app: ${available}` },
         {
@@ -230,7 +232,7 @@ async function fetchLogsForFunctions(
         error,
       );
       if (namesForHint.length === 0) throw error;
-      throw createFunctionNotFoundError(functionName, namesForHint);
+      throw createFunctionNotFoundError(functionName, namesForHint, error);
     }
 
     // The backend does not filter by level for every runtime (per-app

--- a/packages/cli/src/cli/commands/project/logs.ts
+++ b/packages/cli/src/cli/commands/project/logs.ts
@@ -174,6 +174,43 @@ function normalizeLogEntry(
   };
 }
 
+async function getRemoteFunctionNames(): Promise<string[]> {
+  const { functions } = await listDeployedFunctions();
+  return functions.map((fn) => fn.name);
+}
+
+async function getFunctionNamesForHint(
+  availableFunctionNames: string[],
+  logsError: ApiError,
+): Promise<string[]> {
+  if (availableFunctionNames.length > 0) return availableFunctionNames;
+  try {
+    return await getRemoteFunctionNames();
+  } catch {
+    throw logsError;
+  }
+}
+
+function createFunctionNotFoundError(
+  functionName: string,
+  availableFunctionNames: string[],
+) {
+  const available = availableFunctionNames.join(", ");
+  return new InvalidInputError(
+    `Function "${functionName}" was not found in this app`,
+    {
+      hints: [
+        { message: `Available functions in this app: ${available}` },
+        {
+          message:
+            "Make sure the function has been deployed before fetching logs",
+          command: "base44 functions deploy",
+        },
+      ],
+    },
+  );
+}
+
 async function fetchLogsForFunctions(
   functionNames: string[],
   options: LogsOptions,
@@ -187,31 +224,13 @@ async function fetchLogsForFunctions(
     try {
       logs = await fetchFunctionLogs(functionName, filters);
     } catch (error) {
-      if (error instanceof ApiError && error.statusCode === 404) {
-        const namesForHint =
-          availableFunctionNames.length > 0
-            ? availableFunctionNames
-            : await getRemoteFunctionNames();
-        if (namesForHint.length > 0) {
-          const available = namesForHint.join(", ");
-          throw new InvalidInputError(
-            `Function "${functionName}" was not found in this app`,
-            {
-              hints: [
-                {
-                  message: `Available functions in this app: ${available}`,
-                },
-                {
-                  message:
-                    "Make sure the function has been deployed before fetching logs",
-                  command: "base44 functions deploy",
-                },
-              ],
-            },
-          );
-        }
-      }
-      throw error;
+      if (!(error instanceof ApiError) || error.statusCode !== 404) throw error;
+      const namesForHint = await getFunctionNamesForHint(
+        availableFunctionNames,
+        error,
+      );
+      if (namesForHint.length === 0) throw error;
+      throw createFunctionNotFoundError(functionName, namesForHint);
     }
 
     // The backend does not filter by level for every runtime (per-app
@@ -236,11 +255,6 @@ async function fetchLogsForFunctions(
   return allEntries;
 }
 
-async function getRemoteFunctionNames(): Promise<string[]> {
-  const { functions } = await listDeployedFunctions();
-  return functions.map((fn) => fn.name);
-}
-
 function validateLimit(limit: string | undefined): void {
   if (limit === undefined) return;
   const n = Number.parseInt(limit, 10);
@@ -259,6 +273,7 @@ async function logsAction(
   const specifiedFunctions = parseFunctionNames(options.function);
   const availableFunctionNames =
     specifiedFunctions.length === 0 ? await getRemoteFunctionNames() : [];
+
   const functionNames =
     specifiedFunctions.length > 0 ? specifiedFunctions : availableFunctionNames;
 

--- a/packages/cli/tests/cli/logs.spec.ts
+++ b/packages/cli/tests/cli/logs.spec.ts
@@ -476,6 +476,24 @@ describe("logs command", () => {
     );
   });
 
+  it("preserves the logs error when loading the 404 hint fails", async () => {
+    await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockFunctionLogsError("missing-function", {
+      status: 404,
+      body: { error: "Original logs error" },
+    });
+    t.api.mockFunctionsListError({
+      status: 500,
+      body: { error: "Function list error" },
+    });
+
+    const result = await t.run("logs", "--function", "missing-function");
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain("Original logs error");
+    t.expectResult(result).toNotContain("Function list error");
+  });
+
   it("fails when API returns error for function logs", async () => {
     await t.givenLoggedInWithProject(fixture("basic"));
     t.api.mockFunctionLogsError("my-function", {

--- a/packages/cli/tests/cli/logs.spec.ts
+++ b/packages/cli/tests/cli/logs.spec.ts
@@ -98,6 +98,15 @@ describe("logs command", () => {
     t.expectResult(result).toContain("Something went wrong");
   });
 
+  it("does not load local resources when --function is specified", async () => {
+    await t.givenLoggedInWithProject(fixture("invalid-entity"));
+    t.api.mockFunctionLogs("my-function", []);
+
+    const result = await t.run("logs", "--function", "my-function");
+
+    t.expectResult(result).toSucceed();
+  });
+
   it("fetches logs for multiple functions with --function comma-separated", async () => {
     await t.givenLoggedInWithProject(fixture("basic"));
     t.api.mockFunctionLogs("fn1", [
@@ -114,16 +123,31 @@ describe("logs command", () => {
     t.expectResult(result).toContain("From fn2");
   });
 
-  it("fetches logs for all project functions when no --function specified", async () => {
-    await t.givenLoggedInWithProject(fixture("full-project"));
-    t.api.mockFunctionLogs("hello", [
-      { time: "2024-01-15T10:29:00Z", level: "info", message: "Hello world" },
+  it("fetches logs for all deployed functions inside a local project", async () => {
+    await t.givenLoggedInWithProject(fixture("invalid-entity"));
+    t.api.mockFunctionsList({
+      functions: [
+        {
+          name: "remote-fn",
+          deployment_id: "d1",
+          entry: "entry.ts",
+          files: [{ path: "entry.ts", content: "" }],
+          automations: [],
+        },
+      ],
+    });
+    t.api.mockFunctionLogs("remote-fn", [
+      {
+        time: "2024-01-15T10:29:00Z",
+        level: "info",
+        message: "Remote function log",
+      },
     ]);
 
     const result = await t.run("logs");
 
     t.expectResult(result).toSucceed();
-    t.expectResult(result).toContain("Hello world");
+    t.expectResult(result).toContain("Remote function log");
   });
 
   it("fetches logs for path-named (zero-config) function", async () => {
@@ -144,17 +168,6 @@ describe("logs command", () => {
 
   it("fetches logs for a specified function with --app-id outside a project", async () => {
     await t.givenLoggedIn({ email: "test@example.com", name: "Test User" });
-    t.api.mockFunctionsList({
-      functions: [
-        {
-          name: "my-function",
-          deployment_id: "d1",
-          entry: "entry.ts",
-          files: [{ path: "entry.ts", content: "" }],
-          automations: [],
-        },
-      ],
-    });
     t.api.mockFunctionLogs("my-function", [
       {
         time: "2024-01-15T10:30:00.000Z",
@@ -178,17 +191,6 @@ describe("logs command", () => {
   it("fetches logs for a specified function with BASE44_APP_ID outside a project", async () => {
     await t.givenLoggedIn({ email: "test@example.com", name: "Test User" });
     t.givenEnv({ BASE44_APP_ID: t.api.appId });
-    t.api.mockFunctionsList({
-      functions: [
-        {
-          name: "my-function",
-          deployment_id: "d1",
-          entry: "entry.ts",
-          files: [{ path: "entry.ts", content: "" }],
-          automations: [],
-        },
-      ],
-    });
     t.api.mockFunctionLogs("my-function", [
       {
         time: "2024-01-15T10:30:00.000Z",
@@ -230,13 +232,14 @@ describe("logs command", () => {
     t.expectResult(result).toContain("Remote function log");
   });
 
-  it("shows no functions message when project has no functions", async () => {
+  it("shows no functions message when the app has no deployed functions", async () => {
     await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockFunctionsList({ functions: [] });
 
     const result = await t.run("logs");
 
     t.expectResult(result).toSucceed();
-    t.expectResult(result).toContain("No functions found in this project");
+    t.expectResult(result).toContain("No functions found in this app");
   });
 
   it("shows no logs message when empty", async () => {
@@ -311,11 +314,12 @@ describe("logs command", () => {
     t.expectResult(result).toFail();
   });
 
-  it("documents --level in --help", async () => {
+  it("documents log filters in --help", async () => {
     const result = await t.run("logs", "--help");
 
     t.expectResult(result).toSucceed();
     t.expectResult(result).toContain("--level <level>");
+    t.expectResult(result).toContain("all deployed functions");
   });
 
   it("filters function logs by --level", async () => {
@@ -444,6 +448,32 @@ describe("logs command", () => {
 
     t.expectResult(result).toFail();
     t.expectResult(result).toContain("No Base44 app ID found");
+  });
+
+  it("shows deployed function names when a specified function is missing", async () => {
+    await t.givenLoggedInWithProject(fixture("invalid-entity"));
+    t.api.mockFunctionLogsError("missing-function", {
+      status: 404,
+      body: { error: "Not found" },
+    });
+    t.api.mockFunctionsList({
+      functions: [
+        {
+          name: "available-function",
+          deployment_id: "d1",
+          entry: "entry.ts",
+          files: [{ path: "entry.ts", content: "" }],
+          automations: [],
+        },
+      ],
+    });
+
+    const result = await t.run("logs", "--function", "missing-function");
+
+    t.expectResult(result).toFail();
+    t.expectResult(result).toContain(
+      "Available functions in this app: available-function",
+    );
   });
 
   it("fails when API returns error for function logs", async () => {


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> `base44 logs` used to read the local project config to figure out which functions to fetch logs for. That meant an unrelated local config error (e.g. an invalid entity file) could break a purely remote, read-only command, and the "function not found" hint listed local functions rather than what is actually deployed. This PR makes the command source function names exclusively from the deployed-functions API, and only when it actually needs them.
>
> It also hardens the 404 path: the available-functions hint is now looked up lazily, and if that lookup fails the original logs error is rethrown instead of being masked by a secondary failure. When the hint does succeed, the 404 is attached as the `cause` of the resulting `InvalidInputError`.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Dropped `readProjectConfig` / `getProjectFunctionNames` from `logs.ts` — the command no longer loads local project resources, so a broken local config cannot fail a remote log fetch.
> - Function names are now resolved only from `listDeployedFunctions()`, and only when `--function` is omitted; with `--function` specified no list call is made at all.
> - Added `getFunctionNamesForHint()`: on a 404 it lazily fetches deployed function names for the hint, and rethrows the original logs error if that fetch fails, so a secondary error never masks the real one.
> - The `InvalidInputError` for a missing function now carries the 404 `ApiError` as its `cause`, and the hint text reads "Available functions in this app" instead of "in this project".
> - Unified the empty-state message to "No functions found in this app." (no more local/remote split).
> - Updated the `--function` help text to say logs are fetched for "all deployed functions" when the flag is omitted.
> - Tests: added coverage for skipping local resources with `--function`, listing deployed names in the 404 hint, and preserving the original error when the hint lookup fails; reworked existing tests to mock the functions list and removed now-unnecessary mocks.
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [x] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> Behavior change worth noting: inside a local project, `base44 logs` with no `--function` now lists logs for functions deployed to the app rather than functions declared locally. Functions that exist locally but have never been deployed will no longer appear — which matches what the logs API can actually return.
>
> The test suite was not executed in this environment (running it needs `bun run build` first), so the "tested locally"/"all tests pass" boxes are left unchecked pending CI.
>
> ---
> <sub>🤖 Generated by Claude | 2026-08-27 10:26 UTC | 4743740</sub>