### PR TITLE
fix(logs): address the #595 review — cancel the body, surface auth errors, poll for --since

### DIFF
--- a/packages/cli/src/cli/commands/project/logs.ts
+++ b/packages/cli/src/cli/commands/project/logs.ts
@@ -1,3 +1,4 @@
+import { setTimeout as delay } from "node:timers/promises";
 import type { Logger } from "@base44-cli/logger";
 import type { Command } from "commander";
 import { Option } from "commander";
@@ -129,8 +130,6 @@ function writeFollowLine(entry: LogEntry, jsonMode: boolean): void {
   process.stdout.write(`${line}\n`);
 }
 
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
 function streamEventToLogEntry(event: StreamLogEvent): LogEntry {
   return {
     time: event.time,
@@ -254,6 +253,17 @@ async function followLogs(
     functions: parseFunctionNames(options.function),
     env: options.env,
   };
+  if (options.since) {
+    // A stream only carries what happens from now on, so a run that asked for
+    // the past polls from the start rather than opening one.
+    logger.warn(
+      "--since reads the past, so this run polls instead of streaming (lines may lag ~20-30s).",
+    );
+    return pollLogs(functionNames, options, availableFunctionNames, jsonMode, {
+      lastTime: "",
+      boundaryKeys: new Set(),
+    });
+  }
   const opened = await connectWhileTransientlyUnavailable(filters);
   if (opened.kind !== "stream") {
     logger.warn(
@@ -429,11 +439,6 @@ async function logsAction(
   }
 
   if (options.follow) {
-    if (options.since) {
-      throw new InvalidInputError(
-        "--since cannot be combined with --follow yet (the realtime stream starts from now).",
-      );
-    }
     if (options.until) {
       throw new InvalidInputError(
         "--until cannot be combined with --follow (a stream has no end).",

--- a/packages/cli/src/core/resources/function/stream-api.ts
+++ b/packages/cli/src/core/resources/function/stream-api.ts
@@ -97,7 +97,6 @@ const STREAM_SILENCE_TIMEOUT_MS = 60_000;
 interface StreamReader {
   read(): Promise<{ done: boolean; value?: Uint8Array }>;
   cancel(): Promise<unknown>;
-  releaseLock(): void;
 }
 
 async function readOrSilence(
@@ -123,10 +122,7 @@ async function* readLines(
   try {
     while (true) {
       const result = await readOrSilence(reader);
-      if (result === "silence") {
-        await reader.cancel();
-        return;
-      }
+      if (result === "silence") return;
       if (result.done || !result.value) return;
       buffered += decoder.decode(result.value, { stream: true });
       const lines = buffered.split("\n");
@@ -134,7 +130,9 @@ async function* readLines(
       yield* lines;
     }
   } finally {
-    reader.releaseLock();
+    // Cancel, don't just unlock: an unconsumed body keeps its socket alive in
+    // the fetch pool, so a long tail's reconnects pile up connections.
+    await reader.cancel().catch(() => {});
   }
 }
 
@@ -173,6 +171,13 @@ export const isWorthReconnecting = (status: number) => status >= 500;
 export async function openLogStream(
   filters: LogStreamFilters,
 ): Promise<LogStreamAttempt> {
+  // Outside the try on purpose: a missing or unrefreshable token is a real
+  // error to surface, not a transient failure to retry for 15 seconds.
+  const url = buildStreamUrl(filters);
+  const headers = {
+    Accept: "text/event-stream",
+    ...(await buildStreamAuthHeaders()),
+  };
   const connectPhase = new AbortController();
   const connectTimer = setTimeout(
     () => connectPhase.abort(),
@@ -180,13 +185,7 @@ export async function openLogStream(
   );
   let response: Response;
   try {
-    response = await fetch(buildStreamUrl(filters), {
-      headers: {
-        Accept: "text/event-stream",
-        ...(await buildStreamAuthHeaders()),
-      },
-      signal: connectPhase.signal,
-    });
+    response = await fetch(url, { headers, signal: connectPhase.signal });
   } catch {
     return { kind: "transient" };
   } finally {

--- a/packages/cli/tests/cli/logs.spec.ts
+++ b/packages/cli/tests/cli/logs.spec.ts
@@ -14,6 +14,21 @@ import {
 } from "@/core/resources/function/index.js";
 import { fixture, setupCLITests } from "./testkit/index.js";
 
+async function waitForStderr(
+  handle: { readonly stderr: readonly string[] },
+  pattern: RegExp,
+  timeoutMs = 5000,
+) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (pattern.test(handle.stderr.join(""))) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(
+    `Timed out waiting for stderr matching ${pattern}. stderr: ${handle.stderr.join("")}`,
+  );
+}
+
 function entry(time: string, message: string): LogEntry {
   return { time, level: "info", message, source: "fn" };
 }
@@ -424,10 +439,11 @@ describe("logs command", () => {
     t.expectResult(result).toContain("No production logs found");
   });
 
-  it("rejects --follow combined with --since", async () => {
+  it("polls without trying to stream when --follow is combined with --since", async () => {
     await t.givenLoggedInWithProject(fixture("basic"));
+    t.api.mockFunctionLogs("my-function", []);
 
-    const result = await t.run(
+    const handle = await t.runLive(
       "logs",
       "--function",
       "my-function",
@@ -435,9 +451,12 @@ describe("logs command", () => {
       "--since",
       "1h",
     );
+    await waitForStderr(handle, /polls instead of streaming/);
+    const result = await handle.stop();
 
-    t.expectResult(result).toFail();
-    t.expectResult(result).toContain("--since cannot be combined");
+    // The two stream-failure warnings would say "not available for this app" or
+    // "Could not reach" instead, so this line is proof the stream was skipped.
+    t.expectResult(result).toContain("--since reads the past");
   });
 
   it("rejects --follow combined with --order", async () => {


### PR DESCRIPTION
Follows up [#595](https://github.com/base44/cli/pull/595), which merged with an unactioned review. Three findings from @guyofeck plus @netanelgilad's one-liner. Nothing here overlaps #611 in intent, but both touch `logs.ts` — whichever lands second will need a trivial rebase.

## 1. The response body was never cancelled

`readLines`' `finally` called `releaseLock()` and nothing else, so exiting the generator on a typed `end` frame left the body unconsumed. An unconsumed body keeps its socket alive in the fetch pool, so a long-lived tail's reconnects pile up connections. The `finally` now cancels; the silence path's own `cancel()` became redundant and just returns.

**Scope check, because the first version of this PR body overstated it:** this is client-side hygiene, not a server-side subscriber leak. apper's `sse_log_stream` returns right after it yields the `end` frame, and its own `finally` fires `detach()` and `close_stream()` — so on the ordinary 5-minute rollover the server has already let go before the CLI reconnects. The narrow case where an abandoned socket could hold a server-side subscriber is a consumer that walks away from a *still-live* stream, and the silence path already cancelled explicitly for that. The apper side assessed it independently: bounded to ≤300s by the generator's own lifetime cap, whose `finally` detaches.

## 2. Auth failures were classified as transient

`buildStreamUrl()` and `buildStreamAuthHeaders()` were evaluated inside the `fetch()` arguments, i.e. inside the `try`. A logged-out user's `readAuth()` throw was therefore caught as `{kind: "transient"}` and laddered 1+2+4+8s before the real error surfaced through the poll path. Both are now built before the `try`, so a missing or unrefreshable token propagates immediately.

Repro on `main`: `base44 logs -f --function foo` while logged out — a 15s pause before the login error.

## 3. `--since` + `--follow` polls instead of erroring

Before #595 this worked: the first poll passed `since` through, giving backfill-then-tail. #595 turned it into a hard error, and that shipped in v0.1.13.

This restores the old behaviour **as a deliberate compatibility concession, not as a feature.** Anyone whose scripts already pair the two flags keeps working. The design intent is unchanged and stream-only: a live tail carries what happens next, `--since` is not part of the streaming story, and the polling path it falls back to is transitional — it goes away once realtime covers every app. So the combination is accepted with the simplest semantics available and nothing more: **a run that asks for the past never attempts the stream.** No capability check, no backfill-then-stream handover, no silent gap between the two.

```
Warning: --since reads the past, so this run polls instead of streaming (lines may lag ~20-30s).
```

`--until` and `--order` stay rejected with `--follow`.

Docs note: `base44-troubleshooter` in the skills repo says `--since` cannot be combined with `--follow`. That is the right thing for the design and for where this is heading, so it is deliberately **not** being rewritten to advertise the pairing; at most it earns a one-line "accepted today, polls" aside. The dependency is recorded on the apper side's rollout file with the exact locations, so a future owner can decide.

## 4. `delay` is now native

`setTimeout` from `node:timers/promises`, replacing the hand-rolled promise wrapper.

## Tests

The old spec asserted the rejection. It is replaced with a live-process spec that runs `--follow --since`, waits for the warning on stderr, and asserts the message is the `--since` one — the two stream-failure warnings say "not available for this app" or "Could not reach" instead, so that line is proof the stream was skipped rather than attempted and refused.

Full suite 736 passed / 17 skipped; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)