### PR TITLE
fix(cli): correct docs link in scaffold config template

### DIFF
--- a/packages/cli/templates/backend-and-client/base44/config.jsonc.ejs
+++ b/packages/cli/templates/backend-and-client/base44/config.jsonc.ejs
@@ -9,7 +9,7 @@
   "visibility": "public",
 
   // Site/hosting configuration for the client application
-  // Docs: https://docs.base44.com/configuration/hosting
+  // Docs: https://docs.base44.com/developers/backend/overview/project-structure
   "site": {
     "installCommand": "npm install",
     "buildCommand": "npm run build",

--- a/packages/cli/templates/backend-only/base44/config.jsonc.ejs
+++ b/packages/cli/templates/backend-only/base44/config.jsonc.ejs
@@ -9,7 +9,7 @@
   "visibility": "public"
 
   // Site/hosting configuration
-  // Docs: https://docs.base44.com/configuration/hosting
+  // Docs: https://docs.base44.com/developers/backend/overview/project-structure
   // "site": {
   //   "buildCommand": "npm run build",
   //   "serveCommand": "npm run dev",


### PR DESCRIPTION
> [!NOTE]
> ## Description
>
> The `base44/config.jsonc` file generated by `base44 create` contained a comment pointing at `https://docs.base44.com/configuration/hosting`, which is not a valid docs page. Both scaffold templates now link to the project structure page (`https://docs.base44.com/developers/backend/overview/project-structure`) instead. This is a comment-only change to the EJS templates with no behavioral impact on the CLI or on generated projects.
>
> ## Related Issue
>
> None
>
> ## Type of Change
>
> - [x] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [x] Documentation update
> - [ ] Refactoring (no functional changes)
> - [ ] Other (please describe):
>
> ## Changes Made
>
> - Updated the `site` config docs link in `packages/cli/templates/backend-and-client/base44/config.jsonc.ejs` to point at the project structure page.
> - Updated the same link in the commented-out `site` block of `packages/cli/templates/backend-only/base44/config.jsonc.ejs`.
> - No references to the dead `docs.base44.com/configuration/*` path remain in the repo.
>
> ## Testing
>
> - [ ] I have tested these changes locally
> - [ ] I have added/updated tests as needed
> - [ ] All tests pass (`npm test`)
>
> ## Checklist
>
> - [x] My code follows the project's style guidelines
> - [x] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [x] I have made corresponding changes to the documentation (if applicable)
> - [x] My changes generate no new warnings
> - [ ] I have updated `docs/` (AGENTS.md) if I made architectural changes
>
> ## Additional Notes
>
> The change affects only newly scaffolded projects; existing projects keep whatever comment their config was generated with. Testing boxes are left unchecked because the change touches template comments only — no test run is recorded on this branch, and no test asserts on template comment contents.
>
> ---
> <sub>🤖 Generated by Claude | 2026-09-02 08:28 UTC | fba45c1</sub>